### PR TITLE
feat: extend ockam.PublicKey to return an error from DID()

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -39,7 +39,12 @@ func New(attributes Attributes, options ...Option) (*Entity, error) {
 
 	if e.id == nil {
 		if len(e.signers) > 0 {
-			e.id = e.signers[0].PublicKey().DID()
+			id, err := e.signers[0].PublicKey().DID()
+			if err != nil {
+				return e, err
+			}
+
+			e.id = id
 		}
 	}
 

--- a/entity/mock.go
+++ b/entity/mock.go
@@ -18,7 +18,7 @@ func (k mockPublicKey) SetOwner(e ockam.Entity) { return }
 func (k mockPublicKey) Type() string            { return "" }
 func (k mockPublicKey) Encoding() string        { return "" }
 func (k mockPublicKey) Value() string           { return "" }
-func (k mockPublicKey) DID() *did.DID           { return &did.DID{} }
+func (k mockPublicKey) DID() (*did.DID, error)  { return &did.DID{}, nil }
 
 type mockSigner struct{}
 

--- a/key/ed25519/ed25519.go
+++ b/key/ed25519/ed25519.go
@@ -137,10 +137,6 @@ func (p *PublicKey) Value() string {
 }
 
 // DID is
-func (p *PublicKey) DID() *did.DID {
-	// TODO this ignores the error from NewDID() to prevent a snowball
-	// PR. In a follow up PR, we should modify the interface PublicKey
-	// satisfies to have DID() return an error.
-	did, _ := entity.NewDID([]byte(p.Value()))
-	return did
+func (p *PublicKey) DID() (*did.DID, error) {
+	return entity.NewDID([]byte(p.Value()))
 }

--- a/ockam.go
+++ b/ockam.go
@@ -45,7 +45,7 @@ type PublicKey interface {
 	Encoding() string
 	Value() string
 
-	DID() *did.DID
+	DID() (*did.DID, error)
 }
 
 // Signature is


### PR DESCRIPTION
Thank you for sending a pull request :heart:

### Checklist

Please review the [guidelines for contributing code](../CONTRIBUTING.md#contribute-code) to this repository. And check `[x]` all the boxes that apply:

- [x] This request **pulls a feature/bugfix branch** (right side) from my fork. *Not my master.*
- [ ] This request **pulls against** `ockam-network/ockam`’s **develop branch** (left side).
- [x] Build succeeds `./build` with no linter warnings or test failures.
- [x] All code matched our code formatting [conventions](../CONTRIBUTING.md#code-format).
- [x] Commit messages match our [conventions](../CONTRIBUTING.md#commit-messages) and all commits
are [signed](#signed-commits).
- [x] This request includes tests and documentation for all new code.

### Proposed Changes
Follow-up to #12 to extend the `ockam.PublicKey` interface's `DID()` method to return an error. 

Results from local `./build`:
```
➜  ockam malnick/extend-pub-key-iface ✓ ./build
Building .build/ockam_0.2.5_linux_amd64 ... Done.
Building .build/ockam_0.2.5_linux_arm64 ... Done.
Building .build/ockam_0.2.5_darwin_amd64 ... Done.
Building .build/ockam_0.2.5_windows_amd64.exe ... Done.
```
