### PR TITLE
test: add unit test coverage to chain package

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1,0 +1,81 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/ockam-network/ockam/claim"
+	"github.com/ockam-network/ockam/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultChain(t *testing.T) {
+	c, err := New()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, c)
+}
+
+func TestNewChainWithIDOption(t *testing.T) {
+	c, err := New(ID("foo"))
+
+	assert.Nil(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, "foo", c.id)
+}
+
+func TestNewChainWithTrustedNodeOption(t *testing.T) {
+	c, err := New(TrustedNode(mockNode{}))
+
+	assert.Nil(t, err)
+	assert.NotNil(t, c)
+	assert.NotNil(t, c.trustedNode)
+}
+
+func TestIDOption(t *testing.T) {
+	c := &Chain{}
+	o := ID("foo")
+	o(c)
+
+	assert.Equal(t, "foo", c.id)
+}
+
+func TestTrustedNodeOption(t *testing.T) {
+	c := &Chain{}
+	o := TrustedNode(mockNode{})
+	o(c)
+
+	assert.NotNil(t, c.trustedNode)
+}
+
+func TestChainID(t *testing.T) {
+	c := &Chain{id: "foo"}
+
+	assert.Equal(t, c.ID(), "foo")
+}
+
+// the following are limited tests due to the limited
+// mocking done on mockNode{}
+func TestChainSync(t *testing.T) {
+	c := &Chain{trustedNode: mockNode{}}
+	err := c.Sync()
+	assert.Nil(t, err)
+}
+
+func TestChainLatestBlock(t *testing.T) {
+	c := &Chain{trustedNode: mockNode{}}
+	err := c.LatestBlock()
+	assert.Nil(t, err)
+}
+
+func TestChainRegister(t *testing.T) {
+	c := &Chain{trustedNode: mockNode{}}
+	claim, err := c.Register(&entity.Entity{})
+	assert.Nil(t, err)
+	assert.Nil(t, claim)
+}
+
+func TestChainSubmit(t *testing.T) {
+	c := &Chain{trustedNode: mockNode{}}
+	err := c.Submit(&claim.Claim{})
+	assert.Nil(t, err)
+}

--- a/chain/mock.go
+++ b/chain/mock.go
@@ -1,0 +1,13 @@
+package chain
+
+import "github.com/ockam-network/ockam"
+
+type mockNode struct{}
+
+func (n mockNode) Peers() []ockam.Node                        { return nil }
+func (n mockNode) Chain() ockam.Chain                         { return nil }
+func (n mockNode) ID() string                                 { return "" }
+func (n mockNode) Sync() error                                { return nil }
+func (n mockNode) LatestBlock() ockam.Block                   { return nil }
+func (n mockNode) Register(ockam.Entity) (ockam.Claim, error) { return nil, nil }
+func (n mockNode) Submit(ockam.Claim) error                   { return nil }


### PR DESCRIPTION
Thank you for sending a pull request :heart:

### Checklist

Please review the [guidelines for contributing code](../CONTRIBUTING.md#contribute-code) to this repository. And check `[x]` all the boxes that apply:

- [x] This request **pulls a feature/bugfix branch** (right side) from my fork. *Not my master.*
- [ ] This request **pulls against** `ockam-network/ockam`’s **develop branch** (left side).
- [x] Build succeeds `./build` with no linter warnings or test failures.
- [x] All code matched our code formatting [conventions](../CONTRIBUTING.md#code-format).
- [x] Commit messages match our [conventions](../CONTRIBUTING.md#commit-messages) and all commits
are [signed](#signed-commits).
- [x] This request includes tests and documentation for all new code.

### Proposed Changes
This pull request adds unit test coverage to the chain package. Proposed follow-on work is extending the `mockNode{}` type to support more robust testing, and returning an error from the `Option` type. The latter isn't really necessary yet however since none of the `Option` implementations call the types which are passed to them, they are simply there to set values. However, we may want to consider validation on the values passed in order to ensure no nil type or other exceptions occur when these values are accessed later on. 
