### PR TITLE
feat: initial wire protocol impl for elixir

### DIFF
--- a/implementations/elixir/lib/router/protocol.ex
+++ b/implementations/elixir/lib/router/protocol.ex
@@ -1,0 +1,25 @@
+defmodule Ockam.Router.Protocol do
+  alias __MODULE__.Encoding
+  alias __MODULE__.{EncodeError, DecodeError}
+
+  @type message :: %{__struct__: module | map()}
+  @type opts :: map()
+
+  @spec encode_message(message, opts) :: {:ok, binary} | {:error, EncodeError.t() | Exception.t()}
+  defdelegate encode_message(message, opts \\ %{}), to: Encoding, as: :encode
+
+  @spec decode_message(iodata, opts) ::
+          {:ok, message, binary} | {:error, DecodeError.t() | Exception.t()}
+  def decode_message(input, opts \\ %{keys: :atoms!})
+
+  def decode_message(input, opts) when is_list(input) do
+    decode_message(IO.iodata_to_binary(input), opts)
+  end
+
+  def decode_message(input, opts) when is_binary(input) do
+    Encoding.decode(input, normalize_opts(opts))
+  end
+
+  defp normalize_opts(opts) when is_map(opts), do: opts
+  defp normalize_opts(opts) when is_list(opts), do: Enum.into(opts, %{})
+end

--- a/implementations/elixir/lib/router/protocol/decoder.ex
+++ b/implementations/elixir/lib/router/protocol/decoder.ex
@@ -1,0 +1,37 @@
+defprotocol Ockam.Router.Protocol.Decoder do
+  @type t :: term()
+  @type key :: atom()
+  @type type :: :raw | :string | :boolean | :integer | module()
+  @type descriptor :: type | {type, default_value :: term()}
+  @type field :: {key, descriptor}
+  @type schema :: [field]
+  @type opt :: {:schema, schema}
+  @type opts :: [opt]
+  @type reason :: term()
+
+  @fallback_to_any true
+
+  @spec decode(t, iodata, opts) :: {:ok, t, iodata} | {:error, reason}
+  def decode(value, encoded, opts)
+end
+
+defimpl Ockam.Router.Protocol.Decoder, for: Any do
+  alias Ockam.Router.Protocol.Encoding.Default
+
+  defmacro __deriving__(module, _struct, opts) do
+    quote do
+      require Protocol
+      Protocol.derive(unquote(Default.Decoder), unquote(module), unquote(opts))
+
+      defimpl Ockam.Router.Protocol.Decoder, for: unquote(module) do
+        def decode(value, encoded, opts) do
+          unquote(Default.Decoder).decode(value, encoded, opts)
+        end
+      end
+    end
+  end
+
+  def decode(value, encoded, opts) do
+    Default.Decoder.decode(value, encoded, opts)
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoder.ex
+++ b/implementations/elixir/lib/router/protocol/encoder.ex
@@ -1,0 +1,31 @@
+defprotocol Ockam.Router.Protocol.Encoder do
+  @type t :: term()
+  @type opts :: Keyword.t()
+  @type reason :: term()
+
+  @fallback_to_any true
+
+  @spec encode(t, opts) :: {:ok, iodata} | {:error, reason}
+  def encode(value, opts)
+end
+
+defimpl Ockam.Router.Protocol.Encoder, for: Any do
+  alias Ockam.Router.Protocol.Encoding.Default
+
+  defmacro __deriving__(module, _struct, opts) do
+    quote do
+      require Protocol
+      Protocol.derive(unquote(Default.Encoder), unquote(module), unquote(opts))
+
+      defimpl Ockam.Router.Protocol.Encoder, for: unquote(module) do
+        def encode(value, opts) do
+          unquote(Default.Encoder).encode(value, opts)
+        end
+      end
+    end
+  end
+
+  def encode(value, opts) do
+    Default.Encoder.encode(value, opts)
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoding.ex
+++ b/implementations/elixir/lib/router/protocol/encoding.ex
@@ -1,0 +1,19 @@
+defmodule Ockam.Router.Protocol.Encoding do
+  @type message :: term
+  @type opts :: map()
+  @type reason :: term
+
+  alias Ockam.Router.Protocol.{EncodeError, DecodeError}
+  alias __MODULE__.Default
+
+  @callback encode!(message, opts) :: binary | no_return
+  @callback encode(message, opts) :: {:ok, binary} | {:error, EncodeError.t() | Exception.t()}
+  @callback decode!(iodata, opts) :: {message, binary} | no_return
+  @callback decode(iodata, opts) ::
+              {:ok, message, binary} | {:error, DecodeError.t() | Exception.t()}
+
+  defdelegate encode!(message, opts \\ %{}), to: Default
+  defdelegate encode(message, opts \\ %{}), to: Default
+  defdelegate decode!(encoded, opts \\ %{}), to: Default
+  defdelegate decode(encoded, opts \\ %{}), to: Default
+end

