### PR TITLE
Improve Vault and Transport tests

### DIFF
--- a/implementations/c/lib/key_agreement/tests/xx/xx_test.c
+++ b/implementations/c/lib/key_agreement/tests/xx/xx_test.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 #include "ockam/error.h"
 #include "ockam/key_agreement.h"

--- a/implementations/c/lib/transport/tests/posix_socket/tcp/test_tcp.h
+++ b/implementations/c/lib/transport/tests/posix_socket/tcp/test_tcp.h
@@ -2,7 +2,7 @@
 #define TEST_TCP_H
 
 OckamError file_compare(char *p_f1, char *p_f2);
-int testTcpServer(OckamInternetAddress *pHostAddress);
-int testTcpClient(OckamInternetAddress *pHostAddress);
+int testTcpServer(OckamInternetAddress *pIPAddress, char* p_fixture_path);
+int testTcpClient(OckamInternetAddress *pHostAddress, char *p_fixture_path);
 
 #endif

--- a/implementations/c/lib/transport/tests/posix_socket/tcp/test_tcp_client.c
+++ b/implementations/c/lib/transport/tests/posix_socket/tcp/test_tcp_client.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <sys/wait.h>
 
 #include "ockam/syslog.h"
 #include "ockam/transport.h"

--- a/implementations/c/lib/transport/tests/posix_socket/tcp/test_tcp_server.c
+++ b/implementations/c/lib/transport/tests/posix_socket/tcp/test_tcp_server.c
@@ -5,13 +5,16 @@
 #include "ockam/transport.h"
 #include "test_tcp.h"
 
-char *pSrvFileToSend = "fixtures/server_test_data.txt";
-char *pSrvFileToReceive = "fixtures/server_data_received.txt";
-char *pSrvFileToCompare = "fixtures/client_test_data.txt";
+#define DEFAULT_FIXTURE_PATH "fixtures/"
+#define FIXTURE_FULL_PATH_LEN 256
+
+char *pSrvFileToSend = "server_test_data.txt";
+char *pSrvFileToReceive = "server_data_received.txt";
+char *pSrvFileToCompare = "client_test_data.txt";
 
 extern const OckamTransport *transport;
 
-int testTcpServer(OckamInternetAddress *pIPAddress) {
+int testTcpServer(OckamInternetAddress *pIPAddress, char* p_fixture_path) {
   TransportError status = kErrorNone;
   OckamTransportCtx connection = NULL;
   OckamTransportCtx listener = NULL;
@@ -22,6 +25,9 @@ int testTcpServer(OckamInternetAddress *pIPAddress) {
   FILE *fileToSend = NULL;
   FILE *fileToReceive = NULL;
   FILE *errorLog = NULL;
+  char fileSrvToSendPath[FIXTURE_FULL_PATH_LEN] = {0};
+  char fileSrvToReceivePath[FIXTURE_FULL_PATH_LEN] = {0};
+  char fileSrvToComparePath[FIXTURE_FULL_PATH_LEN] = {0};
   uint16_t bytesWritten;
   unsigned sendNotDone = 1;
   unsigned receiveNotDone = 1;
@@ -35,7 +41,8 @@ int testTcpServer(OckamInternetAddress *pIPAddress) {
   }
 
   // Open the test data file for sending
-  fileToSend = fopen(pSrvFileToSend, "r");
+  sprintf(&fileSrvToSendPath[0], "%s/%s", p_fixture_path, pSrvFileToSend);
+  fileToSend = fopen(&fileSrvToSendPath[0], "r");
   if (NULL == fileToSend) {
     status = kTestFailure;
     log_error(status, "failed to open test file test_data_client.txt");
@@ -43,7 +50,8 @@ int testTcpServer(OckamInternetAddress *pIPAddress) {
   }
 
   // Create file for test data received
-  fileToReceive = fopen(pSrvFileToReceive, "w");
+  sprintf(&fileSrvToReceivePath[0], "%s/%s", p_fixture_path, pSrvFileToReceive);
+  fileToReceive = fopen(&fileSrvToReceivePath[0], "w");
   if (NULL == fileToReceive) {
     status = kTestFailure;
     log_error(status, "failed to open test file test_data_client.txt");
@@ -96,7 +104,8 @@ int testTcpServer(OckamInternetAddress *pIPAddress) {
   fclose(fileToSend);
 
   // Now compare the received file and the reference file
-  if (0 != file_compare(pSrvFileToReceive, pSrvFileToCompare)) {
+  sprintf(&fileSrvToComparePath[0], "%s/%s", p_fixture_path, pSrvFileToCompare);
+  if (0 != file_compare(&fileSrvToReceivePath[0], &fileSrvToComparePath[0])) {
     status = kTestFailure;
     log_error(status, "file compare failed");
     goto exit_block;

--- a/implementations/c/lib/vault/default/tests/test_default.c
+++ b/implementations/c/lib/vault/default/tests/test_default.c
@@ -83,7 +83,6 @@ const OckamMemory *memory = &ockam_memory_stdlib;
 
 int main(void) {
   OckamError err;
-  uint8_t i;
   void *default_0 = 0;
 
   memory->Create(0);
@@ -94,7 +93,7 @@ int main(void) {
   /* Vault Init */
   /* ---------- */
 
-  vault->Create(&default_0, &default_cfg, memory);
+  err = vault->Create(&default_0, &default_cfg, memory);
   if (err != kOckamErrorNone) { /* Ensure it initialized before proceeding, otherwise */
     return -1;                  /* don't bother trying to run any other tests         */
   }


### PR DESCRIPTION
This PR contains two improvements:

1. Add getopts to the TCP test to allow for a non-fixed path to the fixtures directory. IP and Port are also added to getopts.
2. Check the error return for the default vault test create step. 