### PR TITLE
build: add raspberry pi tools to debian builder

### DIFF
--- a/tools/builder/debian/provision/arm-rpi.sh
+++ b/tools/builder/debian/provision/arm-rpi.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -eux
+
+cd /tmp
+
+download arm-rpi "https://github.com/raspberrypi/tools/archive/b0c869bc929587a7e1d20a98e2dc828a24ca396a.zip" \
+  "a14d46623b3b35743efb81d6c4096088f7b13796887670bb58dfc54446df1d4a"
+
+mkdir -p "/opt/arm-rpi-4.9.3-linux-gnueabihf"
+mv arm-rpi/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/* /opt/arm-rpi-4.9.3-linux-gnueabihf
+
+echo 'export PATH="/opt/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH"' > /etc/profile.d/arm-rpi.sh
+chmod u+x /etc/profile.d/arm-rpi.sh
+


### PR DESCRIPTION
Currently the raspberry pi compiler and sysroot are a git submodule
being pulled in at the start of every build. This is adding 5+ minutes
to the start of every build. This script will install the raspberry pi
tools into the debian builder so the download does not take place during
every build.