--- a/implementations/elixir/lib/router/protocol/encoding/default.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/default.ex
@@ -1,0 +1,111 @@
+defmodule Ockam.Router.Protocol.Encoding.Default do
+  @behaviour Ockam.Router.Protocol.Encoding
+
+  alias __MODULE__.Encode
+  alias __MODULE__.Encoder
+  alias __MODULE__.Decoder
+  alias Ockam.Router.Protocol.DecodeError
+  alias Ockam.Router.Protocol.Encoding
+  alias Ockam.Router.Protocol.Encoding.Helpers
+  alias Ockam.Router.Protocol.Message.Envelope
+
+  @type message :: Encoding.message()
+  @type opts :: Encoding.opts()
+  @type reason :: Encoding.reason()
+
+  @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> term)
+  @type strings :: :reference | :copy
+  @type decode_opt :: {:keys, keys} | {:strings, strings}
+
+  @spec encode!(message, opts) :: iodata | no_return
+  def encode!(message, opts \\ %{})
+
+  def encode!(message, opts) do
+    case encode(message, opts) do
+      {:ok, encoded} ->
+        encoded
+
+      {:error, error} ->
+        raise error
+    end
+  end
+
+  @spec encode(message, opts) :: {:ok, iodata} | {:error, reason}
+  def encode(message, opts \\ %{})
+
+  def encode(%Envelope{headers: headers, body: %type{} = body}, opts) do
+    opts = normalize_encode_opts(opts)
+    headers_len = Helpers.encode_leb128_u2(map_size(headers))
+
+    with {:ok, headers} <- encode_headers(Map.to_list(headers), opts),
+         {:ok, body} <- Encode.encode(body, opts) do
+      type_id = Helpers.encode_leb128_u2(type.type_id())
+      version = Helpers.encode_leb128_u2(1)
+      {:ok, IO.iodata_to_binary([version, headers_len, headers, type_id, body])}
+    end
+  end
+
+  def encode(%_{} = message, opts) when is_map(opts) do
+    encode(%Envelope{body: message}, opts)
+  end
+
+  defp encode_headers(headers, opts), do: encode_headers(headers, opts, [])
+
+  defp encode_headers([], _opts, acc), do: {:ok, acc}
+
+  defp encode_headers([header | rest], opts, acc) do
+    with {:ok, {type, value}} <- header_to_header_type(header),
+         {:ok, encoded} <- Encoder.encode(value, opts) do
+      encode_headers(rest, opts, [<<type::8>>, encoded | acc])
+    end
+  end
+
+  defp header_to_header_type({:send_to, endpoint}), do: {:ok, {0, endpoint}}
+  defp header_to_header_type({:reply_to, endpoint}), do: {:ok, {1, endpoint}}
+  defp header_to_header_type({key, _value}), do: {:error, {:unknown_header_type, key}}
+
+  @spec decode!(iodata, opts) :: {message, iodata} | no_return
+  def decode!(input, opts \\ %{})
+
+  def decode!(input, opts) do
+    case decode(input, opts) do
+      {:ok, message, rest} ->
+        {message, rest}
+
+      {:error, error} ->
+        raise error
+    end
+  end
+
+  @spec decode(iodata, opts) :: {:ok, message, iodata} | {:error, reason}
+  def decode(input, opts \\ %{})
+
+  def decode(input, opts) when (is_binary(input) or is_list(input)) and is_map(opts) do
+    input = IO.iodata_to_binary(input)
+
+    with {:ok, {version, input}} <- decode_version(input) do
+      decode_envelope(version, input, normalize_decode_opts(opts))
+    end
+  end
+
+  defp decode_version(input) do
+    {:ok, Helpers.decode_leb128_u2(input)}
+  catch
+    :throw, err ->
+      {:error, err}
+  end
+
+  defp decode_envelope(1, input, opts) do
+    Decoder.decode(%Envelope{}, input, opts)
+  end
+
+  defp decode_envelope(version, _input, _opts) do
+    {:error, DecodeError.new("unknown message version (#{inspect(version)})")}
+  end
+
+  defp normalize_encode_opts(opts), do: opts
+
+  defp normalize_decode_opts(opts) do
+    Enum.into(opts, %{keys: :strings, strings: :reference})
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoding/default/codegen.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/default/codegen.ex
@@ -1,0 +1,90 @@
+defmodule Ockam.Router.Protocol.Encoding.Default.Codegen do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+  alias Ockam.Router.Protocol.Encoding.Default.Decode
+
+  def build_kv_iodata(kv, encode_opts, encode_args) do
+    kv
+    |> Enum.map(&encode_pair(&1, encode_opts, encode_args))
+    |> List.flatten()
+    |> collapse_static()
+  end
+
+  def build_constant_iodata(kv, schema, encode_args) do
+    Enum.map(kv, &encode_value(&1, schema, encode_args))
+  end
+
+  def build_decoder(_module, value, input, [], _decode_args) do
+    quote(do: {:ok, unquote(value), unquote(input)})
+  end
+
+  def build_decoder(module, value, input, schema, decode_args) do
+    decodes = build_decoder(module, value, input, schema, decode_args, [])
+
+    quote do
+      with unquote_splicing(decodes) do
+        {:ok, unquote(value), unquote(input)}
+      end
+    end
+  end
+
+  defp build_decoder(_module, _value, _input, [], _decode_args, acc), do: Enum.reverse(acc)
+
+  defp build_decoder(module, value, input, [{key, {type, default}} | schema], decode_args, acc) do
+    acc = build_value_decoder(module, value, input, key, type, default, decode_args, acc)
+    build_decoder(module, value, input, schema, decode_args, acc)
+  end
+
+  defp build_decoder(module, value, input, [{key, type} | schema], decode_args, acc) do
+    acc = build_value_decoder(module, value, input, key, type, nil, decode_args, acc)
+    build_decoder(module, value, input, schema, decode_args, acc)
+  end
+
+  defp build_value_decoder(_module, value, input, key, type, _default, decode_args, acc) do
+    binding = {key, [generated: true], __MODULE__}
+
+    bound =
+      quote do
+        {:ok, unquote(binding), unquote(input)} <-
+          unquote(Decode).decode(
+            unquote(type),
+            unquote_splicing(decode_args)
+          )
+      end
+
+    applied =
+      quote do
+        unquote(value) = Map.put(unquote(value), unquote(key), unquote(binding))
+      end
+
+    [applied, bound | acc]
+  end
+
+  defp encode_pair({key, value}, encode_opts, encode_args) do
+    key = IO.iodata_to_binary(Encode.atom(key, encode_opts))
+    [key, quote(do: unquote(Encode).encode_value(unquote(value), unquote_splicing(encode_args)))]
+  end
+
+  defp encode_value({key, value}, schema, encode_args) do
+    type = Keyword.fetch!(schema, key)
+
+    case type do
+      :i1 ->
+        quote(do: {:ok, unquote(Encode).i1(unquote(value), unquote_splicing(encode_args))})
+
+      _other ->
+        quote(do: unquote(Encode).encode_value(unquote(value), unquote_splicing(encode_args)))
+    end
+  end
+
+  defp collapse_static([bin1, bin2 | rest]) when is_binary(bin1) and is_binary(bin2) do
+    collapse_static([bin1 <> bin2 | rest])
+  end
+
+  defp collapse_static([other | rest]) do
+    [other | collapse_static(rest)]
+  end
+
+  defp collapse_static([]) do
+    []
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoding/default/decode.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/default/decode.ex
@@ -1,0 +1,122 @@
+defmodule Ockam.Router.Protocol.Encoding.Default.Decode do
+  @moduledoc """
+  Decodes encoded values using the `Default` decoder.
+  """
+
+  import Ockam.Router.Protocol.Encoding.Helpers
+
+  alias Ockam.Router.Protocol.DecodeError
+  alias Ockam.Router.Protocol.Encoding.Default.Decoder
+
+  @opaque opts :: map()
+  @type type ::
+          :raw
+          | :string
+          | :atom
+          | :integer
+          | :float
+          | module()
+  @type message :: term()
+
+  @doc false
+  @spec decode(type, iodata, opts) ::
+          {:ok, message, iodata} | {:error, DecodeError.t() | Exception.t()}
+  def decode(type, encoded, opts) when is_binary(encoded) do
+    keys_fun = key_decoder(opts)
+    strings_fun = string_decoder(opts)
+
+    decode(type, encoded, keys_fun, strings_fun, opts)
+  end
+
+  @doc false
+  def decode(type, encoded, keys_fun, strings_fun, opts) when is_binary(encoded) do
+    {decoded, rest} = decode_type(type, encoded, keys_fun, strings_fun, opts)
+    {:ok, decoded, rest}
+  catch
+    :throw, %DecodeError{} = e ->
+      {:error, e}
+  end
+
+  def decode_list_of(0, acc, _type, input, _keys_fun, _strings_fun, _opts),
+    do: {Enum.reverse(acc), input}
+
+  def decode_list_of(n, acc, type, input, keys_fun, strings_fun, opts) do
+    {decoded, rest} = decode_type(type, input, keys_fun, strings_fun, opts)
+    decode_list_of(n - 1, [decoded | acc], type, rest, keys_fun, strings_fun, opts)
+  end
+
+  def decode_type([type], input, keys_fun, strings_fun, opts) do
+    {num_entries, rest} = decode_leb128(input)
+    decode_list_of(num_entries, [], type, rest, keys_fun, strings_fun, opts)
+  end
+
+  def decode_type(:raw, input, _keys_fun, strings_fun, _opts) do
+    decode_raw(input, strings_fun)
+  end
+
+  def decode_type(:string, input, _keys_fun, strings_fun, _opts) do
+    decode_raw(input, strings_fun)
+  end
+
+  def decode_type(:atom, input, keys_fun, strings_fun, _opts) do
+    {raw, rest} = decode_raw(input, strings_fun)
+    {keys_fun.(raw), rest}
+  end
+
+  def decode_type(:i1, <<value::8, rest::binary>>, _, _, _), do: {value, rest}
+  def decode_type(:integer, input, _, _, _), do: decode_leb128(input)
+
+  def decode_type(:float, input, _keys_fun, _strings_fun, _opts) do
+    {bytes, rest} = decode_leb128(input)
+
+    case <<bytes::binary>> do
+      <<f::float>> ->
+        {f, rest}
+
+      _ ->
+        throw(DecodeError.new({:type_error, {:float, bytes}}))
+    end
+  end
+
+  def decode_type(:boolean, <<1::8, rest::binary>>, _, _, _), do: {true, rest}
+  def decode_type(:boolean, <<0::8, rest::binary>>, _, _, _), do: {false, rest}
+
+  def decode_type(:boolean, <<byte::8, _::binary>>, _, _, _) do
+    throw(DecodeError.new({:type_error, {nil, <<byte::8>>}}))
+  end
+
+  def decode_type(module, input, _keys_fun, _strings_fun, opts) when is_atom(module) do
+    with {:ok, decoded, rest} <- Decoder.decode(struct(module, []), input, opts) do
+      {decoded, rest}
+    else
+      {:error, err} ->
+        throw(err)
+    end
+  end
+
+  def decode_type(unknown, _input, _keys_fun, _strings_fun, _opts) do
+    throw(DecodeError.new({:invalid_type, unknown}))
+  end
+
+  def decode_raw(input, strings_fun) do
+    {len, rest} = decode_leb128(input)
+
+    case rest do
+      <<s::binary-size(len), rest::binary>> ->
+        {strings_fun.(s), rest}
+
+      s ->
+        throw(DecodeError.new({:unexpected_eof, len, byte_size(s)}))
+    end
+  end
+
+  def key_decoder(%{keys: :atoms}), do: &String.to_atom/1
+  def key_decoder(%{keys: :atoms!}), do: &String.to_existing_atom/1
+  def key_decoder(%{keys: :strings}), do: & &1
+  def key_decoder(%{keys: fun}) when is_function(fun, 1), do: fun
+  def key_decoder(%{}), do: & &1
+
+  def string_decoder(%{strings: :copy}), do: &:binary.copy/1
+  def string_decoder(%{strings: :reference}), do: & &1
+  def string_decoder(%{}), do: & &1
+end

