### PR TITLE
modify memory interface from uint8_t to void

### DIFF
--- a/implementations/c/include/ockam/memory.h
+++ b/implementations/c/include/ockam/memory.h
@@ -44,7 +44,7 @@ ockam_error_t ockam_memory_deinit(ockam_memory_t* memory);
  * @return  MEMORY_ERROR_INVALID_SIZE if buffer_size <=0.
  * @return  MEMORY_ERROR_ALLOC_FAIL if unable to allocate the desired buffer.
  */
-ockam_error_t ockam_memory_alloc_zeroed(ockam_memory_t* memory, uint8_t** buffer, size_t buffer_size);
+ockam_error_t ockam_memory_alloc_zeroed(ockam_memory_t* memory, void** buffer, size_t buffer_size);
 
 /**
  * @brief   Free the specified buffer.
@@ -55,7 +55,7 @@ ockam_error_t ockam_memory_alloc_zeroed(ockam_memory_t* memory, uint8_t** buffer
  * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory or buffer received.
  * @return  MEMORY_ERROR_INVALID_SIZE if buffer_size <=0.
  */
-ockam_error_t ockam_memory_free(ockam_memory_t* memory, uint8_t* buffer, size_t buffer_size);
+ockam_error_t ockam_memory_free(ockam_memory_t* memory, void* buffer, size_t buffer_size);
 
 /**
  * @brief   Set a set_size number of bytes to the buffer with value.
@@ -67,7 +67,7 @@ ockam_error_t ockam_memory_free(ockam_memory_t* memory, uint8_t* buffer, size_t 
  * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory or buffer received.
  * @return  MEMORY_ERROR_INVALID_SIZE if set_size <=0.
  */
-ockam_error_t ockam_memory_set(ockam_memory_t* memory, uint8_t* buffer, uint8_t value, size_t set_size);
+ockam_error_t ockam_memory_set(ockam_memory_t* memory, void* buffer, uint8_t value, size_t set_size);
 
 /**
  * @brief   Copy data from the source buffer to the destination buffer.
@@ -79,7 +79,7 @@ ockam_error_t ockam_memory_set(ockam_memory_t* memory, uint8_t* buffer, uint8_t 
  * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory, destination or source received.
  * @return  MEMORY_ERROR_INVALID_SIZE if copy_size <=0.
  */
-ockam_error_t ockam_memory_copy(ockam_memory_t* memory, uint8_t* destination, const uint8_t* source, size_t copy_size);
+ockam_error_t ockam_memory_copy(ockam_memory_t* memory, void* destination, const void* source, size_t copy_size);
 
 /**
  * @brief   Move move_size bytes from source to destination.
@@ -91,7 +91,7 @@ ockam_error_t ockam_memory_copy(ockam_memory_t* memory, uint8_t* destination, co
  * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory, destination or source received.
  * @return  MEMORY_ERROR_INVALID_SIZE if move_size <=0.
  */
-ockam_error_t ockam_memory_move(ockam_memory_t* memory, uint8_t* destination, uint8_t* source, size_t move_size);
+ockam_error_t ockam_memory_move(ockam_memory_t* memory, void* destination, void* source, size_t move_size);
 
 /**
  * @}

--- a/implementations/c/lib/memory/impl.h
+++ b/implementations/c/lib/memory/impl.h
@@ -28,7 +28,7 @@ typedef struct {
    * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory or buffer received.
    * @return  MEMORY_ERROR_INVALID_SIZE if buffer_size <=0.
    */
-  ockam_error_t (*alloc_zeroed)(ockam_memory_t* memory, uint8_t** buffer, size_t buffer_size);
+  ockam_error_t (*alloc_zeroed)(ockam_memory_t* memory, void** buffer, size_t buffer_size);
 
   /**
    * @brief   Free the specified buffer.
@@ -39,7 +39,7 @@ typedef struct {
    * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory or buffer received.
    * @return  MEMORY_ERROR_INVALID_SIZE if buffer_size <=0.
    */
-  ockam_error_t (*free)(ockam_memory_t* memory, uint8_t* buffer, size_t buffer_size);
+  ockam_error_t (*free)(ockam_memory_t* memory, void* buffer, size_t buffer_size);
 
   /**
    * @brief   Set a set_size number of bytes to the buffer with value
@@ -51,7 +51,7 @@ typedef struct {
    * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory or buffer received.
    * @return  MEMORY_ERROR_INVALID_SIZE if set_size <=0.
    */
-  ockam_error_t (*set)(ockam_memory_t* memory, uint8_t* buffer, uint8_t value, size_t set_size);
+  ockam_error_t (*set)(ockam_memory_t* memory, void* buffer, uint8_t value, size_t set_size);
 
   /**
    * @brief   Copy data from the source buffer to the destination buffer
@@ -63,7 +63,7 @@ typedef struct {
    * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory, destination or source received.
    * @return  MEMORY_ERROR_INVALID_SIZE if copy_size <=0.
    */
