### PR TITLE
docs: fix the link to the vault proposal, clarify its draft state

### DIFF
--- a/documentation/concepts/vaults.md
+++ b/documentation/concepts/vaults.md
@@ -25,4 +25,4 @@ message authentication, digital signatures, Diffie-Hellman key exchange,
 authenticated encryption etc.
 
 The precise design of the `Vault` interface is being discussed as part of
-Ockam Proposal [OP-0004](https://git.io/JvOka).
+a draft Ockam Proposal [OP-000N](https://git.io/JfcYQ).


### PR DESCRIPTION

### Proposed Changes
Documentation change to fix the broken link on the Vault concept page that references the Vault proposal. 

I could only find the Vault proposal as a WIP on a branch and PR. Maybe the link should go to the Vault guide instead.