--- a/implementations/elixir/lib/router/protocol/encoding/default/decoder.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/default/decoder.ex
@@ -1,0 +1,74 @@
+defprotocol Ockam.Router.Protocol.Encoding.Default.Decoder do
+  @fallback_to_any true
+
+  def decode(value, encoded, opts)
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Decoder, for: Any do
+  alias Ockam.Router.Protocol.Encoding.Default.{Codegen, Decoder, Decode}
+
+  defmacro __deriving__(module, struct, opts) do
+    schema = Keyword.fetch!(opts, :schema)
+    value = generated_var(:value, __MODULE__)
+    input = generated_var(:input, __MODULE__)
+    keys_fun = generated_var(:keys_fun, __MODULE__)
+    strings_fun = generated_var(:strings_fun, __MODULE__)
+    decode_opts = quote(do: opts)
+    decode_args = [input, keys_fun, strings_fun, decode_opts]
+
+    fieldless = 0 == struct |> Map.from_struct() |> map_size()
+    decoder = Codegen.build_decoder(module, value, input, schema, decode_args)
+
+    if fieldless do
+      quote location: :keep do
+        defimpl unquote(Decoder), for: unquote(module) do
+          def decode(unquote(value), unquote(input), opts) do
+            unquote(decoder)
+          end
+        end
+      end
+    else
+      quote location: :keep do
+        defimpl unquote(Decoder), for: unquote(module) do
+          def decode(unquote(value), unquote(input), opts) do
+            unquote(keys_fun) = unquote(Decode).key_decoder(opts)
+            unquote(strings_fun) = unquote(Decode).string_decoder(opts)
+            unquote(decoder)
+          end
+        end
+      end
+    end
+  end
+
+  # The same as Macro.var/2 except it sets generated: true
+  defp generated_var(name, context) do
+    {name, [generated: true], context}
+  end
+
+  def decode(%_{} = struct, _encoded, _opts) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: struct,
+      description: """
+      #{Decoder} protocol must always be explicitly implemented.
+
+      If you own the struct, you can derive the implementation specifying \
+      which fields should be encoded:
+
+          @derive {#{Decoder}, schema: [...]
+          defstruct ...
+
+      Finally, if you don't own the struct you want to encode, \
+      you may use Protocol.derive/3 placed outside of any module:
+
+          Protocol.derive(#{Decoder}, NameOfTheStruct, schema: [...])
+      """
+  end
+
+  def decode(value, _encoded, _opts) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: value,
+      description: "#{Decoder} protocol must always be explicitly implemented"
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoding/default/encode.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/default/encode.ex
@@ -1,0 +1,104 @@
+defmodule Ockam.Router.Protocol.Encoding.Default.Encode do
+  @moduledoc """
+  Encodes values using the `Default` encoder.
+  """
+
+  import Ockam.Router.Protocol.Encoding.Helpers
+
+  alias Ockam.Router.Protocol.EncodeError
+  alias Ockam.Router.Protocol.Encoding.Default
+  alias Ockam.Router.Protocol.Encoding.Default.Encoder
+
+  @opaque opts :: map()
+
+  @doc false
+  @spec encode(any, opts) :: {:ok, iodata} | {:error, EncodeError.t() | Exception.t()}
+  def encode(value, opts) do
+    try do
+      {:ok, encode_value(value, opts)}
+    catch
+      :throw, %EncodeError{} = e ->
+        {:error, e}
+
+      :error, %Protocol.UndefinedError{protocol: Default.Encoder} = e ->
+        {:error, e}
+    end
+  end
+
+  @doc false
+  @spec encode_value(any, opts) :: iodata | no_return
+  def encode_value(value, opts)
+
+  def encode_value(%{__struct__: _} = value, opts) do
+    with {:ok, encoded} <- Encoder.encode(value, opts) do
+      encoded
+    else
+      {:error, err} ->
+        throw(err)
+    end
+  end
+
+  def encode_value(value, opts) when is_map(value) do
+    map(value, opts)
+  end
+
+  def encode_value(value, opts) when is_list(value) do
+    list(value, opts)
+  end
+
+  def encode_value(value, opts) do
+    with {:ok, encoded} <- Encoder.encode(value, opts) do
+      encoded
+    else
+      {:error, err} ->
+        throw(err)
+    end
+  end
+
+  def atom(true, opts), do: boolean(true, opts)
+  def atom(false, opts), do: boolean(false, opts)
+  def atom(nil, _opts), do: <<>>
+  def atom(value, opts), do: string(Atom.to_string(value), opts)
+
+  def raw(s, _opts), do: [encode_size(s), s]
+  def string(s, _opts), do: [encode_size(s), s]
+  def iso8601_string(s, _opts), do: [encode_size(s), s]
+
+  def boolean(true, _opts), do: <<1::8>>
+  def boolean(false, _opts), do: <<0::8>>
+
+  def i1(value, opts), do: encode_i1(value, opts)
+
+  def integer(value, _opts) when is_integer(value) do
+    encode_leb128(value)
+  end
+
+  def float(value, _opts) when is_float(value) do
+    <<int::64>> = <<value::float>>
+    encode_leb128(int)
+  end
+
+  def list(value, opts) when is_list(value) do
+    [encode_size(value) | do_encode_list(value, opts)]
+  end
+
+  defp do_encode_list([], _opts), do: []
+
+  defp do_encode_list([h | t], opts) do
+    [encode_value(h, opts) | do_encode_list(t, opts)]
+  end
+
+  def map(value, opts) do
+    [encode_size(value) | do_encode_map(Map.to_list(value), opts)]
+  end
+
+  defp do_encode_map([], _opts), do: []
+
+  defp do_encode_map([{key, value} | t], opts) do
+    [encode_value(key, opts), encode_value(value, opts) | do_encode_map(t, opts)]
+  end
+
+  def encode_size(map) when is_map(map), do: encode_leb128_u2(map_size(map))
+  def encode_size(list) when is_list(list), do: encode_leb128_u2(length(list))
+  def encode_size(bin) when is_binary(bin), do: encode_leb128_u2(byte_size(bin))
+end

