### PR TITLE
build: fixes to docker builder detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,19 +3,31 @@ plugins {
     id 'network.ockam.gradle.builders' version '1.0.0'
 }
 
+task detectDockerProvider {
+  doLast {
+    def dockerDir = new File('.vagrant/machines/builder-debian/docker')
+    if (dockerDir.exists()) {
+      project.ext.useDockerProvider = true
+    } else {
+      project.ext.useDockerProvider = false
+    }
+  }
+}
+
 ['build', 'test', 'clean'].each { t ->
   task "${t}" {
     group 'Ockam'
     def implementationTasks = ['c', 'elixir', 'go', 'javascript', 'rust', 'swift'].stream().map { impl ->
       tasks.create("${t}${impl.capitalize()}") {
         group impl.capitalize()
+
+        dependsOn detectDockerProvider
+
         doLast {
           exec {
-            if (project.hasProperty('useDockerProvider') && project.findProperty('useDockerProvider') == true) {
-              environment 'VAGRANT_DEFAULT_PROVIDER', 'docker'
-            }
+            def useDockerProvider = project.ext.useDockerProvider
             workingDir "implementations/${impl}"
-            commandLine '../../gradlew', '-q', "${t}"
+            commandLine '../../gradlew', '-q', "-PuseDockerProvider=${useDockerProvider}", "${t}"
           }
         }
       }
@@ -51,12 +63,15 @@ clean.doLast {
 }
 
 task setDockerProvider {
-  doLast {
-    project.ext.useDockerProvider = true
+  dependsOn detectDockerProvider
 
-    def vboxDir = new File('.vagrant/machines/builder-debian/virtualbox')
-    if (vboxDir.exists()) {
-      throw new GradleException('Cannot build with Docker without removing VirtualBox builder first!')
+  doLast {
+    if (!project.ext.useDockerProvider) {
+      def vboxDir = new File('.vagrant/machines/builder-debian/virtualbox/id')
+      if (vboxDir.exists()) {
+        throw new GradleException('Cannot build with Docker without removing VirtualBox builder first!')
+      }
+      project.ext.useDockerProvider = true
     }
   }
 }

--- a/implementations/c/test/ockam/vault/build.gradle
+++ b/implementations/c/test/ockam/vault/build.gradle
@@ -12,9 +12,10 @@ plugins {
                 group test.capitalize()
                 onlyIf { host.debianBuilder.enabled }
                 doLast {
+                    def useDockerProvider = project.ext.useDockerProvider
                     exec {
                         workingDir "${test}"
-                        commandLine '../../../../../../gradlew', '-q', "${t}"
+                        commandLine '../../../../../../gradlew', '-q', "-PuseDockerProvider=${useDockerProvider}", "${t}"
                     }
                 }
             }

--- a/tools/gradle/plugins/builder/src/main/groovy/network/ockam/gradle/builders/BuildersPlugin.groovy
+++ b/tools/gradle/plugins/builder/src/main/groovy/network/ockam/gradle/builders/BuildersPlugin.groovy
@@ -62,6 +62,11 @@ class BuildersPlugin implements Plugin<Project> {
     if (project.hasProperty('useDockerProvider') && project.getProperty('useDockerProvider') == true) {
       return true;
     }
+    def dockerBuilder = new File(project.host.vagrantfileDir, '.vagrant/machines/builder-debian/docker')
+    if (dockerBuilder.exists()) {
+      project.ext.useDockerProvider = true;
+      return true;
+    }
     def env = System.getenv("VAGRANT_DEFAULT_PROVIDER")
     def useDockerProvider = env == "docker";
     project.ext.useDockerProvider = useDockerProvider;
@@ -114,6 +119,9 @@ class BuildersPlugin implements Plugin<Project> {
       ("OCKAM_${builderName.toUpperCase()}_BUILDER_MEMORY".toString()): (project.host["${builderName}Builder"]).memory,
       ("OCKAM_${builderName.toUpperCase()}_BUILDER_CPUS".toString()): (project.host["${builderName}Builder"]).cpus
     ]
+    if (usingDockerProvider(project)) {
+      env['VAGRANT_DEFAULT_PROVIDER'] = 'docker'
+    }
     if(project.host.privateBoxesSharedAccessToken != null) {
       env['OCKAM_PRIVATE_BOXES_SHARED_ACCESS_TOKEN'] = project.host.privateBoxesSharedAccessToken
     }


### PR DESCRIPTION
Improves handling of builder detection when building in subdirectories, can now invoke things like `buildC` directly without having to specify a Docker-specific task, or export environment variables