### PR TITLE
fix: Correct bug in writing shared secret value from mbed-crypto

### DIFF
--- a/implementations/c/source/ockam/vault/host/mbedcrypto.c
+++ b/implementations/c/source/ockam/vault/host/mbedcrypto.c
@@ -406,9 +406,9 @@ OCKAM_ERR ockam_vault_host_ecdh(OCKAM_VAULT_KEY_e key_type,
             break;
         }
 
-        mbed_ret = mbedtls_mpi_write_binary(&pms,               /* Write the generated PMS to the PMS buffer          */
-                                            p_pms,
-                                            pms_size);
+        mbed_ret = mbedtls_mpi_write_binary_le(&pms,            /* Write the generated PMS to the PMS buffer          */
+                                               p_pms,
+                                               pms_size);
         if(mbed_ret != 0) {
             ret_val = OCKAM_ERR_VAULT_HOST_ECDH_FAIL;
             break;


### PR DESCRIPTION
Change from write_ binary to write_binary_le
Add tests for Curve25519 to key_ecdh test cases to validate Curve25519
ECDH results