### PR TITLE
refactor: add types directory to ockam/node

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ockam-network/ockam"
 	"github.com/ockam-network/ockam/chain"
+	"github.com/ockam-network/ockam/node/types"
 	"github.com/ockam-network/ockam/random"
 	"github.com/pkg/errors"
 )
@@ -20,65 +21,7 @@ func init() {
 // expects other peers to implement
 type Peer interface {
 	ockam.Node
-	LatestCommit() *Commit
-}
-
-// Commit is
-type Commit struct {
-	SignedHeader struct {
-		Header struct {
-			ChainID     string    `json:"chain_id"`
-			Height      string    `json:"height"`
-			Time        time.Time `json:"time"`
-			NumTxs      string    `json:"num_txs"`
-			TotalTxs    string    `json:"total_txs"`
-			LastBlockID struct {
-				Hash  string `json:"hash"`
-				Parts struct {
-					Total string `json:"total"`
-					Hash  string `json:"hash"`
-				} `json:"parts"`
-			} `json:"last_block_id"`
-			LastCommitHash     string `json:"last_commit_hash"`
-			DataHash           string `json:"data_hash"`
-			ValidatorsHash     string `json:"validators_hash"`
-			NextValidatorsHash string `json:"next_validators_hash"`
-			ConsensusHash      string `json:"consensus_hash"`
-			AppHash            string `json:"app_hash"`
-			LastResultsHash    string `json:"last_results_hash"`
-			EvidenceHash       string `json:"evidence_hash"`
-			ProposerAddress    string `json:"proposer_address"`
-		} `json:"header"`
-		Commit struct {
-			BlockID struct {
-				Hash  string `json:"hash"`
-				Parts struct {
-					Total string `json:"total"`
-					Hash  string `json:"hash"`
-				} `json:"parts"`
-			} `json:"block_id"`
-			Precommits []Precommit `json:"precommits"`
-		} `json:"commit"`
-	} `json:"signed_header"`
-	Canonical bool `json:"canonical"`
-}
-
-// Precommit is
-type Precommit struct {
-	Type      int       `json:"type"`
-	Height    string    `json:"height"`
-	Round     string    `json:"round"`
-	Timestamp time.Time `json:"timestamp"`
-	BlockID   struct {
-		Hash  string `json:"hash"`
-		Parts struct {
-			Total string `json:"total"`
-			Hash  string `json:"hash"`
-		} `json:"parts"`
-	} `json:"block_id"`
-	ValidatorAddress string `json:"validator_address"`
-	ValidatorIndex   string `json:"validator_index"`
-	Signature        string `json:"signature"`
+	LatestCommit() *types.Commit
 }
 
 // Tx is
@@ -108,7 +51,7 @@ type Node struct {
 	chain           ockam.Chain
 	peers           []Peer
 	peerDiscoverers []ockam.NodeDiscoverer
-	latestCommit    *Commit
+	latestCommit    *types.Commit
 }
 
 // Option is
@@ -195,7 +138,7 @@ func (n *Node) Sync() error {
 func (n *Node) LatestBlock() ockam.Block {
 	return &block{
 		height: n.latestCommit.SignedHeader.Header.Height,
-		hash:   n.latestCommit.SignedHeader.Commit.BlockID.Hash,
+		hash:   n.latestCommit.SignedHeader.Commit.BlockID.Hash.String(),
 	}
 }
 

--- a/node/remote/http/http.go
+++ b/node/remote/http/http.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ockam-network/ockam"
 	"github.com/ockam-network/ockam/chain"
 	"github.com/ockam-network/ockam/claim"
-	"github.com/ockam-network/ockam/node"
+	"github.com/ockam-network/ockam/node/types"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +20,7 @@ type Node struct {
 	port         int
 	chain        ockam.Chain
 	peers        []ockam.Node
-	latestCommit *node.Commit
+	latestCommit *types.Commit
 }
 
 // Option is
@@ -83,7 +83,7 @@ func (n *Node) Chain() ockam.Chain {
 }
 
 // LatestCommit returns
-func (n *Node) LatestCommit() *node.Commit {
+func (n *Node) LatestCommit() *types.Commit {
 	return n.latestCommit
 }
 
@@ -106,7 +106,7 @@ func (b *block) Hash() string {
 func (n *Node) LatestBlock() ockam.Block {
 	return &block{
 		height: n.latestCommit.SignedHeader.Header.Height,
-		hash:   n.latestCommit.SignedHeader.Commit.BlockID.Hash,
+		hash:   n.latestCommit.SignedHeader.Commit.BlockID.Hash.String(),
 	}
 }
 
@@ -115,7 +115,7 @@ func (n *Node) Peers() []ockam.Node {
 	return n.peers
 }
 
-func (n *Node) getLatestCommit() (*node.Commit, error) {
+func (n *Node) getLatestCommit() (*types.Commit, error) {
 	r := new(CommitResponse)
 	err := n.Call("/commit", &r)
 	if err != nil {

--- a/node/remote/http/rpc.go
+++ b/node/remote/http/rpc.go
@@ -8,13 +8,15 @@ import (
 	"time"
 
 	"github.com/ockam-network/ockam/node"
+
+	"github.com/ockam-network/ockam/node/types"
 	"github.com/pkg/errors"
 )
 
 // CommitResponse is
 type CommitResponse struct {
-	Error  interface{} `json:"error"`
-	Result node.Commit `json:"result"`
+	Error  interface{}  `json:"error"`
+	Result types.Commit `json:"result"`
 }
 
 // TxResponse is
@@ -35,7 +37,7 @@ type BroadcastTxSyncResponse struct {
 }
 
 // Commit fetches the the commit at the provided height
-func (n *Node) Commit(height string) (*node.Commit, error) {
+func (n *Node) Commit(height string) (*types.Commit, error) {
 	r := new(CommitResponse)
 	err := n.Call(fmt.Sprintf("/commit?height=%s", height), &r)
 	if err != nil {

--- a/node/types/canonical.go
+++ b/node/types/canonical.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"time"
+)
+
+//The Canonicalize functions are used to canonicalize precommits before verifying signatures
+type CanonicalVote struct {
+	Type      SignedMsgType // type alias for byte
+	Height    int64         `binary:"fixed64"`
+	Round     int64         `binary:"fixed64"`
+	Timestamp time.Time
+	BlockID   CanonicalBlockID
+	ChainID   string
+}
+
+type CanonicalBlockID struct {
+	Hash        HexBytes
+	PartsHeader CanonicalPartSetHeader
+}
+
+type CanonicalPartSetHeader struct {
+	Hash  HexBytes
+	Total int
+}
+
+func CanonicalizeVote(chainID string, vote *Precommit) CanonicalVote {
+	return CanonicalVote{
+		Type:      vote.Type,
+		Height:    vote.Height,
+		Round:     int64(vote.Round),
+		Timestamp: vote.Timestamp,
+		BlockID:   CanonicalizeBlockID(vote.BlockID),
+		ChainID:   chainID,
+	}
+}
+
+func CanonicalizeBlockID(blockID BlockID) CanonicalBlockID {
+	return CanonicalBlockID{
+		Hash:        blockID.Hash,
+		PartsHeader: CanonicalizePartSetHeader(blockID.PartsHeader),
+	}
+}
+
+func CanonicalizePartSetHeader(psh PartSetHeader) CanonicalPartSetHeader {
+	return CanonicalPartSetHeader{
+		psh.Hash,
+		psh.Total,
+	}
+}

--- a/node/types/commit.go
+++ b/node/types/commit.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"time"
+)
+
+// Commit is
+type Commit struct {
+	SignedHeader struct {
+		Header struct {
+			ChainID     string    `json:"chain_id"`
+			Height      string    `json:"height"`
+			Time        time.Time `json:"time"`
+			NumTxs      string    `json:"num_txs"`
+			TotalTxs    string    `json:"total_txs"`
+			LastBlockID struct {
+				Hash  string `json:"hash"`
+				Parts struct {
+					Total string `json:"total"`
+					Hash  string `json:"hash"`
+				} `json:"parts"`
+			} `json:"last_block_id"`
+			LastCommitHash     string `json:"last_commit_hash"`
+			DataHash           string `json:"data_hash"`
+			ValidatorsHash     string `json:"validators_hash"`
+			NextValidatorsHash string `json:"next_validators_hash"`
+			ConsensusHash      string `json:"consensus_hash"`
+			AppHash            string `json:"app_hash"`
+			LastResultsHash    string `json:"last_results_hash"`
+			EvidenceHash       string `json:"evidence_hash"`
+			ProposerAddress    string `json:"proposer_address"`
+		} `json:"header"`
+		Commit NestedCommit `json:"commit"`
+	} `json:"signed_header"`
+	Canonical bool `json:"canonical"`
+}
+
+//
+type NestedCommit struct {
+	BlockID    BlockID      `json:"block_id"`
+	Precommits []*Precommit `json:"precommits"`
+
+	firstPrecommit *Precommit
+}
+
+func (commit *NestedCommit) FirstPrecommit() *Precommit {
+	if len(commit.Precommits) == 0 {
+		return nil
+	}
+	if commit.firstPrecommit != nil {
+		return commit.firstPrecommit
+	}
+	for _, precommit := range commit.Precommits {
+		if precommit != nil {
+			commit.firstPrecommit = precommit
+			return precommit
+		}
+	}
+	return &Precommit{}
+}
+
+// Height returns the height of the commit
+func (commit *NestedCommit) Height() (int64, error) {
+	if len(commit.Precommits) == 0 {
+		return 0, nil
+	}
+
+	return commit.FirstPrecommit().Height, nil
+}
+
+func (commit *NestedCommit) Round() int {
+	if len(commit.Precommits) == 0 {
+		return 0
+	}
+	return commit.FirstPrecommit().Round
+}

--- a/node/types/hexbytes.go
+++ b/node/types/hexbytes.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// The main purpose of HexBytes is to enable HEX-encoding for json/encoding.
+type HexBytes []byte
+
+// Marshal needed for protobuf compatibility
+func (bz HexBytes) Marshal() ([]byte, error) {
+	return bz, nil
+}
+
+// Unmarshal needed for protobuf compatibility
+func (bz *HexBytes) Unmarshal(data []byte) error {
+	*bz = data
+	return nil
+}
+
+// This is the point of Bytes.
+func (bz HexBytes) MarshalJSON() ([]byte, error) {
+	s := strings.ToUpper(hex.EncodeToString(bz))
+	jbz := make([]byte, len(s)+2)
+	jbz[0] = '"'
+	copy(jbz[1:], []byte(s))
+	jbz[len(jbz)-1] = '"'
+	return jbz, nil
+}
+
+// This is the point of Bytes.
+func (bz *HexBytes) UnmarshalJSON(data []byte) error {
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return fmt.Errorf("Invalid hex string: %s", data)
+	}
+	bz2, err := hex.DecodeString(string(data[1 : len(data)-1]))
+	if err != nil {
+		return err
+	}
+	*bz = bz2
+	return nil
+}
+
+// Allow it to fulfill various interfaces in light-client, etc...
+func (bz HexBytes) Bytes() []byte {
+	return bz
+}
+
+func (bz HexBytes) String() string {
+	return strings.ToUpper(hex.EncodeToString(bz))
+}
+
+func (bz HexBytes) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'p':
+		s.Write([]byte(fmt.Sprintf("%p", bz)))
+	default:
+		s.Write([]byte(fmt.Sprintf("%X", []byte(bz))))
+	}
+}

--- a/node/types/precommit.go
+++ b/node/types/precommit.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/pkg/errors"
+	amino "github.com/tendermint/go-amino"
+)
+
+type SignedMsgType byte
+
+const (
+	// Votes
+	PrevoteType   SignedMsgType = 0x01
+	PrecommitType SignedMsgType = 0x02
+
+	// Proposals
+	ProposalType SignedMsgType = 0x20
+
+	// Heartbeat
+	HeartbeatType SignedMsgType = 0x30
+)
+
+type ValAddress = HexBytes
+
+// Precommit is
+type Precommit struct {
+	Type             SignedMsgType `json:"type"`
+	Height           int64         `json:"height,string"`
+	Round            int           `json:"round,string"`
+	Timestamp        time.Time     `json:"timestamp"`
+	BlockID          BlockID       `json:"block_id"`
+	ValidatorAddress ValAddress    `json:"validator_address"`
+	ValidatorIndex   string        `json:"validator_index"`
+	Signature        []byte        `json:"signature"`
+}
+
+func (pc *Precommit) SignBytes(chainID string) ([]byte, error) {
+
+	var cdc = amino.NewCodec()
+
+	cv := CanonicalizeVote(chainID, pc)
+	bz, err := cdc.MarshalBinaryLengthPrefixed(cv)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return bz, nil
+}
+
+type BlockID struct {
+	Hash        HexBytes      `json:"hash"`
+	PartsHeader PartSetHeader `json:"parts"`
+}
+
+// Equals returns true if the BlockID matches the given BlockID
+func (blockID BlockID) Equals(other BlockID) bool {
+	return bytes.Equal(blockID.Hash, other.Hash) &&
+		blockID.PartsHeader.Equals(other.PartsHeader)
+}
+
+type PartSetHeader struct {
+	Total int      `json:"total,string"`
+	Hash  HexBytes `json:"hash"`
+}
+
+func (psh PartSetHeader) Equals(other PartSetHeader) bool {
+	return psh.Total == other.Total && bytes.Equal(psh.Hash, other.Hash)
+}

--- a/node/types/public_key.go
+++ b/node/types/public_key.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"golang.org/x/crypto/ed25519"
+)
+
+//Public Key for the validator
+type PubKey struct {
+	Type  string `json:"type"`
+	Value []byte `json:"value"`
+}
+
+func (pc *PubKey) VerifyBytes(msg []byte, sig []byte) bool {
+	isVerified := ed25519.Verify(pc.Value[:], msg, sig)
+
+	return isVerified
+}

--- a/node/types/validator.go
+++ b/node/types/validator.go
@@ -1,0 +1,20 @@
+package types
+
+// ValidatorsResponse is
+type ValidatorsResponse struct {
+	Jsonrpc string `json:"jsonrpc"`
+	ID      string `json:"id"`
+	Result  struct {
+		BlockHeight string `json:"block_height"`
+		Validators  []*Validator
+	} `json:"result"`
+	Error interface{} `json:"error"`
+}
+
+// Validator is
+type Validator struct {
+	Address     HexBytes `json:"address"`
+	PubKey      PubKey   `json:"pub_key"`
+	VotingPower int64    `json:"voting_power,string"`
+	Accum       string   `json:"accum"`
+}

--- a/node/types/validator_set.go
+++ b/node/types/validator_set.go
@@ -1,0 +1,223 @@
+package types
+
+import (
+	"bytes"
+	"math"
+	"sort"
+
+	"github.com/pkg/errors"
+)
+
+type ValidatorSet struct {
+	Validators []*Validator
+	Proposer   *Validator //Don't know if we need this for what we're doing here
+
+	totalVotingPower int64
+}
+
+func (v *Validator) Copy() *Validator {
+	vCopy := *v
+	return &vCopy
+}
+
+func NewValidatorSet(valz []*Validator) (*ValidatorSet, error) {
+	if valz != nil && len(valz) == 0 {
+		return nil, errors.New("validator set initialization slice cannot be an empty slice (but it can be nil)")
+	}
+	validators := make([]*Validator, len(valz))
+	for i, val := range valz {
+		validators[i] = val.Copy()
+	}
+	sort.Sort(ValidatorsByAddress(validators))
+	vals := &ValidatorSet{
+		Validators: validators,
+	}
+	//establish total voting power on initialization of val set
+	_ = vals.TotalVotingPower()
+	return vals, nil
+}
+
+// Size returns the length of the validator set.
+func (vals *ValidatorSet) Size() int {
+	return len(vals.Validators)
+}
+
+// GetByIndex returns the validator's address and validator itself by index.
+// It returns nil values if index is less than 0 or greater or equal to
+// len(ValidatorSet.Validators).
+func (vals *ValidatorSet) GetByIndex(index int) (address []byte, val *Validator) {
+	if index < 0 || index >= len(vals.Validators) {
+		return nil, nil
+	}
+	val = vals.Validators[index]
+	return val.Address, val.Copy()
+}
+
+func (vals *ValidatorSet) GetByAddress(address []byte) (index int, val *Validator) {
+	idx := sort.Search(len(vals.Validators), func(i int) bool {
+		return bytes.Compare(address, vals.Validators[i].Address) <= 0
+	})
+	if idx < len(vals.Validators) && bytes.Equal(vals.Validators[idx].Address, address) {
+		return idx, vals.Validators[idx].Copy()
+	}
+	return -1, nil
+}
+
+func (vals *ValidatorSet) TotalVotingPower() int64 {
+	if vals.totalVotingPower == 0 {
+		for _, val := range vals.Validators {
+			//mind overflow
+			vals.totalVotingPower = safeAddClip(vals.totalVotingPower, val.VotingPower)
+		}
+	}
+	return vals.totalVotingPower
+}
+
+func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID, height int64, commit *NestedCommit) error {
+	if vals.Size() != len(commit.Precommits) {
+		return errors.Errorf("Invalid commit -- wrong set size: %v vs %v", vals.Size(), len(commit.Precommits))
+	}
+	commitHeight, err := commit.Height()
+	if err != nil {
+		return err
+	}
+	if height != commitHeight {
+		return errors.Errorf("Invalid commit -- wrong height: %v vs %v", height, commitHeight)
+	}
+
+	talliedVotingPower := int64(0)
+	round := commit.Round()
+
+	for idx, precommit := range commit.Precommits {
+		if precommit == nil {
+			continue //OK, some precommits can be missing
+		}
+		if precommit.Height != height {
+			return errors.Errorf("Invalid commit -- wrong height: want %v got %v", height, precommit.Height)
+		}
+		if precommit.Round != round {
+			return errors.Errorf("Invalid commit -- wrong round: want %v got %v", round, precommit.Round)
+		}
+		_, val := vals.GetByIndex(idx)
+		precommitSignBytes, err := precommit.SignBytes(chainID)
+		if err != nil {
+			return err
+		}
+
+		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
+			return errors.Errorf("Invalid commit -- invalid signature: %v", precommit)
+		}
+		//Good precommit!
+		if blockID.Equals(precommit.BlockID) {
+			talliedVotingPower += val.VotingPower
+		} else {
+			// It's OK that the BlockID doesn't match.  We include stray
+			// precommits to measure validator availability.
+		}
+	}
+
+	if talliedVotingPower > vals.TotalVotingPower()*2/3 {
+		return nil
+	}
+	return errors.Errorf("Invalid commit -- insufficient voting power: got %v, needed %v",
+		talliedVotingPower, (vals.TotalVotingPower()*2/3 + 1))
+}
+
+func (vals *ValidatorSet) VerifyFutureCommit(newSet *ValidatorSet, chainID string, blockID BlockID, height int64, commit *NestedCommit) error {
+	oldVals := vals
+	//commit must be a valid commit for new set
+	err := newSet.VerifyCommit(chainID, blockID, height, commit)
+	if err != nil {
+		return err
+	}
+
+	//check old voting power
+	oldVotingPower := int64(0)
+	seen := map[int]bool{}
+	round := commit.Round()
+
+	for idx, precommit := range commit.Precommits {
+		if precommit == nil {
+			continue
+		}
+		if precommit.Height != height {
+			return errors.Errorf("Blocks don't match - %d vs %d", height, precommit.Height)
+		}
+		if precommit.Round != round {
+			return errors.Errorf("Invalid commit -- wrong round: %v vs %v", round, precommit.Round)
+		}
+		if precommit.Type != PrecommitType {
+			return errors.Errorf("Invalid commit -- not precommit @ index %v", idx)
+		}
+		//see if this validator is in oldVals
+		idx, val := oldVals.GetByAddress(precommit.ValidatorAddress)
+		if val == nil || seen[idx] {
+			continue //missing or double vote
+		}
+		seen[idx] = true
+
+		//Validate signature
+		precommitSignBytes, err := precommit.SignBytes(chainID)
+		if err != nil {
+			return err
+		}
+		if !val.PubKey.VerifyBytes(precommitSignBytes, precommit.Signature) {
+			return errors.Errorf("Invalid commit -- invalid signature: %v", precommit)
+		}
+		//Good Precommit!
+		if blockID.Equals(precommit.BlockID) {
+			oldVotingPower += val.VotingPower
+		} else {
+			// It's OK that the BlockID doesn't match.  We include stray
+			// precommits to measure validator availability.
+		}
+	}
+
+	if oldVotingPower <= oldVals.TotalVotingPower()*2/3 {
+		return errors.Errorf("Invalid commit -- insufficient old voting power: got %v, needed %v",
+			oldVotingPower, oldVals.TotalVotingPower()*2/3+1)
+	}
+
+	return nil
+}
+
+//-------------------------------------
+// Implements sort for sorting validators by address.
+
+// Sort validators by address
+type ValidatorsByAddress []*Validator
+
+func (valz ValidatorsByAddress) Len() int {
+	return len(valz)
+}
+
+func (valz ValidatorsByAddress) Less(i, j int) bool {
+	return bytes.Compare(valz[i].Address, valz[j].Address) == -1
+}
+
+func (valz ValidatorsByAddress) Swap(i, j int) {
+	it := valz[i]
+	valz[i] = valz[j]
+	valz[j] = it
+}
+
+//helpers -- Safe Addition
+func safeAdd(a, b int64) (int64, bool) {
+	if b > 0 && a > math.MaxInt64-b {
+		return -1, true
+	} else if b < 0 && a < math.MinInt64-b {
+		return -1, true
+	}
+	return a + b, false
+}
+
+func safeAddClip(a, b int64) int64 {
+	c, overflow := safeAdd(a, b)
+	if overflow {
+		if b < 0 {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	return c
+}


### PR DESCRIPTION
1. move structs and methods from node/dynamic to node/types
2. move commit and precommit structs from node/node.go to node/types
3. update references to type node.Commit to types.Commit
4. add .String() function to block.Hash (type HexBytes) to comply with Block interface


Thank you for sending a pull request :heart:

### Checklist

Please review the [guidelines for contributing code](../CONTRIBUTING.md#contribute-code) to this repository. And check `[x]` all the boxes that apply:

- [x] This request **pulls a feature/bugfix branch** (right side) from my fork. *Not my master.*
- [ ] This request **pulls against** `ockam-network/ockam`’s **develop branch** (left side).
- [x] Build succeeds `./build` with no linter warnings or test failures.
- [x] All code matched our code formatting [conventions](../CONTRIBUTING.md#code-format).
- [x] Commit messages match our [conventions](../CONTRIBUTING.md#commit-messages) and all commits
are [signed](#signed-commits).
- [ ] This request includes tests and documentation for all new code.

### Proposed Changes
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
