### PR TITLE
feat(implementation/c): Vault for mbed crypto

### DIFF
--- a/implementations/c/include/ockam/error.h
+++ b/implementations/c/include/ockam/error.h
@@ -60,10 +60,11 @@ typedef enum {
     OCKAM_ERR_VAULT_TPM_AES_GCM_DECRYPT_INVALID       = 0x020B, /*!< AES GCM tag invalid for decryption               */
 
     OCKAM_ERR_VAULT_HOST_INIT_FAIL                    = 0x0301, /*!< Host software library failed to initialize       */
-    OCKAM_ERR_VAULT_HOST_KEY_FAIL                     = 0x0302, /*!< Key failure in software                          */
-    OCKAM_ERR_VAULT_HOST_ECDH_FAIL                    = 0x0303, /*!< ECDH failed to complete successfully             */
-    OCKAM_ERR_VAULT_HOST_HKDF_FAIL                    = 0x0304, /*!< HKDF failed to complete successfully             */
-    OCKAM_ERR_VAULT_HOST_AES_FAIL                     = 0x0305  /*!< AES failed to complete successfully              */
+    OCKAM_ERR_VAULT_HOST_RAND_FAIL                    = 0x0302, /*!< Random number failed to generate on host         */
+    OCKAM_ERR_VAULT_HOST_KEY_FAIL                     = 0x0303, /*!< Key failure in software                          */
+    OCKAM_ERR_VAULT_HOST_ECDH_FAIL                    = 0x0304, /*!< ECDH failed to complete successfully             */
+    OCKAM_ERR_VAULT_HOST_HKDF_FAIL                    = 0x0305, /*!< HKDF failed to complete successfully             */
+    OCKAM_ERR_VAULT_HOST_AES_FAIL                     = 0x0306  /*!< AES failed to complete successfully              */
 } OCKAM_ERR;
 
 

--- a/implementations/c/include/ockam/memory.h
+++ b/implementations/c/include/ockam/memory.h
@@ -84,6 +84,7 @@ OCKAM_ERR ockam_mem_free(void* p_buf);
 
 OCKAM_ERR ockam_mem_copy(void* p_target, void* p_source, uint32_t length);
 
+OCKAM_ERR ockam_mem_set(void* p_target, uint8_t value, uint32_t num);
 
 #ifdef __cplusplus
 }

--- a/implementations/c/include/ockam/vault.h
+++ b/implementations/c/include/ockam/vault.h
@@ -58,6 +58,17 @@ typedef enum {
 } OCKAM_VAULT_AES_GCM_MODE_e;
 
 
+/**
+ *******************************************************************************
+ * @enum    OCKAM_VAULT_EC_e
+ * @brief   The elliptic curve vault will support
+ *******************************************************************************
+ */
+typedef enum {
+    OCKAM_VAULT_EC_P256 = 0,                                   /*!< NIST P-256/SECP256R1                             */
+    OCKAM_VAULT_EC_CURVE25519                                  /*!< Curve 25519                                      */
+} OCKAM_VAULT_EC_e;
+
 
 /*
  ********************************************************************************************************
@@ -74,6 +85,7 @@ typedef enum {
 typedef struct {
     void* p_tpm;                                                /*!<  TPM specific configuration                      */
     void* p_host;                                               /*!<  Host software library specific configuration    */
+    OCKAM_VAULT_EC_e ec;                                        /*!< The type of EC Key supported by vault            */
 } OCKAM_VAULT_CFG_s;
 
 