--- a/implementations/elixir/lib/router/protocol/encoding/default/encoder.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/default/encoder.ex
@@ -1,0 +1,138 @@
+defprotocol Ockam.Router.Protocol.Encoding.Default.Encoder do
+  @fallback_to_any true
+
+  def encode(value, opts)
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: Any do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+  alias Ockam.Router.Protocol.Encoding.Default.{Codegen, Encoder}
+
+  defmacro __deriving__(module, struct, opts) do
+    opts = Enum.into(opts, %{})
+    schema = Map.fetch!(opts, :schema)
+    keys = Enum.map(schema, fn {k, _} -> k end)
+    fields = fields_to_encode(struct, keys)
+    kv = Enum.map(fields, &{&1, generated_var(&1, __MODULE__)})
+    encode_opts = quote(do: opts)
+    encode_args = [encode_opts]
+
+    iodata = Codegen.build_constant_iodata(kv, schema, encode_args)
+
+    quote location: :keep do
+      defimpl unquote(Encoder), for: unquote(module) do
+        def encode(%{unquote_splicing(kv)}, unquote(encode_opts)) do
+          {:ok, unquote(iodata)}
+        end
+      end
+    end
+  end
+
+  # The same as Macro.var/2 except it sets generated: true
+  defp generated_var(name, context) do
+    {name, [generated: true], context}
+  end
+
+  defp fields_to_encode(%module{} = struct, keys) do
+    known_keys =
+      struct
+      |> Map.keys()
+      |> Enum.into(MapSet.new())
+
+    expected_keys = Enum.into(keys, MapSet.new())
+
+    unless MapSet.subset?(expected_keys, known_keys) do
+      diff = MapSet.difference(expected_keys, known_keys)
+      raise ArgumentError, message: "unknown fields for #{module}: #{inspect(diff)}"
+    end
+
+    keys
+  end
+
+  def encode(%_{} = struct, _opts) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: struct,
+      description: """
+      #{Encoder} protocol must always be explicitly implemented.
+
+      If you own the struct, you can derive the implementation specifying \
+      which fields should be encoded:
+
+          @derive #{Encoder}, schema: [...]
+          defstruct ...
+
+      Finally, if you don't own the struct you want to encode, \
+      you may use Protocol.derive/3 placed outside of any module:
+
+          Protocol.derive(#{Encoder}, NameOfTheStruct, schema: [...])
+      """
+  end
+
+  def encode(value, _opts) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: value,
+      description: "#{Encoder} protocol must always be explicitly implemented"
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: Atom do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(atom, opts) do
+    {:ok, Encode.atom(atom, opts)}
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: Integer do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(integer, opts) do
+    {:ok, Encode.integer(integer, opts)}
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: Float do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(float, opts) do
+    {:ok, Encode.float(float, opts)}
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: List do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(list, opts) do
+    {:ok, Encode.list(list, opts)}
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: Map do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(map, opts) do
+    {:ok, Encode.map(map, opts)}
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: BitString do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(binary, opts) when is_binary(binary) do
+    {:ok, Encode.string(binary, opts)}
+  end
+
+  def encode(bitstring, opts) do
+    {:ok, Encode.raw(bitstring, opts)}
+  end
+end
+
+defimpl Ockam.Router.Protocol.Encoding.Default.Encoder, for: [NaiveDateTime, DateTime] do
+  alias Ockam.Router.Protocol.Encoding.Default.Encode
+
+  def encode(value, opts) do
+    {:ok, Encode.iso8601_string(@for.to_iso8601(value), opts)}
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoding/helpers.ex
+++ b/implementations/elixir/lib/router/protocol/encoding/helpers.ex
@@ -1,0 +1,109 @@
+defmodule Ockam.Router.Protocol.Encoding.Helpers do
+  import Bitwise
+
+  alias Ockam.Router.Protocol.EncodeError
+  alias Ockam.Router.Protocol.DecodeError
+
+  @doc """
+  Encodes a signed/unsigned integer using a one-byte encoding
+
+  If the value requires more than one byte to be encoded, this
+  function will throw `EncodeError`
+  """
+  def encode_i1(v, _opts) when is_integer(v) and v > -128 and v <= 255 do
+    <<v::8>>
+  end
+
+  def encode_i1(v, _opts), do: throw(EncodeError.new({:invalid_i1, v}))
+
+  @doc """
+  Encodes an unsigned integer using a variable length encoding (LEB-128)
+  which is constrained to a maximum of two bytes.
+
+  If the value requires more than two bytes to be encoded, this function
+  will throw `EncodeError`
+  """
+  @spec encode_leb128_u2(non_neg_integer()) :: binary | no_return
+  def encode_leb128_u2(v)
+
+  def encode_leb128_u2(v) when is_integer(v) and v <= 16384,
+    do: do_encode_leb128(v)
+
+  def encode_leb128_u2(v) do
+    throw(EncodeError.new({:invalid_leb128, v}))
+  end
+
+  @doc """
+  Encodes an unsigned integer using a variable length encoding (LEB-128)
+
+  This function will throw `EncodeError` if given a non-integer value
+  """
+  @spec encode_leb128(non_neg_integer()) :: binary
+  def encode_leb128(v)
+
+  def encode_leb128(v) when is_integer(v),
+    do: do_encode_leb128(v)
+
+  def encode_leb128(v),
+    do: throw(EncodeError.new({:invalid_leb128, v}))
+
+  defp do_encode_leb128(v) when is_integer(v) and v < 128, do: <<0::1, v::7>>
+
+  defp do_encode_leb128(v) when is_integer(v),
+    do: <<1::1, v::7, do_encode_leb128(v >>> 7)::binary>>
+
+  @doc """
+  Decodes an unsigned integer using a variable length encoding (LEB-128)
+  which is constrained to a maximum of two bytes
+
+  If the decoded value would exceed two bytes, this function
+  will throw `DecodeError`
+  """
+  @spec decode_leb128_u2(binary) :: non_neg_integer() | no_return
+  def decode_leb128_u2(bin)
+
+  def decode_leb128_u2(<<0::1, byte::7, rest::binary>>) do
+    {byte, rest}
+  end
+
+  def decode_leb128_u2(<<1::1, lo::7, 0::1, hi::7, rest::binary>>) do
+    {lo ||| hi <<< 7, rest}
+  end
+
+  def decode_leb128_u2(input) do
+    throw(DecodeError.new({:invalid_leb128_u2, input}))
+  end
+
+  @doc """
+  Decodes an unsigned integer using a variable length encoding (LEB-128)
+
+  This function will throw `EncodeError` if given a non-binary value
+  """
+  @spec decode_leb128(binary) :: non_neg_integer()
+  def decode_leb128(bin) do
+    do_decode_leb128(bin)
+  catch
+    :throw, :invalid_leb128 ->
+      throw(DecodeError.new({:invalid_leb128, bin}))
+  end
+
+  defp do_decode_leb128(v, shift \\ 0, result \\ 0)
+
+  defp do_decode_leb128(<<0::1, byte::7, rest::binary>>, 0, 0) do
+    {byte, rest}
+  end
+
+  defp do_decode_leb128(<<0::1, byte::7, rest::binary>>, shift, result) do
+    {result ||| byte <<< shift, rest}
+  end
+
+  defp do_decode_leb128(<<1::1, byte::7, rest::binary>>, shift, result) do
+    do_decode_leb128(
+      rest,
+      shift + 7,
+      result ||| byte <<< shift
+    )
+  end
+
+  defp do_decode_leb128(_v, _shift, _result), do: throw(:invalid_leb128)
+end