-  ockam_error_t (*copy)(ockam_memory_t* memory, uint8_t* destination, const uint8_t* source, size_t copy_size);
+  ockam_error_t (*copy)(ockam_memory_t* memory, void* destination, const void* source, size_t copy_size);
 
   /**
    * @brief   Move a move_size bytes from source to destination.
@@ -75,7 +75,7 @@ typedef struct {
    * @return  MEMORY_ERROR_INVALID_PARAM if invalid memory, destination or source received.
    * @return  MEMORY_ERROR_INVALID_SIZE if move_size <=0.
    */
-  ockam_error_t (*move)(ockam_memory_t* memory, uint8_t* destination, uint8_t* source, size_t move_size);
+  ockam_error_t (*move)(ockam_memory_t* memory, void* destination, void* source, size_t move_size);
 } ockam_memory_dispatch_table_t;
 
 /**

--- a/implementations/c/lib/memory/memory.c
+++ b/implementations/c/lib/memory/memory.c
@@ -23,7 +23,7 @@ exit:
   return error;
 }
 
-ockam_error_t ockam_memory_alloc_zeroed(ockam_memory_t* memory, uint8_t** buffer, size_t buffer_size)
+ockam_error_t ockam_memory_alloc_zeroed(ockam_memory_t* memory, void** buffer, size_t buffer_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -38,7 +38,7 @@ exit:
   return error;
 }
 
-ockam_error_t ockam_memory_free(ockam_memory_t* memory, uint8_t* buffer, size_t buffer_size)
+ockam_error_t ockam_memory_free(ockam_memory_t* memory, void* buffer, size_t buffer_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -53,7 +53,7 @@ exit:
   return error;
 }
 
-ockam_error_t ockam_memory_copy(ockam_memory_t* memory, uint8_t* destination, const uint8_t* source, size_t copy_size)
+ockam_error_t ockam_memory_copy(ockam_memory_t* memory, void* destination, const void* source, size_t copy_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -68,7 +68,7 @@ exit:
   return error;
 }
 
-ockam_error_t ockam_memory_set(ockam_memory_t* memory, uint8_t* buffer, uint8_t value, size_t set_size)
+ockam_error_t ockam_memory_set(ockam_memory_t* memory, void* buffer, uint8_t value, size_t set_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -83,7 +83,7 @@ exit:
   return error;
 }
 
-ockam_error_t ockam_memory_move(ockam_memory_t* memory, uint8_t* destination, uint8_t* source, size_t move_size)
+ockam_error_t ockam_memory_move(ockam_memory_t* memory, void* destination, void* source, size_t move_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 

--- a/implementations/c/lib/memory/stdlib/stdlib.c
+++ b/implementations/c/lib/memory/stdlib/stdlib.c
@@ -13,11 +13,11 @@
 #include "memory/stdlib/stdlib.h"
 
 ockam_error_t memory_stdlib_deinit(ockam_memory_t* memory);
-ockam_error_t memory_stdlib_alloc_zeroed(ockam_memory_t* memory, uint8_t** buffer, size_t buffer_size);
-ockam_error_t memory_stdlib_free(ockam_memory_t* memory, uint8_t* buffer, size_t buffer_size);
-ockam_error_t memory_stdlib_set(ockam_memory_t* memory, uint8_t* buffer, uint8_t value, size_t set_size);
-ockam_error_t memory_stdlib_copy(ockam_memory_t* memory, uint8_t* destination, const uint8_t* source, size_t copy_size);
-ockam_error_t memory_stdlib_move(ockam_memory_t* memory, uint8_t* destination, uint8_t* source, size_t move_size);
+ockam_error_t memory_stdlib_alloc_zeroed(ockam_memory_t* memory, void** buffer, size_t buffer_size);
+ockam_error_t memory_stdlib_free(ockam_memory_t* memory, void* buffer, size_t buffer_size);
+ockam_error_t memory_stdlib_set(ockam_memory_t* memory, void* buffer, uint8_t value, size_t set_size);
+ockam_error_t memory_stdlib_copy(ockam_memory_t* memory, void* destination, const void* source, size_t copy_size);
+ockam_error_t memory_stdlib_move(ockam_memory_t* memory, void* destination, void* source, size_t move_size);
 
 ockam_memory_dispatch_table_t memory_stdlib_dispatch_table = { &memory_stdlib_deinit, &memory_stdlib_alloc_zeroed,
                                                                &memory_stdlib_free,   &memory_stdlib_set,
@@ -47,7 +47,7 @@ exit:
   return error;
 }
 
-ockam_error_t memory_stdlib_alloc_zeroed(ockam_memory_t* memory, uint8_t** buffer, size_t buffer_size)
+ockam_error_t memory_stdlib_alloc_zeroed(ockam_memory_t* memory, void** buffer, size_t buffer_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -74,7 +74,7 @@ exit:
   return error;
 }
 
-ockam_error_t memory_stdlib_free(ockam_memory_t* memory, uint8_t* buffer, size_t buffer_size)
+ockam_error_t memory_stdlib_free(ockam_memory_t* memory, void* buffer, size_t buffer_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -91,7 +91,7 @@ exit:
   return error;
 }
 
-ockam_error_t memory_stdlib_set(ockam_memory_t* memory, uint8_t* buffer, uint8_t value, size_t set_size)
+ockam_error_t memory_stdlib_set(ockam_memory_t* memory, void* buffer, uint8_t value, size_t set_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -106,7 +106,7 @@ exit:
   return error;
 }
 
-ockam_error_t memory_stdlib_copy(ockam_memory_t* memory, uint8_t* destination, const uint8_t* source, size_t copy_size)
+ockam_error_t memory_stdlib_copy(ockam_memory_t* memory, void* destination, const void* source, size_t copy_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 
@@ -121,7 +121,7 @@ exit:
   return error;
 }
 
-ockam_error_t memory_stdlib_move(ockam_memory_t* memory, uint8_t* destination, uint8_t* source, size_t move_size)
+ockam_error_t memory_stdlib_move(ockam_memory_t* memory, void* destination, void* source, size_t move_size)
 {
   ockam_error_t error = OCKAM_ERROR_NONE;
 

--- a/implementations/c/lib/vault/default/default.c
+++ b/implementations/c/lib/vault/default/default.c
@@ -121,8 +121,8 @@ ockam_error_t ockam_vault_default_init(ockam_vault_t* vault, ockam_vault_default
       goto exit;
     }
 
-    error = ockam_memory_alloc_zeroed(
-      attributes->memory, (uint8_t**) &(vault->context), sizeof(ockam_vault_shared_context_t));
+    error =
+      ockam_memory_alloc_zeroed(attributes->memory, (void**) &(vault->context), sizeof(ockam_vault_shared_context_t));
     if (error != OCKAM_ERROR_NONE) { goto exit; }
 
     ctx         = (ockam_vault_shared_context_t*) vault->context;
@@ -206,7 +206,7 @@ ockam_error_t vault_default_deinit(ockam_vault_t* vault)
 
   if (ctx->default_features & OCKAM_VAULT_FEAT_AEAD_AES_GCM) { vault_default_aead_aes_gcm_deinit(ctx); }
 
-  if (delete_ctx) { ockam_memory_free(ctx->memory, (uint8_t*) ctx, sizeof(ockam_vault_shared_context_t)); }
+  if (delete_ctx) { ockam_memory_free(ctx->memory, ctx, sizeof(ockam_vault_shared_context_t)); }
 
   vault->context  = 0;
   vault->dispatch = 0;
@@ -229,15 +229,15 @@ ockam_error_t vault_default_random_init(ockam_vault_shared_context_t* ctx)
   error = ockam_random_get_bytes(ctx->random, &buffer[0], VAULT_DEFAULT_RANDOM_SEED_BYTES);
   if (error != OCKAM_ERROR_NONE) { goto exit; };
 
-  error = ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &random_ctx, sizeof(vault_default_random_ctx_t));
+  error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &random_ctx, sizeof(vault_default_random_ctx_t));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
   random_ctx->br_random = &br_hmac_drbg_vtable;
 
-  error = ockam_memory_alloc_zeroed(
-    ctx->memory, (uint8_t**) &(random_ctx->br_random_ctx), random_ctx->br_random->context_size);
+  error =
+    ockam_memory_alloc_zeroed(ctx->memory, (void**) &(random_ctx->br_random_ctx), random_ctx->br_random->context_size);
   if (error != OCKAM_ERROR_NONE) {
-    ockam_memory_free(ctx->memory, (uint8_t*) random_ctx, sizeof(vault_default_random_ctx_t));
+    ockam_memory_free(ctx->memory, random_ctx, sizeof(vault_default_random_ctx_t));
     goto exit;
   }
 
@@ -264,10 +264,10 @@ ockam_error_t vault_default_random_deinit(ockam_vault_shared_context_t* ctx)
   random_ctx = (vault_default_random_ctx_t*) ctx->random_ctx;
 
   if (random_ctx->br_random_ctx != 0) {
-    ockam_memory_free(ctx->memory, (uint8_t*) random_ctx->br_random_ctx, random_ctx->br_random->context_size);
+    ockam_memory_free(ctx->memory, random_ctx->br_random_ctx, random_ctx->br_random->context_size);
   }
 
-  error = ockam_memory_free(ctx->memory, (uint8_t*) random_ctx, sizeof(vault_default_random_ctx_t));
+  error = ockam_memory_free(ctx->memory, random_ctx, sizeof(vault_default_random_ctx_t));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
   ctx->random_ctx = 0;
@@ -323,15 +323,15 @@ ockam_error_t vault_default_sha256_init(ockam_vault_shared_context_t* ctx)
     goto exit;
   }
 
-  error = ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &sha256_ctx, sizeof(vault_default_sha256_ctx_t));
+  error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &sha256_ctx, sizeof(vault_default_sha256_ctx_t));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
   sha256_ctx->br_sha256 = &br_sha256_vtable;
 
-  error = ockam_memory_alloc_zeroed(
-    ctx->memory, (uint8_t**) &(sha256_ctx->br_sha256_ctx), sha256_ctx->br_sha256->context_size);
+  error =
+    ockam_memory_alloc_zeroed(ctx->memory, (void**) &(sha256_ctx->br_sha256_ctx), sha256_ctx->br_sha256->context_size);
   if (error != OCKAM_ERROR_NONE) {
-    ockam_memory_free(ctx->memory, (uint8_t*) sha256_ctx, sizeof(vault_default_sha256_ctx_t));
+    ockam_memory_free(ctx->memory, sha256_ctx, sizeof(vault_default_sha256_ctx_t));
     goto exit;
   }
 
@@ -355,10 +355,10 @@ ockam_error_t vault_default_sha256_deinit(ockam_vault_shared_context_t* ctx)
   sha256_ctx = (vault_default_sha256_ctx_t*) ctx->sha256_ctx;
 
   if (sha256_ctx->br_sha256_ctx != 0) {
-    ockam_memory_free(ctx->memory, (uint8_t*) sha256_ctx->br_sha256_ctx, sha256_ctx->br_sha256->context_size);
+    ockam_memory_free(ctx->memory, sha256_ctx->br_sha256_ctx, sha256_ctx->br_sha256->context_size);
   }
 
-  error = ockam_memory_free(ctx->memory, (uint8_t*) sha256_ctx, sizeof(vault_default_sha256_ctx_t));
+  error = ockam_memory_free(ctx->memory, sha256_ctx, sizeof(vault_default_sha256_ctx_t));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
   ctx->default_features &= (!OCKAM_VAULT_FEAT_SHA256);
@@ -555,13 +555,13 @@ ockam_error_t vault_default_secret_ec_create(ockam_vault_t*                     
   }
 
   if (secret->context == 0) {
-    error = ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
+    error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
     if (error != OCKAM_ERROR_NONE) { goto exit; }
   } else {
     secret_ctx = (vault_default_secret_ec_ctx_t*) secret->context;
   }
 
-  ockam_memory_set(ctx->memory, (uint8_t*) &(secret->attributes), 0, sizeof(ockam_vault_secret_attributes_t));
+  ockam_memory_set(ctx->memory, &(secret->attributes), 0, sizeof(ockam_vault_secret_attributes_t));
 
   switch (attributes->type) {
   case OCKAM_VAULT_SECRET_TYPE_P256_PRIVATEKEY:
@@ -604,10 +604,9 @@ ockam_error_t vault_default_secret_ec_create(ockam_vault_t*                     
   }
 
   if (secret_ctx->private_key == 0) {
-    error =
-      ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &(secret_ctx->private_key), secret_ctx->private_key_size);
+    error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &(secret_ctx->private_key), secret_ctx->private_key_size);
     if (error != OCKAM_ERROR_NONE) {
-      ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
+      ockam_memory_free(ctx->memory, secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
       secret->context = 0;
       goto exit;
     }
@@ -620,7 +619,7 @@ ockam_error_t vault_default_secret_ec_create(ockam_vault_t*                     
       goto exit;
     }
   } else {
-    ockam_memory_copy(ctx->memory, (uint8_t*) secret_ctx->private_key, input, input_length);
+    ockam_memory_copy(ctx->memory, secret_ctx->private_key, input, input_length);
   }
 
   {
@@ -637,8 +636,7 @@ ockam_error_t vault_default_secret_ec_create(ockam_vault_t*                     
     secret_ctx->ockam_public_key_size = size;
   }
 
-  ockam_memory_copy(
-    ctx->memory, (uint8_t*) &(secret->attributes), (uint8_t*) attributes, sizeof(ockam_vault_secret_attributes_t));
+  ockam_memory_copy(ctx->memory, &(secret->attributes), attributes, sizeof(ockam_vault_secret_attributes_t));
 
   secret->attributes.length = secret_ctx->private_key_size; /* User-supplied length is always ignored for EC keys,   */
   secret->context           = secret_ctx;                   /* instead we save the private key length.               */