--- a/implementations/c/include/ockam/vault/host.h
+++ b/implementations/c/include/ockam/vault/host.h
@@ -66,18 +66,116 @@ extern "C" {
 #endif
 
 
+/**
+ ********************************************************************************************************
+ *                                        ockam_vault_host_init()
+ *
+ * @brief   Initialize the host for Ockam Vault
+ *
+ * @param   p_arg   Optional void* argument
+ *
+ * @return  OCKAM_ERR_NONE if initialized successfully. OCKAM_ERR_VAULT_ALREADY_INIT if already
+ *          initialized. Other errors if specific chip fails init.
+ *
+ ********************************************************************************************************
+ */
+
 OCKAM_ERR ockam_vault_host_init(void *p_arg);
 
+
+/**
+ ********************************************************************************************************
+ *                                          ockam_vault_host_free()
+ *
+ * @brief   Free the host and all associated data structures
+ *
+ * @return  OCKAM_ERR_NONE on success.
+ *
+ ********************************************************************************************************
+ */
+
 OCKAM_ERR ockam_vault_host_free(void);
+
+
+/**
+ ********************************************************************************************************
+ *                                        ockam_vault_host_random()
+ *
+ * @brief   Generate and return a random number
+ *
+ * @param   p_rand_num[out]     32-byte array to be filled with the random number
+ *
+ * @param   rand_num_size[in]   The size of the desired random number & buffer passed in. Used to verify
+ *                              correct size.
+ *
+ * @return  OCKAM_ERR_NONE if successful. OCKAM_ERR_VAULT_INVALID_SIZE if size
+ *
+ ********************************************************************************************************
+ */
 
 OCKAM_ERR ockam_vault_host_random(uint8_t *p_rand_num,
                                   uint32_t rand_num_size);
 
+
+/**
+ ********************************************************************************************************
+ *                                       ockam_vault_host_key_gen()
+ *
+ * @brief   Generate an keypair of a specified type
+ *
+ * @param   key_type[in]    The type of key pair to generate.
+ *
+ * @return  OCKAM_ERR_NONE if successful.
+ *
+ ********************************************************************************************************
+ */
+
 OCKAM_ERR ockam_vault_host_key_gen(OCKAM_VAULT_KEY_e key_type);
+
+
+/**
+ ********************************************************************************************************
+ *                                       ockam_vault_host_key_get_pub()
+ *
+ * @brief   Get a public key from the host vault
+ *
+ * @param   key_type[in]        OCKAM_VAULT_KEY_STATIC if requesting static public key
+ *                              OCKAM_VAULT_KEY_EPHEMERAL if requesting the ephemeral public key
+ *
+ * @param   p_pub_key[out]      Buffer to place the public key in
+ *
+ * @param   pub_key_size[in]    Size of the public key buffer
+ *
+ * @return  OCKAM_ERR_NONE if successful.
+ *
+ ********************************************************************************************************
+ */
 
 OCKAM_ERR ockam_vault_host_key_get_pub(OCKAM_VAULT_KEY_e key_type,
                                        uint8_t *p_pub_key,
                                        uint32_t pub_key_size);
+
+
+/**
+ ********************************************************************************************************
+ *                                       ockam_vault_host_ecdh()
+ *
+ * @brief   Perform ECDH using the specified key
+ *
+ * @param   key_type[in]        Specify which key type to use in the ECDH execution
+ *
+ * @param   p_pub_key[in]       Buffer with the public key
+ *
+ * @param   pub_key_size[in]    Size of the public key buffer
+ *
+ * @param   p_pms[out]          Pre-master secret from ECDH
+ *
+ * @param   pms_size[in]        Size of the pre-master secret buffer
+ *
+ * @return  OCKAM_ERR_NONE if successful.
+ *
+ ********************************************************************************************************
+ */
 
 OCKAM_ERR ockam_vault_host_ecdh(OCKAM_VAULT_KEY_e key_type,
                                 uint8_t *p_pub_key,
@@ -88,9 +186,9 @@ OCKAM_ERR ockam_vault_host_ecdh(OCKAM_VAULT_KEY_e key_type,
 
 /**
  ********************************************************************************************************
- *                                          ockam_vault_host_hkdf()
+ *                                     ockam_vault_host_hkdf()
  *
- * @brief   Perform HKDF in the host crypto library
+ * @brief   Perform HKDF in the host vault
  *
  * @param   p_salt[in]          Buffer for the Ockam salt value
  *
@@ -121,9 +219,9 @@ OCKAM_ERR ockam_vault_host_hkdf(uint8_t *p_salt, uint32_t salt_size,
 
 /**
  ********************************************************************************************************
- *                                          ockam_vault_host_aes_gcm()
+ *                                       ockam_vault_host_aes_gcm()
  *
- * @brief   Perform AES GCM in the mbed TLS library
+ * @brief   Perform AES GCM in the host vault
  *
  * @param   mode                AES GCM Mode: Encrypt or Decrypt
  *
@@ -138,6 +236,11 @@ OCKAM_ERR ockam_vault_host_hkdf(uint8_t *p_salt, uint32_t salt_size,
  * @param   p_aad[in]           Buffer with the additional authentication data (can be NULL)
  *
  * @param   aad_size[in]        Size of the additional authentication data (set to 0 if p_aad is NULL)
+ *
+ * @param   p_tag[in,out]       Buffer to either hold the tag when encrypting or pass in the tag
+ *                              when decrypting.
+ *
+ * @param   tag_size[in]        Size of the tag buffer
  *
  * @param   p_input[in]         Buffer with the input data to encrypt or decrypt
  *
@@ -166,3 +269,4 @@ OCKAM_ERR ockam_vault_host_aes_gcm(OCKAM_VAULT_AES_GCM_MODE_e mode,
 #endif
 
 #endif
+

--- a/implementations/c/source/ockam/memory/stdlib.c
+++ b/implementations/c/source/ockam/memory/stdlib.c
@@ -209,3 +209,41 @@ OCKAM_ERR ockam_mem_copy(void* p_target,
     return ret_val;
 }
 
+
+/**
+ ********************************************************************************************************
+ *                                          ockam_mem_set()
+ *
+ * @brief   Set the memory buffer to the specified value
+ *
+ * @param   p_target[in]    Buffer address to write data to
+ *
+ * @param   value[in]       Value to set to the memory buffer
+ *
+ * @param   num             The number of bytes to set to the value
+ *
+ * @return  OCKAM_ERR_NONE on success.
+ *
+ ********************************************************************************************************
+ */
+
+OCKAM_ERR ockam_mem_set(void* p_target,
+                        uint8_t value,
+                        uint32_t num)
+{
+    OCKAM_ERR ret_val = OCKAM_ERR_NONE;
+
+
+    do {
+        if(p_target == 0) {                                     /* Target MUST be a valid buffer                      */
+            ret_val = OCKAM_ERR_INVALID_PARAM;
+            break;
+        }
+
+        memset(p_target, value, num);
+
+    } while(0);
+
+    return ret_val;
+}
+

--- a/implementations/c/test/ockam/vault/atecc508a/source/test_atecc508a.c
+++ b/implementations/c/test/ockam/vault/atecc508a/source/test_atecc508a.c
@@ -84,7 +84,8 @@ VAULT_MICROCHIP_CFG_s atecc508a_cfg = {
 OCKAM_VAULT_CFG_s vault_cfg =
 {
     .p_tpm                       = &atecc508a_cfg,
-    .p_host                      = 0
+    .p_host                      = 0,
+    OCKAM_VAULT_EC_P256
 };
 
 
@@ -146,7 +147,7 @@ void main (void)
     /* Key Generation & ECDH */
     /* --------------------- */
 
-    test_vault_key_ecdh();
+    test_vault_key_ecdh(vault_cfg.ec);
 
     /* -----*/
     /* HKDF */

--- a/implementations/c/test/ockam/vault/atecc608a/source/test_atecc608a.c
+++ b/implementations/c/test/ockam/vault/atecc608a/source/test_atecc608a.c
@@ -82,7 +82,8 @@ VAULT_MICROCHIP_CFG_s atecc608a_cfg = {
 OCKAM_VAULT_CFG_s vault_cfg =
 {
     .p_tpm                       = &atecc608a_cfg,
-    .p_host                      = 0
+    .p_host                      = 0,
+    OCKAM_VAULT_EC_P256
 };
 
 
@@ -135,12 +136,6 @@ void main (void)
         return;
     }
 
-
-    err = ockam_vault_init((void*) &vault_cfg);                 /* Initialize Vault                                   */
-    if(err != OCKAM_ERR_NONE) {
-        printf("Error: Ockam Vauilt Init failed\r\n");
-    }
-
     /* ------------------------ */
     /* Random Number Generation */
     /* ------------------------ */
@@ -151,7 +146,7 @@ void main (void)
     /* Key Generation & ECDH */
     /* --------------------- */
 
-    test_vault_key_ecdh();
+    test_vault_key_ecdh(vault_cfg.ec);
 
     /* -----*/
     /* HKDF */

--- a/implementations/c/test/ockam/vault/build.gradle
+++ b/implementations/c/test/ockam/vault/build.gradle
@@ -7,7 +7,7 @@ plugins {
 ['build', 'test', 'clean'].each { t ->
     task "${t}" {
         group 'vault'
-        def testTasks = ['atecc508a', 'atecc608a'].stream().map { test ->
+        def testTasks = ['atecc508a', 'atecc608a', 'mbedcrypto'].stream().map { test ->
             tasks.create("${t}${test.capitalize()}") {
                 group test.capitalize()
                 onlyIf { host.debianBuilder.enabled }

--- a/implementations/c/test/ockam/vault/mbedcrypto/CMakeLists.txt
+++ b/implementations/c/test/ockam/vault/mbedcrypto/CMakeLists.txt
@@ -1,0 +1,110 @@
+cmake_minimum_required(VERSION 3.13)
+
+###########################
+# Path & Compiler Options #
+###########################
+
+# Always load the path.cmake file FIRST
+include($ENV{OCKAM_C_BASE}/tools/cmake/path.cmake)
+
+# This must be included BEFORE the project declaration
+include(${OCKAM_C_BASE}/tools/cmake/toolchains/raspberry-pi.cmake)
+
+###########
+# Project #
+###########
+
+project(test_mbedcrypto)
+
+
+###########################
+# Set directory locations #
+###########################
+
+set(TEST_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source)
+set(TEST_CFG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/config)
+
+set(TEST_COMMON_SRC_DIR ${OCKAM_C_BASE}/test/ockam/vault/source)
+set(TEST_COMMON_INC_DIR ${OCKAM_C_BASE}/test/ockam/vault/include)
+
+set(OCKAM_SRC_DIR ${OCKAM_C_BASE}/source/ockam)
+set(OCKAM_INC_DIR ${OCKAM_C_BASE}/include)
+
+set(VAULT_SRC_DIR ${OCKAM_SRC_DIR}/vault)
+set(KAL_SRC_DIR ${OCKAM_SRC_DIR}/kal)
+set(LOG_SRC_DIR ${OCKAM_SRC_DIR}/log)
+set(MEM_SRC_DIR ${OCKAM_SRC_DIR}/memory)
+
+set(THIRD_PARTY_DIR ${OCKAM_C_BASE}/third-party)
+
+
+#################
+# Build Options #
+#################
+
+# Vault Build Options
+set(VAULT_HOST_MBEDCRYPTO TRUE)
+
+# KAL Build Option
+set(KAL_LINUX TRUE)
+
+# Log Build Option
+set(LOG_PRINTF TRUE)
+
+# Mem Build Option
+set(MEM_STDLIB TRUE)
+
+# Compiler Build Options
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+
+###########################
+# Set include directories #
+###########################
+
+set(TEST_INC ${TEST_INC} ${OCKAM_INC_DIR})
+set(TEST_INC ${TEST_INC} ${TEST_COMMON_INC_DIR})
+
+include_directories(${TEST_INC})
+
+
+####################
+# Set config files #
+####################
+
+add_definitions(-DOCKAM_VAULT_CONFIG_FILE="${TEST_CFG_DIR}/vault_config.h")
+
+####################
+# Set source files #
+####################
+
+set(TEST_SRC ${TEST_SRC} ${TEST_SRC_DIR}/test_mbedcrypto.c)
+set(TEST_SRC ${TEST_SRC} ${TEST_COMMON_SRC_DIR}/aes_gcm.c)
+set(TEST_SRC ${TEST_SRC} ${TEST_COMMON_SRC_DIR}/hkdf.c)
+set(TEST_SRC ${TEST_SRC} ${TEST_COMMON_SRC_DIR}/key_ecdh.c)
+set(TEST_SRC ${TEST_SRC} ${TEST_COMMON_SRC_DIR}/print.c)
+set(TEST_SRC ${TEST_SRC} ${TEST_COMMON_SRC_DIR}/random.c)
+
+###########################
+# Set the desired modules #
+###########################
+
+add_subdirectory(${VAULT_SRC_DIR} vault)
+add_subdirectory(${KAL_SRC_DIR} kal)
+add_subdirectory(${LOG_SRC_DIR} log)
+add_subdirectory(${MEM_SRC_DIR} mem)
+
+#########################################
+# Configure link libraries & executable #
+#########################################
+
+link_directories(${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
+add_executable(test_mbedcrypto ${TEST_SRC})
+
+target_link_libraries(test_mbedcrypto ockam_vault)
+target_link_libraries(test_mbedcrypto ockam_kal)
+target_link_libraries(test_mbedcrypto ockam_log)
+target_link_libraries(test_mbedcrypto ockam_mem)
+target_link_libraries(test_mbedcrypto mbedcrypto)
+
+install(TARGETS test_mbedcrypto DESTINATION bin)

--- a/implementations/c/test/ockam/vault/mbedcrypto/build.gradle
+++ b/implementations/c/test/ockam/vault/mbedcrypto/build.gradle
@@ -1,0 +1,36 @@
+
+plugins {
+  id 'network.ockam.gradle.host' version '1.0.0'
+  id 'network.ockam.gradle.builders' version '1.0.0'
+}
+
+task build {
+  onlyIf { host.debianBuilder.enabled }
+  doLast {
+    builderExec 'debian', {
+      script '''
+        mkdir -p _build/
+        cd _build/
+        cmake .. 
+        make
+      '''
+    }
+  }
+}
+
+task test {
+  onlyIf { host.debianBuilder.enabled }
+  //doLast {
+  //  builderExec 'debian', {
+  //    script '''
+  //      ./_build/x86_64-unknown-linux-gnu/_install/bin/test_ockam
+  //    '''
+  //  }
+  //}
+}
+
+task clean {
+  doLast {
+    delete '_build'
+  }
+}

--- a/implementations/c/test/ockam/vault/mbedcrypto/config/vault_config.h
+++ b/implementations/c/test/ockam/vault/mbedcrypto/config/vault_config.h
@@ -1,0 +1,39 @@
+/**
+ ********************************************************************************************************
+ * @file        vault_config.h
+ * @brief
+ ********************************************************************************************************
+ */
+
+#ifndef VAULT_CONFIG_H_
+#define VAULT_CONFIG_H_
+
+
+/*
+ ********************************************************************************************************
+ *                                               INCLUDES                                               *
+ ********************************************************************************************************
+ */
+
+#include <ockam/vault/define.h>
+
+
+/*
+ ********************************************************************************************************
+ *                                         Function Configuration                                       *
+ ********************************************************************************************************
+ */
+
+
+#define OCKAM_VAULT_CFG_INIT               OCKAM_VAULT_HOST_MBEDCRYPTO
+
+#define OCKAM_VAULT_CFG_RAND               OCKAM_VAULT_HOST_MBEDCRYPTO
+
+#define OCKAM_VAULT_CFG_KEY_ECDH           OCKAM_VAULT_HOST_MBEDCRYPTO
+
+#define OCKAM_VAULT_CFG_HKDF               OCKAM_VAULT_HOST_MBEDCRYPTO
+
+#define OCKAM_VAULT_CFG_AES_GCM            OCKAM_VAULT_HOST_MBEDCRYPTO
+
+
+#endif

--- a/implementations/c/test/ockam/vault/mbedcrypto/settings.gradle
+++ b/implementations/c/test/ockam/vault/mbedcrypto/settings.gradle
@@ -1,0 +1,7 @@
+rootProject.name = 'atecc508a'
+
+boolean inComposite = gradle.parent != null
+if (!inComposite) {
+  includeBuild '../../../../../../tools/gradle/plugins/host'
+  includeBuild '../../../../../../tools/gradle/plugins/builder'
+}

--- a/implementations/c/test/ockam/vault/mbedcrypto/source/test_mbedcrypto.c
+++ b/implementations/c/test/ockam/vault/mbedcrypto/source/test_mbedcrypto.c
@@ -1,7 +1,7 @@
 /**
- ********************************************************************************************************
- * @file    test_vault.h
- * @brief   Common test functions for vault
+********************************************************************************************************
+ * @file        test_atecc508a.c
+ * @brief
  ********************************************************************************************************
  */
 
@@ -11,10 +11,15 @@
  ********************************************************************************************************
  */
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
 
-#include <ockam/log.h>
+#include <ockam/define.h>
+#include <ockam/error.h>
 #include <ockam/vault.h>
+
+#include <test_vault.h>
 
 
 /*
@@ -22,9 +27,6 @@
  *                                                DEFINES                                               *
  ********************************************************************************************************
  */
-
-#define TEST_VAULT_NO_TEST_CASE                     0xFF
-
 
 /*
  ********************************************************************************************************
@@ -50,6 +52,14 @@
  ********************************************************************************************************
  */
 
+OCKAM_VAULT_CFG_s vault_cfg =
+{
+    .p_tpm                       = 0,
+    .p_host                      = 0,
+    OCKAM_VAULT_EC_CURVE25519
+};
+
+
 /*
  ********************************************************************************************************
  *                                           GLOBAL FUNCTIONS                                           *
@@ -62,11 +72,60 @@
  ********************************************************************************************************
  */
 
-void test_vault_random(void);
-void test_vault_key_ecdh(OCKAM_VAULT_EC_e ec);
-void test_vault_hkdf(void);
-void test_vault_aes_gcm(void);
 
-void test_vault_print(OCKAM_LOG_e level, char* p_module, uint32_t test_case, char* p_msg);
-void test_vault_print_array(OCKAM_LOG_e level, char* p_module, char* p_label, uint8_t* p_array, uint32_t size);
+/**
+ ********************************************************************************************************
+ *                                             main()
+ *
+ * @brief   Main point of entry for mbedcrypto test
+ *
+ ********************************************************************************************************
+ */
+
+void main (void)
+{
+    OCKAM_ERR err;
+    uint8_t i;
+
+
+    /* ---------- */
+    /* Vault Init */
+    /* ---------- */
+
+    err = ockam_vault_init((void*) &vault_cfg);                 /* Initialize vault                                   */
+
+    if(err != OCKAM_ERR_NONE) {                                 /* Ensure it initialized before proceeding, otherwise */
+        test_vault_print(OCKAM_LOG_ERROR,                       /* don't bother trying to run any other tests         */
+                         "MBEDCRYPTO",
+                          0,
+                         "Error: Ockam Vault Init failed");
+        return;
+    }
+
+    /* ------------------------ */
+    /* Random Number Generation */
+    /* ------------------------ */
+
+    test_vault_random();
+
+    /* --------------------- */
+    /* Key Generation & ECDH */
+    /* --------------------- */
+
+    test_vault_key_ecdh(vault_cfg.ec);
+
+    /* -----*/
+    /* HKDF */
+    /* -----*/
+
+    test_vault_hkdf();
+
+    /* -------------------- */
+    /* AES GCM Calculations */
+    /* -------------------- */
+
+    test_vault_aes_gcm();
+
+    return;
+}
 

--- a/implementations/c/test/ockam/vault/source/print.c
+++ b/implementations/c/test/ockam/vault/source/print.c
@@ -56,7 +56,7 @@ char *g_log_level_str[MAX_OCKAM_LOG] =
     "FATAL",
 };
 
-OCKAM_LOG_e g_log_level = OCKAM_LOG_INFO;                   /* Only print log statements at info or higher            */
+OCKAM_LOG_e g_log_level = OCKAM_LOG_INFO;                       /* Only print log statements at info or higher            */
 
 
 /*


### PR DESCRIPTION
Add Ockam Vault support for the following operations using mbed crypto: #69 
-Random Number Generation
-Key Generation/Public Key Retrieval
-ECDH
-HKDF
-AES GCM 128/192/256

Test application target:
-Raspberry Pi