--- a/implementations/elixir/lib/router/protocol/endpoint.ex
+++ b/implementations/elixir/lib/router/protocol/endpoint.ex
@@ -1,0 +1,313 @@
+defmodule Ockam.Router.Protocol.Endpoint do
+  alias Ockam.Transport.Address
+
+  defstruct [:value]
+
+  defmodule Local do
+    defstruct [:data]
+
+    def type_id(%__MODULE__{}), do: 0
+
+    defimpl Ockam.Router.Protocol.Encoder do
+      def encode(value, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Router.Protocol.Encoding.Default.Encode
+      alias Ockam.Router.Protocol.Encoding.Default.Encoder
+      alias Ockam.Router.Protocol.Endpoint.Local
+
+      def encode(%Local{data: data} = value, opts) do
+        type = Encode.i1(Local.type_id(value), opts)
+        len = Helpers.encode_leb128_u2(byte_size(data))
+        {:ok, [type, len, data]}
+      end
+    end
+
+    defimpl Ockam.Router.Protocol.Decoder do
+      def decode(value, input, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Router.Protocol.Endpoint.Local
+
+      def decode(value, input, _opts) do
+        {len, rest} = Helpers.decode_leb128_u2(input)
+
+        if len > 0 do
+          <<data::binary-size(len), rest::binary>> = rest
+          {:ok, %Local{value | data: data}, rest}
+        else
+          {:ok, value, rest}
+        end
+      end
+    end
+  end
+
+  defmodule Channel do
+    defstruct [:public_key, :endpoint]
+
+    def type_id(%__MODULE__{}), do: 1
+
+    defimpl Ockam.Router.Protocol.Encoder do
+      def encode(value, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+      alias Ockam.Router.Protocol.Encoding.Default.Encode
+      alias Ockam.Router.Protocol.Encoding.Default.Encoder
+      alias Ockam.Router.Protocol.Endpoint.Channel
+
+      def encode(%Channel{public_key: pk, endpoint: endpoint} = value, opts) do
+        with {:ok, endpoint_encoded} <- Encoder.encode(endpoint, opts) do
+          type = Encode.i1(Channel.type_id(value), opts)
+          {:ok, pk_encoded} = encode_public_key(pk)
+          {:ok, [type, pk_encoded, endpoint_encoded]}
+        end
+      end
+
+      defp encode_public_key({:x25519, <<pk::binary-size(32)>>}),
+        do: <<1::8, pk::binary>>
+
+      defp encode_public_key({:p256_compressed_y0, <<pk::binary-size(32)>>}),
+        do: <<2::8, pk::binary>>
+
+      defp encode_public_key({:p256_compressed_y1, <<pk::binary-size(32)>>}),
+        do: <<3::8, pk::binary>>
+
+      defp encode_public_key({
+             :p256_uncompressed,
+             <<x::binary-size(32)>>,
+             <<y::binary-size(32)>>
+           }) do
+        <<4::8, x::binary, y::binary>>
+      end
+    end
+
+    defimpl Ockam.Router.Protocol.Decoder do
+      def decode(value, input, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+      alias Ockam.Router.Protocol.DecodeError
+      alias Ockam.Router.Protocol.Encoding.Default.Decoder
+      alias Ockam.Router.Protocol.Endpoint
+      alias Ockam.Router.Protocol.Endpoint.Channel
+
+      def decode(value, input, opts) do
+        with {:ok, pk, rest} <- decode_public_key(input, opts),
+             {:ok, endpoint, rest} <- Decoder.decode(%Endpoint{}, rest, opts) do
+          {:ok, %Channel{value | public_key: pk, endpoint: endpoint}, rest}
+        end
+      end
+
+      defp decode_public_key(<<type::8, rest::binary>>, opts),
+        do: decode_public_key(type, rest, opts)
+
+      defp decode_public_key(1, <<pk::size(32)-unit(8), rest::binary>>, _opts),
+        do: {:ok, {:x25519, pk}, rest}
+
+      defp decode_public_key(2, <<pk::size(32)-unit(8), rest::binary>>, _opts),
+        do: {:ok, {:p256_compressed_y0, pk}, rest}
+
+      defp decode_public_key(3, <<pk::size(32)-unit(8), rest::binary>>, _opts),
+        do: {:ok, {:p256_compressed_y1, pk}, rest}
+
+      defp decode_public_key(
+             4,
+             <<x::size(32)-unit(8), y::size(32)-unit(8), rest::binary>>,
+             _opts
+           ),
+           do: {:ok, {:p256_uncompressed, x, y}, rest}
+
+      defp decode_public_key(type, input, _opts) do
+        {:error,
+         DecodeError.new(
+           "invalid public key (type = #{inspect(type)}, input = #{inspect(input)})"
+         )}
+      end
+    end
+  end
+
+  defmodule IPv4 do
+    defstruct [:protocol, :address]
+
+    def type_id(%__MODULE__{protocol: :tcp}), do: 2
+    def type_id(%__MODULE__{protocol: :udp}), do: 4
+
+    defimpl Ockam.Router.Protocol.Encoder do
+      def encode(value, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+      alias Ockam.Router.Protocol.Encoding.Default.Encode
+      alias Ockam.Router.Protocol.Endpoint.IPv4
+      alias Ockam.Transport.Address
+
+      def encode(%IPv4{address: address} = value, opts) do
+        type = Encode.i1(IPv4.type_id(value), opts)
+        addr = encode_address(address, opts)
+        port = Encode.integer(Address.port(address), opts)
+        {:ok, [type, addr, port]}
+      end
+
+      defp encode_address(address, _opts) do
+        {a, b, c, d} = Address.ip(address)
+        <<a::8, b::8, c::8, d::8>>
+      end
+    end
+
+    defimpl Ockam.Router.Protocol.Decoder do
+      def decode(value, input, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Router.Protocol.Endpoint.IPv4
+      alias Ockam.Transport.Address
+
+      def decode(value, <<addr::binary-size(4), rest::binary>>, %{protocol: protocol}) do
+        {port, rest} = Helpers.decode_leb128_u2(rest)
+        address = decode_address(addr, port)
+        {:ok, %IPv4{value | protocol: protocol, address: address}, rest}
+      end
+
+      defp decode_address(<<a::8, b::8, c::8, d::8>>, port) do
+        case {a, b, c, d} do
+          {127, 0, 0, 1} ->
+            %Address{family: :inet, addr: :loopback, port: port}
+
+          {0, 0, 0, 0} ->
+            %Address{family: :inet, addr: :any, port: port}
+
+          addr ->
+            %Address{family: :inet, addr: addr, port: port}
+        end
+      end
+    end
+  end
+
+  defmodule IPv6 do
+    defstruct [:protocol, :address]
+
+    def type_id(%__MODULE__{protocol: :tcp}), do: 3
+    def type_id(%__MODULE__{protocol: :udp}), do: 5
+
+    defimpl Ockam.Router.Protocol.Encoder do
+      def encode(value, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+      alias Ockam.Router.Protocol.Encoding.Default.Encode
+      alias Ockam.Router.Protocol.Endpoint.IPv6
+      alias Ockam.Transport.Address
+
+      def encode(%IPv6{address: address} = value, opts) do
+        type = Encode.i1(IPv6.type_id(value), opts)
+        addr = encode_address(address, opts)
+        port = Encode.integer(Address.port(address), opts)
+        {:ok, [type, addr, port]}
+      end
+
+      defp encode_address(address, _opts) do
+        {a, b, c, d, e, f, g, h} = Address.ip(address)
+
+        <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+      end
+    end
+
+    defimpl Ockam.Router.Protocol.Decoder do
+      def decode(value, input, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Router.Protocol.Endpoint.IPv6
+      alias Ockam.Transport.Address
+
+      def decode(value, <<addr::binary-size(16), rest::binary>>, %{protocol: protocol}) do
+        {port, rest} = Helpers.decode_leb128_u2(rest)
+        address = decode_address(addr, port)
+        {:ok, %IPv6{value | protocol: protocol, address: address}, rest}
+      end
+
+      defp decode_address(<<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>, port) do
+        %Address{family: :inet, addr: {a, b, c, d, e, f, g, h}, port: port}
+      end
+    end
+  end
+
+  def new(endpoint) do
+    %__MODULE__{value: endpoint}
+  end
+
+  def new_ipv4(:tcp, %Address{} = address) do
+    %__MODULE__{value: %IPv4{protocol: :tcp, address: address}}
+  end
+
+  def new_ipv4(:udp, %Address{} = address) do
+    %__MODULE__{value: %IPv4{protocol: :udp, address: address}}
+  end
+
+  def new_ipv6(:tcp, %Address{} = address) do
+    %__MODULE__{value: %IPv6{protocol: :tcp, address: address}}
+  end
+
+  def new_ipv6(:udp, %Address{} = address) do
+    %__MODULE__{value: %IPv6{protocol: :udp, address: address}}
+  end
+
+  def value(%__MODULE__{value: value}), do: value
+
+  defimpl Ockam.Router.Protocol.Encoder do
+    def encode(value, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+    alias Ockam.Router.Protocol.Endpoint
+
+    def encode(%Endpoint{value: value}, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Decoder do
+    def decode(value, input, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+    alias Ockam.Router.Protocol.DecodeError
+    alias Ockam.Router.Protocol.Encoding.Default.Decoder
+    alias Ockam.Router.Protocol.Endpoint
+
+    def decode(value, <<type::8, input::binary>>, opts) do
+      with {:ok, endpoint_mod, opts} <- endpoint_type(type, opts),
+           {:ok, endpoint, rest} <- decode_endpoint(endpoint_mod, input, opts) do
+        {:ok, %Endpoint{value | value: endpoint}, rest}
+      end
+    end
+
+    defp decode_endpoint(mod, input, opts) do
+      Decoder.decode(struct(mod, []), input, opts)
+    end
+
+    defp endpoint_type(0, opts), do: {:ok, Endpoint.Local, opts}
+    defp endpoint_type(1, opts), do: {:ok, Endpoint.Channel, opts}
+    defp endpoint_type(2, opts), do: {:ok, Endpoint.IPv4, Map.put(opts, :protocol, :tcp)}
+    defp endpoint_type(3, opts), do: {:ok, Endpoint.IPv6, Map.put(opts, :protocol, :tcp)}
+    defp endpoint_type(4, opts), do: {:ok, Endpoint.IPv4, Map.put(opts, :protocol, :udp)}
+    defp endpoint_type(5, opts), do: {:ok, Endpoint.IPv6, Map.put(opts, :protocol, :udp)}
+    defp endpoint_type(n, _opts), do: {:error, DecodeError.new({:invalid_endpoint_type, n})}
+  end
+end

--- a/implementations/elixir/lib/router/protocol/errors.ex
+++ b/implementations/elixir/lib/router/protocol/errors.ex
@@ -1,0 +1,70 @@
+defmodule Ockam.Router.Protocol.EncodeError do
+  defexception [:message]
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  def new({:invalid_leb128, v}) do
+    %__MODULE__{message: "value cannot be encoded as an LEB128 integer: `#{inspect(v)}`"}
+  end
+end
+
+defmodule Ockam.Router.Protocol.DecodeError do
+  defexception [:message]
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  def new({reason, bytes}) when reason in [:invalid_leb128, :invalid_leb128_u2] do
+    %__MODULE__{
+      message: "expected an LEB128-encoded integer, but got: #{inspect(bytes, base: :hex)}"
+    }
+  end
+
+  def new({:invalid_i1, bytes}) do
+    %__MODULE__{
+      message: "expected an i1-encoded integer, but got: #{inspect(bytes, base: :hex)}"
+    }
+  end
+
+  def new({:unexpected_eof, expected, got}) do
+    %__MODULE__{
+      message: "unexpected EOF: expected to decode #{expected} bytes, but only found #{got}"
+    }
+  end
+
+  def new({:invalid_message_type, type}) do
+    %__MODULE__{
+      message: "unrecognized message type code #{inspect(type, base: :hex)}"
+    }
+  end
+
+  def new({:invalid_message_body, type, body}) do
+    %__MODULE__{
+      message: "unrecognized message content for type #{inspect(type)}: #{inspect(body)}"
+    }
+  end
+
+  def new({:type_error, {type, raw}}) do
+    %__MODULE__{
+      message: "unable to decode value of type #{type}, got: #{inspect(raw, base: :hex)}"
+    }
+  end
+
+  def new({:type_error, {type, raw, reason}}) do
+    %__MODULE__{
+      message:
+        "unable to decode value of type #{type} (#{inspect(reason)}), got: #{
+          inspect(raw, base: :hex)
+        }"
+    }
+  end
+
+  def new({:invalid_type, type}) do
+    %__MODULE__{
+      message: "unrecognized type code #{inspect(type, base: :hex)}"
+    }
+  end
+
+  def new(message) when is_binary(message) do
+    %__MODULE__{message: message}
+  end
+end

--- a/implementations/elixir/lib/router/protocol/message.ex
+++ b/implementations/elixir/lib/router/protocol/message.ex
@@ -1,0 +1,138 @@
+defmodule Ockam.Router.Protocol.Message do
+  alias Ockam.Router.Protocol.Decoder
+  alias Ockam.Router.Protocol.DecodeError
+  alias Ockam.Router.Protocol.MessageType
+
+  @type t :: %{__struct__: module | map()}
+  @type version :: non_neg_integer()
+  @type opts :: map()
+
+  @callback type_id() :: non_neg_integer()
+  @callback version() :: non_neg_integer()
+  @callback decode(version, term, opts) :: {:ok, t} | {:error, DecodeError.t() | Exception.t()}
+  @callback handle_version_change(version, term, opts) ::
+              {:ok, t} | {:error, DecodeError.t() | Exception.t()}
+
+  defmodule UnknownVersionError do
+    defexception [:type, :version, :description]
+
+    def message(%__MODULE__{description: description}), do: description
+  end
+
+  defmacro __using__(opts \\ []) do
+    caller = __CALLER__.module
+    schema = Keyword.get(opts, :schema, [])
+    version = Keyword.get(opts, :version, 1)
+    typeid = Keyword.fetch!(opts, :type_id)
+
+    keys =
+      Enum.map(schema, fn
+        {key, {_type, default}} ->
+          {key, default}
+
+        {key, [_type]} ->
+          {key, []}
+
+        {key, _type} ->
+          {key, nil}
+      end)
+
+    derivation =
+      case Keyword.get(opts, :derive, true) do
+        opt when opt in [true, :all] ->
+          quote do
+            @derive {Ockam.Router.Protocol.Encoder, schema: unquote(schema)}
+            @derive {Ockam.Router.Protocol.Decoder, schema: unquote(schema)}
+          end
+
+        :encoder ->
+          quote do
+            @derive {Ockam.Router.Protocol.Encoder, schema: unquote(schema)}
+          end
+
+        :decoder ->
+          quote do
+            @derive {Ockam.Router.Protocol.Decoder, schema: unquote(schema)}
+          end
+
+        _ ->
+          quote(do: nil)
+      end
+
+    quote location: :keep do
+      @behaviour unquote(__MODULE__)
+
+      @version unquote(version)
+
+      unquote(derivation)
+      defstruct unquote(keys)
+
+      alias Ockam.Router.Protocol.DecodeError
+
+      @impl unquote(__MODULE__)
+      def type_id, do: unquote(typeid)
+
+      @impl unquote(__MODULE__)
+      def version, do: unquote(version)
+
+      @impl unquote(__MODULE__)
+      def decode(version, input, opts)
+
+      def decode(@version, input, opts) when is_binary(input) do
+        unquote(Decoder).decode(%__MODULE__{}, input, opts)
+      end
+
+      def decode(@version, input, _opts) do
+        {:error, DecodeError.new({:invalid_message_body, __MODULE__, input})}
+      end
+
+      def decode(version, input, opts) when is_binary(input) do
+        handle_version_change(version, input, opts)
+      end
+
+      @impl unquote(__MODULE__)
+      def handle_version_change(version, _input, _opts) do
+        raise unquote(UnknownVersionError),
+          type: __MODULE__,
+          version: version,
+          description: """
+          A message of known type was received, but with a different version than
+          the currently supported version (#{@version}).
+
+          To handle version changes for message types which are backwards or fowards
+          compatible, you must implement the `handle_version_change/3` callback. By
+          default, this error is raised.
+          """
+      end
+
+      defoverridable decode: 3, handle_version_change: 3
+
+      defimpl unquote(MessageType) do
+        def type_id(_), do: unquote(caller).type_id()
+        def version(_), do: unquote(caller).version()
+      end
+    end
+  end
+
+  @doc false
+  @spec lookup(non_neg_integer()) ::
+          {:ok, module()} | {:error, {:unknown_type_id, non_neg_integer()}}
+  def lookup(id) when is_integer(id) do
+    search_paths = [:code.lib_dir(:ockam, :ebin)]
+    impls = Protocol.extract_impls(MessageType, search_paths)
+
+    lookup(impls, id)
+  end
+
+  defp lookup([], id), do: {:error, {:unknown_type_id, id}}
+
+  defp lookup([mod | rest], id) do
+    case mod.type_id() do
+      ^id ->
+        {:ok, mod}
+
+      _ ->
+        lookup(rest, id)
+    end
+  end
+end

--- a/implementations/elixir/lib/router/protocol/message/connect.ex
+++ b/implementations/elixir/lib/router/protocol/message/connect.ex
@@ -1,0 +1,12 @@
+defmodule Ockam.Router.Protocol.Message.Connect do
+  use Ockam.Router.Protocol.Message,
+    type_id: 4,
+    schema: [options: [Ockam.Router.Protocol.Message.Connect.Option]]
+
+  defmodule Option do
+    @schema [name: :string, value: :string]
+    @derive {Ockam.Router.Protocol.Encoder, schema: @schema}
+    @derive {Ockam.Router.Protocol.Decoder, schema: @schema}
+    defstruct [:name, :value]
+  end
+end

--- a/implementations/elixir/lib/router/protocol/message/envelope.ex
+++ b/implementations/elixir/lib/router/protocol/message/envelope.ex
@@ -1,0 +1,64 @@
+defmodule Ockam.Router.Protocol.Message.Envelope do
+  defstruct headers: %{}, body: nil
+
+  defimpl Ockam.Router.Protocol.Encoder do
+    def encode(value, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.encode(value, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+    alias Ockam.Router.Protocol.Encoding.Default
+
+    def encode(value, opts) do
+      Default.encode(value, opts)
+    end
+  end
+
+  defimpl Ockam.Router.Protocol.Decoder do
+    def decode(value, input, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+    alias Ockam.Router.Protocol.DecodeError
+    alias Ockam.Router.Protocol.Encoding.Default.Decoder
+    alias Ockam.Router.Protocol.Encoding.Helpers
+    alias Ockam.Router.Protocol.Endpoint
+    alias Ockam.Router.Protocol.Message
+    alias Ockam.Router.Protocol.Message.Envelope
+
+    def decode(value, input, opts) do
+      {headers_len, rest} = Helpers.decode_leb128_u2(input)
+
+      with {:ok, headers, rest} <- decode_headers(headers_len, rest, opts),
+           {:ok, type, rest} <- decode_message_type(rest),
+           {:ok, body, rest} <- Decoder.decode(struct(type, []), rest, opts) do
+        {:ok, %Envelope{value | headers: headers, body: body}, rest}
+      end
+    end
+
+    defp decode_headers(n, input, opts), do: decode_headers(n, input, opts, %{})
+
+    defp decode_headers(0, input, _opts, acc), do: {:ok, acc, input}
+
+    defp decode_headers(n, <<type::8, rest::binary>>, opts, acc) do
+      case type do
+        type when type in [0, 1] ->
+          key = if type == 0, do: :send_to, else: :reply_to
+
+          with {:ok, endpoint, rest} <- Decoder.decode(%Endpoint{}, rest, opts) do
+            decode_headers(n - 1, rest, opts, Map.put(acc, key, endpoint))
+          end
+
+        unknown ->
+          {:error, DecodeError.new("unknown header type (#{inspect(unknown)})")}
+      end
+    end
+
+    defp decode_message_type(<<ty::8, input::binary>>) do
+      with {:ok, type} = Message.lookup(ty) do
+        {:ok, type, input}
+      end
+    end
+  end
+end

--- a/implementations/elixir/lib/router/protocol/message/payload.ex
+++ b/implementations/elixir/lib/router/protocol/message/payload.ex
@@ -1,0 +1,54 @@
+defmodule Ockam.Router.Protocol.Message.Payload do
+  use Ockam.Router.Protocol.Message,
+    type_id: 2,
+    schema: [data: :raw]
+end
+
+defmodule Ockam.Router.Protocol.Message.EncryptedPayload do
+  use Ockam.Router.Protocol.Message,
+    type_id: 3,
+    derive: false,
+    schema: [data: :raw, tag: :raw]
+
+  defimpl Ockam.Router.Protocol.Encoder do
+    def encode(value, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+    alias Ockam.Router.Protocol.Encoding.Helpers
+    alias Ockam.Router.Protocol.Message.EncryptedPayload
+
+    def encode(%EncryptedPayload{data: data, tag: tag}, _opts) do
+      len = byte_size(data) + byte_size(tag)
+      encoded_len = Helpers.encode_leb128_u2(len)
+      {:ok, [encoded_len, data, tag]}
+    end
+  end
+
+  defimpl Ockam.Router.Protocol.Decoder do
+    def decode(value, input, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+    alias Ockam.Router.Protocol.DecodeError
+    alias Ockam.Router.Protocol.Encoding.Helpers
+    alias Ockam.Router.Protocol.Message.EncryptedPayload
+
+    def decode(value, input, _opts) do
+      {size, rest} = Helpers.decode_leb128_u2(input)
+      data_length = size - 16
+
+      if data_length > 0 do
+        <<data::binary-size(data_length), tag::binary-size(16), rest::binary>> = rest
+        {:ok, %EncryptedPayload{value | data: data, tag: tag}, rest}
+      else
+        {:error,
+         DecodeError.new(
+           "invalid payload length, expected at least 48 bytes, but got #{byte_size(input)}"
+         )}
+      end
+    end
+  end
+end

--- a/implementations/elixir/lib/router/protocol/message/ping.ex
+++ b/implementations/elixir/lib/router/protocol/message/ping.ex
@@ -1,0 +1,4 @@
+defmodule Ockam.Router.Protocol.Message.Ping do
+  use Ockam.Router.Protocol.Message,
+    type_id: 0
+end

--- a/implementations/elixir/lib/router/protocol/message/pong.ex
+++ b/implementations/elixir/lib/router/protocol/message/pong.ex
@@ -1,0 +1,4 @@
+defmodule Ockam.Router.Protocol.Message.Pong do
+  use Ockam.Router.Protocol.Message,
+    type_id: 1
+end

--- a/implementations/elixir/lib/router/protocol/message_type.ex
+++ b/implementations/elixir/lib/router/protocol/message_type.ex
@@ -1,0 +1,9 @@
+defprotocol Ockam.Router.Protocol.MessageType do
+  @type t :: any()
+
+  @spec type_id(t) :: non_neg_integer()
+  def type_id(value)
+
+  @spec version(t) :: non_neg_integer()
+  def version(value)
+end

--- a/implementations/elixir/lib/transport/socket.ex
+++ b/implementations/elixir/lib/transport/socket.ex
@@ -36,11 +36,11 @@ defmodule Ockam.Transport.Socket do
     new(role, address)
   end
 
-  def handle_message(%__MODULE__{} = state, {:socket, socket, :select, _info}) do
+  def handle_message(%__MODULE__{} = state, {:"$socket", socket, :select, _info}) do
     {:ok, :recv, %__MODULE__{state | socket: socket}}
   end
 
-  def handle_message(%__MODULE__{} = state, {:socket, socket, :abort, {_info, reason}}) do
+  def handle_message(%__MODULE__{} = state, {:"$socket", socket, :abort, {_info, reason}}) do
     {:error, {:abort, reason}, %__MODULE__{state | socket: socket}}
   end
 
@@ -67,7 +67,7 @@ defmodule Ockam.Transport.Socket do
   end
 
   defp do_recv(%__MODULE__{} = state, flags, timeout) do
-    with {:wait, {:recv, select_ref}, new_state} <- recv_nonblocking(state, flags) do
+    with {:wait, {:recv, select_ref}, state} <- recv_nonblocking(state, flags) do
       receive do
         {:"$socket", socket, :select, ^select_ref} ->
           do_recv(%__MODULE__{state | socket: socket}, flags, timeout)

--- a/implementations/elixir/test/router/encoding_test.exs
+++ b/implementations/elixir/test/router/encoding_test.exs
@@ -1,0 +1,70 @@
+defmodule Ockam.Router.Protocol.Encoding.Test do
+  use ExUnit.Case, async: true
+  require Logger
+
+  alias Ockam.Router.Protocol.Message
+  alias Ockam.Router.Protocol.Message.Envelope
+  alias Ockam.Router.Protocol.Encoding
+  alias Ockam.Router.Protocol.Endpoint
+  alias Ockam.Transport.Address
+
+  test "ping" do
+    ping = %Message.Ping{}
+    opts = %{}
+
+    assert {:ok, encoded} = Encoding.encode(ping, opts)
+    assert {:ok, %Envelope{body: ^ping}, <<>>} = Encoding.decode(encoded, opts)
+  end
+
+  test "pong" do
+    pong = %Message.Pong{}
+    opts = %{}
+
+    assert {:ok, encoded} = Encoding.encode(pong, opts)
+    assert {:ok, %Envelope{body: ^pong}, <<>>} = Encoding.decode(encoded, opts)
+  end
+
+  test "payloads" do
+    payload = %Message.Payload{data: "hello"}
+    opts = %{}
+
+    assert {:ok, encoded} = Encoding.encode(payload, opts)
+    assert {:ok, %Envelope{body: ^payload}, <<>>} = Encoding.decode(encoded, opts)
+
+    tag = String.duplicate("t", 16)
+    encrypted_payload = %Message.EncryptedPayload{data: "hello", tag: tag}
+
+    assert {:ok, encoded} = Encoding.encode(encrypted_payload, opts)
+    assert {:ok, %Envelope{body: ^encrypted_payload}, <<>>} = Encoding.decode(encoded, opts)
+  end
+
+  test "connect" do
+    connect = %Message.Connect{
+      options: [
+        %Message.Connect.Option{name: "foo", value: "bar"},
+        %Message.Connect.Option{name: "baz", value: "qux"}
+      ]
+    }
+
+    opts = %{}
+
+    assert {:ok, encoded} = Encoding.encode(connect, opts)
+    assert {:ok, %Envelope{body: ^connect}, <<>>} = Encoding.decode(encoded, opts)
+  end
+
+  test "payload with headers" do
+    headers = %{
+      send_to: Endpoint.new_ipv4(:tcp, Address.new!(:inet, :any, 8080)),
+      reply_to: Endpoint.new_ipv6(:tcp, Address.new!(:inet, "::1", 8081))
+    }
+
+    payload = %Message.Payload{data: "hello"}
+    message = %Envelope{headers: headers, body: payload}
+    opts = %{}
+
+    assert {:ok, encoded} = Encoding.encode(message, opts)
+
+    assert {:ok, %Envelope{headers: ^headers, body: ^payload}, <<>>} =
+             Encoding.decode(encoded, opts)
+  end
+end


### PR DESCRIPTION
- Define reusable encoding/decoding infrastructure
- Define messages that exist in proposed schema
- Define a message that contains nested types for testing
- Convert handshake implementation to use wire protocol

NOTE: This is not ready to be merged until upstream implementation in C
is ready, then the integration tests can be updated