### PR TITLE
feat(c): add size parameter to memory free

### DIFF
--- a/implementations/c/include/ockam/memory.h
+++ b/implementations/c/include/ockam/memory.h
@@ -91,11 +91,13 @@ typedef struct {
    *
    * @param   p_buf[in] Pointer to the buffer to free. Must have been allocated from Alloc().
    *
+   * @param   size[in]  Size of the buffer that was allocated. Must match what was specified in Alloc.
+   *
    * @return  kOckamErrNone on success.
    ****************************************************************************************************
    */
 
-  MemoryError (*Free)(void *p_buf);
+  MemoryError (*Free)(void *p_buf, size_t size);
 
   /**
    ****************************************************************************************************

--- a/implementations/c/lib/memory/stdlib.c
+++ b/implementations/c/lib/memory/stdlib.c
@@ -41,7 +41,7 @@
 
 MemoryError MemoryStdlibCreate(void *p_arg);
 MemoryError MemoryStdlibAlloc(void **p_buf, size_t size);
-MemoryError MemoryStdlibFree(void *p_buf);
+MemoryError MemoryStdlibFree(void *p_buf, size_t size);
 MemoryError MemoryStdlibCopy(void *p_dest, void *p_src, size_t size);
 MemoryError MemoryStdlibSet(void *p_mem, uint8_t val, size_t size);
 MemoryError MemoryStdlibMove(void *p_dest, void *p_src, size_t num);
@@ -112,8 +112,10 @@ exit_block:
  ********************************************************************************************************
  */
 
-MemoryError MemoryStdlibFree(void *p_buf) {
+MemoryError MemoryStdlibFree(void *p_buf, size_t size) {
   MemoryError ret_val = kOckamErrorNone;
+
+  (void) size;
 
   if (p_buf == 0) {
     ret_val = kMemoryErrorInvalidParam;

--- a/implementations/c/lib/vault/default/default.c
+++ b/implementations/c/lib/vault/default/default.c
@@ -229,7 +229,7 @@ VaultError VaultDefaultDestroy(OckamVaultCtx *p_ctx) {
   }
 
   memory = p_ctx->memory;
-  memory->Free(p_ctx);
+  memory->Free(p_ctx, sizeof(OckamVaultCtx));
 
 exit_block:
   return ret_val;
@@ -295,10 +295,10 @@ VaultError VaultDefaultRandomDestroy(OckamVaultCtx *p_ctx) {
   p_random_ctx = p_ctx->random_ctx;
 
   if (p_random_ctx->br_random_ctx != 0) {
-    memory->Free(p_random_ctx->br_random_ctx);
+    memory->Free(p_random_ctx->br_random_ctx, p_random_ctx->br_random->context_size);
   }
 
-  ret_val = memory->Free(p_random_ctx);
+  ret_val = memory->Free(p_random_ctx, sizeof(VaultDefaultRandomCtx));
   if (ret_val != kOckamErrorNone) {
     goto exit_block;
   }
@@ -438,11 +438,11 @@ VaultError VaultDefaultKeyEcdhDestroy(OckamVaultCtx *p_ctx) {
 
   for (i = 0; i < kMaxOckamVaultKey; i++) {
     if (p_key_ecdh_ctx->br_private_key_buf[i] != 0) {
-      memory->Free(p_key_ecdh_ctx->br_private_key_buf[i]);
+      memory->Free(p_key_ecdh_ctx->br_private_key_buf[i], p_key_ecdh_ctx->br_private_key_size);
     }
   }
 
-  ret_val = memory->Free(p_key_ecdh_ctx);
+  ret_val = memory->Free(p_key_ecdh_ctx, sizeof(VaultDefaultKeyEcdhCtx));
   if (ret_val != kOckamErrorNone) {
     goto exit_block;
   }
@@ -687,10 +687,10 @@ VaultError VaultDefaultSha256Destroy(OckamVaultCtx *p_ctx) {
   p_sha256_ctx = p_ctx->sha256_ctx;
 
   if (p_sha256_ctx->br_sha256_ctx != 0) {
-    memory->Free(p_sha256_ctx->br_sha256_ctx);
+    memory->Free(p_sha256_ctx->br_sha256_ctx, p_sha256_ctx->br_sha256->context_size);
   }
 
-  ret_val = memory->Free(p_sha256_ctx);
+  ret_val = memory->Free(p_sha256_ctx, sizeof(VaultDefaultSha256Ctx));
   if (ret_val != kOckamErrorNone) {
     goto exit_block;
   }
@@ -782,7 +782,7 @@ VaultError VaultDefaultHkdfDestroy(OckamVaultCtx *p_ctx) {
 
   memory = p_ctx->memory;
 
-  ret_val = memory->Free(p_ctx->hkdf_ctx);
+  ret_val = memory->Free(p_ctx->hkdf_ctx, sizeof(br_hkdf_context));
   if (ret_val != kOckamErrorNone) {
     goto exit_block;
   }
@@ -864,7 +864,7 @@ VaultError VaultDefaultAesGcmCreate(OckamVaultCtx *p_ctx) {
 
   ret_val = memory->Alloc((void **)&(p_aes_gcm_ctx->br_aes_gcm_ctx), sizeof(br_gcm_context));
   if (ret_val != kOckamErrorNone) {
-    memory->Free(p_aes_gcm_ctx->br_aes_keys);
+    memory->Free(p_aes_gcm_ctx->br_aes_keys, sizeof(br_aes_ct_ctr_keys));
     goto exit_block;
   }
 
@@ -893,15 +893,15 @@ VaultError VaultDefaultAesGcmDestroy(OckamVaultCtx *p_ctx) {
 
   memory = p_ctx->memory;
 
-  if (p_aes_gcm_ctx->br_aes_keys != 0) {
-    memory->Free(p_aes_gcm_ctx->br_aes_keys);
-  }
-
   if (p_aes_gcm_ctx->br_aes_gcm_ctx != 0) {
-    memory->Free(p_aes_gcm_ctx->br_aes_gcm_ctx);
+    memory->Free(p_aes_gcm_ctx->br_aes_gcm_ctx, sizeof(br_gcm_context));
   }
 
-  ret_val = memory->Free(p_aes_gcm_ctx);
+  if (p_aes_gcm_ctx->br_aes_keys != 0) {
+    memory->Free(p_aes_gcm_ctx->br_aes_keys, sizeof(br_aes_ct_ctr_keys));
+  }
+
+  ret_val = memory->Free(p_aes_gcm_ctx, sizeof(VaultDefaultAesGcmCtx));
   if (ret_val != kOckamErrorNone) {
     goto exit_block;
   }

--- a/implementations/c/lib/vault/tests/aes_gcm.c
+++ b/implementations/c/lib/vault/tests/aes_gcm.c
@@ -227,8 +227,10 @@ void TestVaultAesGcm(void **state) {
   /* ----------- */
 
   // TODO this will not be freed on an error
-  p_test_data->p_memory->Free(p_aes_gcm_encrypt_hash); /* Ignore the error result. Some tests don't allocate */
-  p_test_data->p_memory->Free(p_aes_gcm_decrypt_data); /* memory which freeing results in an error.          */
+  p_test_data->p_memory->Free(p_aes_gcm_encrypt_hash,           /* Ignore the error result. Some tests don't allocate */
+      g_aes_gcm_data[p_test_data->test_count].text_size);
+  p_test_data->p_memory->Free(p_aes_gcm_decrypt_data,           /* memory which freeing results in an error.          */
+      g_aes_gcm_data[p_test_data->test_count].text_size);
 }
 
 /**

--- a/implementations/c/lib/vault/tests/hkdf.c
+++ b/implementations/c/lib/vault/tests/hkdf.c
@@ -193,7 +193,7 @@ void TestVaultHkdf(void **state) {
   /* Memory Free */
   /* ----------- */
 
-  p_test_data->p_memory->Free(p_hkdf_key);
+  p_test_data->p_memory->Free(p_hkdf_key, g_hkdf_data[p_test_data->test_count].output_size);
 }
 
 /**

--- a/implementations/c/lib/vault/tests/key_ecdh.c
+++ b/implementations/c/lib/vault/tests/key_ecdh.c
@@ -318,8 +318,8 @@ void TestVaultKeyEcdh(void **state) {
   /* Memory free */
   /* ----------- */
 
-  p_test_data->p_memory->Free(p_static_pub);
-  p_test_data->p_memory->Free(p_ephemeral_pub);
+  p_test_data->p_memory->Free(p_static_pub, p_test_data->key_size);
+  p_test_data->p_memory->Free(p_ephemeral_pub, p_test_data->key_size);
 }
 
 /**


### PR DESCRIPTION
In order to integrate the C memory functions with Rust's
Alloc/GlobalAlloc, a size parameter is needed in OckamMemory's Free
function. Caller's of Free should always pass in the size they
allocated, but the underlying implementation of Free may choose to
enforce or ignore the size parameter.