@@ -703,14 +701,14 @@ ockam_error_t vault_default_secret_key_create(ockam_vault_t*                    
   }
 
   if (secret->context == 0) {
-    error = ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &secret_ctx, sizeof(vault_default_secret_key_ctx_t));
+    error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &secret_ctx, sizeof(vault_default_secret_key_ctx_t));
     if (error != OCKAM_ERROR_NONE) { goto exit; }
   } else {
     secret_ctx = (vault_default_secret_key_ctx_t*) secret->context;
   }
 
   if ((secret_ctx->key != 0) && (attributes->length != secret_ctx->key_size)) {
-    ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx->key, secret_ctx->key_size);
+    ockam_memory_free(ctx->memory, secret_ctx->key, secret_ctx->key_size);
     secret_ctx->key = 0;
   }
 
@@ -718,16 +716,16 @@ ockam_error_t vault_default_secret_key_create(ockam_vault_t*                    
   secret_ctx->buffer_size = attributes->length;
 
   if (secret_ctx->key == 0) {
-    error = ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &(secret_ctx->key), secret_ctx->key_size);
+    error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &(secret_ctx->key), secret_ctx->key_size);
     if (error != OCKAM_ERROR_NONE) {
-      ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
+      ockam_memory_free(ctx->memory, secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
       secret->context = 0;
       goto exit;
     }
   }
 
   if (generate) {
-    error = vault_default_random(vault, (uint8_t*) secret_ctx->key, secret_ctx->key_size);
+    error = vault_default_random(vault, secret_ctx->key, secret_ctx->key_size);
     if (error != OCKAM_ERROR_NONE) {
       vault_default_secret_destroy(vault, secret);
       goto exit;
@@ -738,11 +736,10 @@ ockam_error_t vault_default_secret_key_create(ockam_vault_t*                    
       goto exit;
     }
 
-    ockam_memory_copy(ctx->memory, (uint8_t*) secret_ctx->key, input, input_length);
+    ockam_memory_copy(ctx->memory, secret_ctx->key, input, input_length);
   }
 
-  ockam_memory_copy(
-    ctx->memory, (uint8_t*) &(secret->attributes), (uint8_t*) attributes, sizeof(ockam_vault_secret_attributes_t));
+  ockam_memory_copy(ctx->memory, &(secret->attributes), attributes, sizeof(ockam_vault_secret_attributes_t));
 
   secret->context = secret_ctx;
 
@@ -814,11 +811,11 @@ ockam_error_t vault_default_secret_ec_destroy(ockam_vault_t* vault, ockam_vault_
   secret_ctx = (vault_default_secret_ec_ctx_t*) secret->context;
 
   if (secret_ctx->private_key != 0) {
-    ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx->private_key, secret_ctx->private_key_size);
+    ockam_memory_free(ctx->memory, secret_ctx->private_key, secret_ctx->private_key_size);
   }
 
-  ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
-  ockam_memory_set(ctx->memory, (uint8_t*) &(secret->attributes), 0, sizeof(ockam_vault_secret_attributes_t));
+  ockam_memory_free(ctx->memory, secret_ctx, sizeof(vault_default_secret_ec_ctx_t));
+  ockam_memory_set(ctx->memory, &(secret->attributes), 0, sizeof(ockam_vault_secret_attributes_t));
 
   secret->context = 0;
 
@@ -858,10 +855,10 @@ ockam_error_t vault_default_secret_key_destroy(ockam_vault_t* vault, ockam_vault
 
   secret_ctx = (vault_default_secret_key_ctx_t*) secret->context;
 
-  if (secret_ctx->key != 0) { ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx->key, secret_ctx->buffer_size); }
+  if (secret_ctx->key != 0) { ockam_memory_free(ctx->memory, secret_ctx->key, secret_ctx->buffer_size); }
 
-  ockam_memory_free(ctx->memory, (uint8_t*) secret_ctx, sizeof(vault_default_secret_key_ctx_t));
-  ockam_memory_set(ctx->memory, (uint8_t*) &(secret->attributes), 0, sizeof(ockam_vault_secret_attributes_t));
+  ockam_memory_free(ctx->memory, secret_ctx, sizeof(vault_default_secret_key_ctx_t));
+  ockam_memory_set(ctx->memory, &(secret->attributes), 0, sizeof(ockam_vault_secret_attributes_t));
 
   secret->context = 0;
 
@@ -990,8 +987,7 @@ ockam_error_t vault_default_secret_attributes_get(ockam_vault_t*                
 
   ctx = (ockam_vault_shared_context_t*) vault->context;
 
-  error = ockam_memory_copy(
-    ctx->memory, (uint8_t*) attributes, (uint8_t*) &(secret->attributes), sizeof(ockam_vault_secret_attributes_t));
+  error = ockam_memory_copy(ctx->memory, attributes, &(secret->attributes), sizeof(ockam_vault_secret_attributes_t));
 
 exit:
   return error;
@@ -1132,7 +1128,7 @@ ockam_error_t vault_default_hkdf_sha256_init(ockam_vault_shared_context_t* ctx)
     goto exit;
   }
 
-  error = ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &(ctx->hkdf_sha256_ctx), sizeof(br_hkdf_context));
+  error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &(ctx->hkdf_sha256_ctx), sizeof(br_hkdf_context));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
   ctx->default_features |= OCKAM_VAULT_FEAT_HKDF_SHA256;
@@ -1150,7 +1146,7 @@ ockam_error_t vault_default_hkdf_sha256_deinit(ockam_vault_shared_context_t* ctx
     goto exit;
   }
 
-  error = ockam_memory_free(ctx->memory, (uint8_t*) ctx->hkdf_sha256_ctx, sizeof(br_hkdf_context));
+  error = ockam_memory_free(ctx->memory, ctx->hkdf_sha256_ctx, sizeof(br_hkdf_context));
 
   ctx->hkdf_sha256_ctx = 0;
   ctx->default_features &= (!OCKAM_VAULT_FEAT_HKDF_SHA256);
@@ -1204,7 +1200,7 @@ ockam_error_t vault_default_hkdf_sha256(ockam_vault_t*        vault,
 
   br_hkdf_ctx = (br_hkdf_context*) ctx->hkdf_sha256_ctx;
 
-  ockam_memory_set(ctx->memory, (uint8_t*) br_hkdf_ctx, 0, sizeof(br_hkdf_context));
+  ockam_memory_set(ctx->memory, br_hkdf_ctx, 0, sizeof(br_hkdf_context));
 
   if (salt->context == 0) {
     error = OCKAM_VAULT_ERROR_INVALID_CONTEXT;
@@ -1267,22 +1263,19 @@ ockam_error_t vault_default_aead_aes_gcm_init(ockam_vault_shared_context_t* ctx)
     goto exit;
   }
 
-  error =
-    ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
+  error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
-  error =
-    ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &(aead_aes_gcm_ctx->br_aes_key), sizeof(br_aes_ct_ctr_keys));
+  error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &(aead_aes_gcm_ctx->br_aes_key), sizeof(br_aes_ct_ctr_keys));
   if (error != OCKAM_ERROR_NONE) {
-    ockam_memory_free(ctx->memory, (uint8_t*) aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
+    ockam_memory_free(ctx->memory, aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
     goto exit;
   }
 
-  error =
-    ockam_memory_alloc_zeroed(ctx->memory, (uint8_t**) &(aead_aes_gcm_ctx->br_aes_gcm_ctx), sizeof(br_gcm_context));
+  error = ockam_memory_alloc_zeroed(ctx->memory, (void**) &(aead_aes_gcm_ctx->br_aes_gcm_ctx), sizeof(br_gcm_context));
   if (error != OCKAM_ERROR_NONE) {
-    ockam_memory_free(ctx->memory, (uint8_t*) aead_aes_gcm_ctx->br_aes_key, sizeof(br_aes_ct_ctr_keys));
-    ockam_memory_free(ctx->memory, (uint8_t*) aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
+    ockam_memory_free(ctx->memory, aead_aes_gcm_ctx->br_aes_key, sizeof(br_aes_ct_ctr_keys));
+    ockam_memory_free(ctx->memory, aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
     goto exit;
   }
 
@@ -1304,14 +1297,14 @@ ockam_error_t vault_default_aead_aes_gcm_deinit(ockam_vault_shared_context_t* ct
   }
 
   if (aead_aes_gcm_ctx->br_aes_gcm_ctx != 0) {
-    ockam_memory_free(ctx->memory, (uint8_t*) aead_aes_gcm_ctx->br_aes_gcm_ctx, sizeof(br_gcm_context));
+    ockam_memory_free(ctx->memory, aead_aes_gcm_ctx->br_aes_gcm_ctx, sizeof(br_gcm_context));
   }
 
   if (aead_aes_gcm_ctx->br_aes_key != 0) {
-    ockam_memory_free(ctx->memory, (uint8_t*) aead_aes_gcm_ctx->br_aes_key, sizeof(br_aes_ct_ctr_keys));
+    ockam_memory_free(ctx->memory, aead_aes_gcm_ctx->br_aes_key, sizeof(br_aes_ct_ctr_keys));
   }
 
-  error = ockam_memory_free(ctx->memory, (uint8_t*) aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
+  error = ockam_memory_free(ctx->memory, aead_aes_gcm_ctx, sizeof(vault_default_aead_aes_gcm_ctx_t));
   if (error != OCKAM_ERROR_NONE) { goto exit; }
 
   ctx->default_features &= (!OCKAM_VAULT_FEAT_AEAD_AES_GCM);

--- a/implementations/c/lib/vault/tests/aead_aes_gcm.c
+++ b/implementations/c/lib/vault/tests/aead_aes_gcm.c
@@ -159,14 +159,14 @@ void test_vault_aead_aes_gcm(void** state)
     aead_aes_gcm_encrypt_hash_size =
       g_aead_aes_gcm_data[test_data->test_count].text_size + TEST_VAULT_AEAD_AES_GCM_TAG_SIZE;
 
-    error = ockam_memory_alloc_zeroed(
-      test_data->memory, (uint8_t**) &aead_aes_gcm_encrypt_hash, aead_aes_gcm_encrypt_hash_size);
+    error =
+      ockam_memory_alloc_zeroed(test_data->memory, (void**) &aead_aes_gcm_encrypt_hash, aead_aes_gcm_encrypt_hash_size);
     if (error != OCKAM_ERROR_NONE) { fail_msg("Unable to alloc aead_aes_gcm_encrypt_hash"); }
 
     aead_aes_gcm_decrypt_data_size = g_aead_aes_gcm_data[test_data->test_count].text_size;
 
-    error = ockam_memory_alloc_zeroed(
-      test_data->memory, (uint8_t**) &aead_aes_gcm_decrypt_data, aead_aes_gcm_decrypt_data_size);
+    error =
+      ockam_memory_alloc_zeroed(test_data->memory, (void**) &aead_aes_gcm_decrypt_data, aead_aes_gcm_decrypt_data_size);
     if (error != OCKAM_ERROR_NONE) { fail_msg("Unable to alloc aead_aes_gcm_decrypt_data"); }
   }
 
@@ -279,7 +279,7 @@ int test_vault_run_aead_aes_gcm(ockam_vault_t* vault, ockam_memory_t* memory)
   test_vault_aead_aes_gcm_shared_data_t shared_data;
 
   error = ockam_memory_alloc_zeroed(
-    memory, (uint8_t**) &cmocka_data, TEST_VAULT_AEAD_AES_GCM_TEST_CASES * sizeof(struct CMUnitTest));
+    memory, (void**) &cmocka_data, TEST_VAULT_AEAD_AES_GCM_TEST_CASES * sizeof(struct CMUnitTest));
   if (error != OCKAM_ERROR_NONE) {
     rc = -1;
     goto exit_block;
@@ -293,7 +293,7 @@ int test_vault_run_aead_aes_gcm(ockam_vault_t* vault, ockam_memory_t* memory)
   shared_data.memory         = memory;
 
   for (i = 0; i < TEST_VAULT_AEAD_AES_GCM_TEST_CASES; i++) {
-    error = ockam_memory_alloc_zeroed(memory, (uint8_t**) &test_name, TEST_VAULT_AEAD_AES_GCM_NAME_SIZE);
+    error = ockam_memory_alloc_zeroed(memory, (void**) &test_name, TEST_VAULT_AEAD_AES_GCM_NAME_SIZE);
     if (error != OCKAM_ERROR_NONE) {
       rc = -1;
       goto exit_block;

--- a/implementations/c/lib/vault/tests/hkdf.c
+++ b/implementations/c/lib/vault/tests/hkdf.c
@@ -285,8 +285,8 @@ int test_vault_run_hkdf(ockam_vault_t* vault, ockam_memory_t* memory)
   struct CMUnitTest*            cmocka_tests = 0;
   test_vault_hkdf_shared_data_t shared_data;
 
-  error = ockam_memory_alloc_zeroed(
-    memory, (uint8_t**) &cmocka_data, (TEST_VAULT_HKDF_TEST_CASES * sizeof(struct CMUnitTest)));
+  error =
+    ockam_memory_alloc_zeroed(memory, (void**) &cmocka_data, (TEST_VAULT_HKDF_TEST_CASES * sizeof(struct CMUnitTest)));
   if (error != OCKAM_ERROR_NONE) {
     rc = -1;
     goto exit_block;
@@ -300,7 +300,7 @@ int test_vault_run_hkdf(ockam_vault_t* vault, ockam_memory_t* memory)
   shared_data.memory         = memory;
 
   for (i = 0; i < TEST_VAULT_HKDF_TEST_CASES; i++) {
-    error = ockam_memory_alloc_zeroed(memory, (uint8_t**) &test_name, TEST_VAULT_HKDF_NAME_SIZE);
+    error = ockam_memory_alloc_zeroed(memory, (void**) &test_name, TEST_VAULT_HKDF_NAME_SIZE);
     if (error != OCKAM_ERROR_NONE) {
       rc = -1;
       goto exit_block;

--- a/implementations/c/lib/vault/tests/random.c
+++ b/implementations/c/lib/vault/tests/random.c
@@ -39,7 +39,7 @@ void test_vault_random(void** state)
 
   test_data = (test_vault_random_shared_data_t*) *state;
 
-  error = ockam_vault_random_bytes_generate(test_data->vault, (uint8_t*) &g_rand_num[0], TEST_VAULT_RAND_NUM_SIZE);
+  error = ockam_vault_random_bytes_generate(test_data->vault, &g_rand_num[0], TEST_VAULT_RAND_NUM_SIZE);
   assert_int_equal(error, OCKAM_ERROR_NONE);
 }
 

--- a/implementations/c/lib/vault/tests/secret_ecdh.c
+++ b/implementations/c/lib/vault/tests/secret_ecdh.c
@@ -228,10 +228,10 @@ void test_vault_secret_ecdh(void** state)
   /* Memory Allocation */
   /* ----------------- */
 
-  error = ockam_memory_alloc_zeroed(test_data->memory, &generated_initiator_pub, test_data->key_size);
+  error = ockam_memory_alloc_zeroed(test_data->memory, (void**) &generated_initiator_pub, test_data->key_size);
   if (error != OCKAM_ERROR_NONE) { fail_msg("Unable to alloc generated_initiator_pub"); }
 
-  error = ockam_memory_alloc_zeroed(test_data->memory, &generated_responder_pub, test_data->key_size);
+  error = ockam_memory_alloc_zeroed(test_data->memory, (void**) &generated_responder_pub, test_data->key_size);
   if (error != OCKAM_ERROR_NONE) { fail_msg("Unable to alloc generated_responder_pub"); }
 
   /* ------------------ */
@@ -412,7 +412,7 @@ int test_vault_run_secret_ecdh(ockam_vault_t*            vault,
   }
 
   error =
-    ockam_memory_alloc_zeroed(memory, (uint8_t**) &cmocka_data, test_data.test_count_max * sizeof(struct CMUnitTest));
+    ockam_memory_alloc_zeroed(memory, (void**) &cmocka_data, test_data.test_count_max * sizeof(struct CMUnitTest));
   if (error != OCKAM_ERROR_NONE) {
     rc = -1;
     goto exit_block;
@@ -421,7 +421,7 @@ int test_vault_run_secret_ecdh(ockam_vault_t*            vault,
   cmocka_tests = (struct CMUnitTest*) cmocka_data;
 
   for (i = 0; i < test_data.test_count_max; i++) {
-    error = ockam_memory_alloc_zeroed(memory, (uint8_t**) &test_name, TEST_VAULT_KEY_NAME_SIZE);
+    error = ockam_memory_alloc_zeroed(memory, (void**) &test_name, TEST_VAULT_KEY_NAME_SIZE);
     if (error != OCKAM_ERROR_NONE) { break; }
 
     snprintf(test_name, TEST_VAULT_KEY_NAME_SIZE, "%s Test Case %02d", name, i);

--- a/implementations/c/lib/vault/tests/sha256.c
+++ b/implementations/c/lib/vault/tests/sha256.c
@@ -1118,7 +1118,7 @@ int test_vault_run_sha256(ockam_vault_t* vault, ockam_memory_t* memory)
   test_vault_sha256_shared_data_t shared_data;
 
   error = ockam_memory_alloc_zeroed(
-    memory, (uint8_t**) &cmocka_data, (TEST_VAULT_SHA256_TEST_CASES * sizeof(struct CMUnitTest)));
+    memory, (void**) &cmocka_data, (TEST_VAULT_SHA256_TEST_CASES * sizeof(struct CMUnitTest)));
   if (error != OCKAM_ERROR_NONE) {
     rc = -1;
     goto exit;
@@ -1133,7 +1133,7 @@ int test_vault_run_sha256(ockam_vault_t* vault, ockam_memory_t* memory)
   shared_data.memory = memory;
 
   for (i = 0; i < TEST_VAULT_SHA256_TEST_CASES; i++) {
-    error = ockam_memory_alloc_zeroed(memory, (uint8_t**) &test_name, TEST_VAULT_SHA256_NAME_SIZE);
+    error = ockam_memory_alloc_zeroed(memory, (void**) &test_name, TEST_VAULT_SHA256_NAME_SIZE);
     if (error != OCKAM_ERROR_NONE) {
       rc = -1;
       goto exit;

--- a/implementations/rust/crates/ockam/src/memory.rs
+++ b/implementations/rust/crates/ockam/src/memory.rs
@@ -38,10 +38,10 @@ impl RustAlloc {
 
 unsafe extern "C" fn alloc_zeroed_impl(
     _: *mut ockam_memory_t,
-    buffer: *mut *mut u8,
+    buffer: *mut *mut core::ffi::c_void,
     size: usize,
 ) -> ockam_error_t {
-    let layout_result = Layout::from_size_align(size, mem::align_of::<u8>());
+    let layout_result = Layout::from_size_align(size, mem::align_of::<core::ffi::c_void>());
     if let Ok(layout) = layout_result {
         let ptr = std::alloc::alloc_zeroed(layout);
         if !ptr.is_null() {
@@ -53,8 +53,8 @@ unsafe extern "C" fn alloc_zeroed_impl(
     ockam_vault_sys::OCKAM_MEMORY_ERROR_ALLOC_FAIL
 }
 
-unsafe extern "C" fn free_impl(_: *mut ockam_memory_t, ptr: *mut u8, size: usize) -> ockam_error_t {
-    let layout_result = Layout::from_size_align(size, mem::align_of::<u8>());
+unsafe extern "C" fn free_impl(_: *mut ockam_memory_t, ptr: *mut core::ffi::c_void, size: usize) -> ockam_error_t {
+    let layout_result = Layout::from_size_align(size, mem::align_of::<core::ffi::c_void>());
     if let Ok(layout) = layout_result {
         std::alloc::dealloc(ptr as *mut _, layout);
         ockam_vault_sys::OCKAM_ERROR_NONE
@@ -65,7 +65,7 @@ unsafe extern "C" fn free_impl(_: *mut ockam_memory_t, ptr: *mut u8, size: usize
 
 unsafe extern "C" fn memset_impl(
     _: *mut ockam_memory_t,
-    ptr: *mut u8,
+    ptr: *mut core::ffi::c_void,
     byte: u8,
     count: usize,
 ) -> ockam_error_t {
@@ -75,8 +75,8 @@ unsafe extern "C" fn memset_impl(
 
 unsafe extern "C" fn memcpy_impl(
     _: *mut ockam_memory_t,
-    dst: *mut u8,
-    src: *const u8,
+    dst: *mut core::ffi::c_void,
+    src: *const core::ffi::c_void,
     size: usize,
 ) -> ockam_error_t {
     core::intrinsics::copy_nonoverlapping(src, dst, size);
@@ -85,8 +85,8 @@ unsafe extern "C" fn memcpy_impl(
 
 unsafe extern "C" fn memmove_impl(
     _: *mut ockam_memory_t,
-    dst: *mut u8,
-    src: *mut u8,
+    dst: *mut core::ffi::c_void,
+    src: *mut core::ffi::c_void,
     size: usize,
 ) -> ockam_error_t {
     core::intrinsics::copy(src, dst, size);


### PR DESCRIPTION
This PR modifies the Ockam memory interface to use `void*` rather than `uint8_t*` to closer mimic the stdlib implementation and prevent unnecessary casting. The one exception is the `allocate_zeroed()` which requires a `void**` to allow the function to be consistent with all other Ockam interface calls and return `ockam_error_t`

In addition to updating the interface, the vault's use of the memory interface and rust's use of the memory interface have been updated. 
