### PR TITLE
feat: draft of influx integration

### DIFF
--- a/implementations/elixir/config/config.exs
+++ b/implementations/elixir/config/config.exs
@@ -2,5 +2,6 @@ import Config
 
 config :ockam, vault: []
 config :ockam, transports: []
+config :ockam, services: []
 
 import_config "#{Mix.env()}.exs"

--- a/implementations/elixir/config/dev.exs
+++ b/implementations/elixir/config/dev.exs
@@ -18,3 +18,19 @@ config :ockam, :transports,
     listen_address: "0.0.0.0",
     listen_port: 4000
   ]
+
+config :ockam, :services,
+  influx_example: [
+    service: Ockam.Services.Influx,
+    database: "test",
+    http: [
+      host: "127.0.0.1",
+      port: 8086
+    ]
+  ]
+
+config :fluxter, Ockam.Services.Influx.Fluxter,
+  host: "127.0.0.1",
+  port: 8089,
+  pool_size: 5,
+  prefix: nil

--- a/implementations/elixir/config/test.exs
+++ b/implementations/elixir/config/test.exs
@@ -3,4 +3,8 @@ import Config
 config :logger,
   level: :warn
 
-config :ockam, :vault, curve: :curve25519
+config :fluxter, Ockam.Services.Influx.Fluxter,
+  host: "127.0.0.1",
+  port: 8089,
+  pool_size: 5,
+  prefix: nil

--- a/implementations/elixir/influx.sh
+++ b/implementations/elixir/influx.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+BUILD_DIR="${SCRIPT_DIR}/_build"
+VAR_DIR="${BUILD_DIR}/influxdb"
+
+mkdir -p "${VAR_DIR}"
+
+exec docker run -p 8086:8086 -p 8089:8089 \
+  -v "${VAR_DIR}:/var/lib/influxdb" \
+  -e INFLUXDB_DB=test \
+  -e INFLUXDB_HTTP_ENABLED=true \
+  -e INFLUXDB_HTTP_FLUX_ENABLED=true \
+  -e INFLUXDB_HTTP_BIND_ADDRESS=':8086' \
+  -e INFLUXDB_UDP_ENABLED=true \
+  -e INFLUXDB_UDP_BIND_ADDRESS=':8089' \
+  -e INFLUXDB_UDP_DATABASE=test \
+  -e INFLUXDB_REPORTING_DISABLED=true \
+  influxdb:1.8-alpine

--- a/implementations/elixir/lib/app.ex
+++ b/implementations/elixir/lib/app.ex
@@ -7,8 +7,11 @@ defmodule Ockam.App do
     Logger.info("Starting #{__MODULE__}")
 
     transports = Application.get_env(:ockam, :transports, [])
+    services = Application.get_env(:ockam, :services, [])
 
     children = [
+      {Ockam.Registry, []},
+      {Ockam.Services, [services]},
       {Ockam.Transport.Supervisor, [transports]}
     ]
 

--- a/implementations/elixir/lib/registry.ex
+++ b/implementations/elixir/lib/registry.ex
@@ -1,0 +1,26 @@
+defmodule Ockam.Registry do
+  @type service :: module()
+  @type name :: term()
+
+  def child_spec([]) do
+    Registry.child_spec(keys: :unique, name: __MODULE__)
+  end
+
+  @doc "Lookup a registered service by name"
+  @spec lookup(name()) :: nil | {pid(), service()}
+  def lookup(name) do
+    case Registry.lookup(__MODULE__, name) do
+      [] ->
+        nil
+
+      [registered] ->
+        registered
+    end
+  end
+
+  @doc "Lookup registered instances of the given service"
+  @spec lookup_by_service(service()) :: [{pid(), name()}]
+  def lookup_by_service(service) do
+    Registry.select(__MODULE__, [{{:"$1", :"$2", service}, [], [{:"$2", :"$1"}]}])
+  end
+end

--- a/implementations/elixir/lib/router.ex
+++ b/implementations/elixir/lib/router.ex
@@ -1,0 +1,39 @@
+defmodule Ockam.Router do
+  alias __MODULE__.Protocol.Endpoint
+
+  @opaque connection :: %{__struct__: module()}
+
+  @doc """
+  Connects to the given endpoint
+
+  Certain endpoints may be treated specially, such as when Influx is hosted
+  within the router itself; this allows the router to act in both its primary
+  capacity, and as the service shim layer for such services.
+  """
+  @spec connect(Endpoint.t()) :: {:ok, connection} | {:error, term}
+  def connect(dest)
+
+  def connect(%Endpoint{value: %Endpoint.Local{data: name}}) do
+    case Ockam.Registry.lookup(name) do
+      nil ->
+        {:error, :not_found}
+
+      {pid, service} when is_pid(pid) and is_atom(service) ->
+        service.connect(pid, self())
+    end
+  end
+
+  def connect(%Endpoint{}), do: {:error, :unsupported}
+
+  @doc "Send a message to the given connection"
+  @spec send(connection, term) :: :ok | {:error, term}
+  def send(%mod{} = connection, message) do
+    mod.send(connection, message)
+  end
+
+  @doc "Execute a request to the given connection"
+  @spec request(connection, term) :: {:ok, reply :: term} | {:error, term}
+  def request(%mod{} = connection, req) do
+    mod.request(connection, req)
+  end
+end

--- a/implementations/elixir/lib/router/protocol/encoder.ex
+++ b/implementations/elixir/lib/router/protocol/encoder.ex
@@ -1,6 +1,6 @@
 defprotocol Ockam.Router.Protocol.Encoder do
   @type t :: term()
-  @type opts :: Keyword.t()
+  @type opts :: map()
   @type reason :: term()
 
   @fallback_to_any true

--- a/implementations/elixir/lib/router/protocol/message/ack.ex
+++ b/implementations/elixir/lib/router/protocol/message/ack.ex
@@ -1,0 +1,4 @@
+defmodule Ockam.Router.Protocol.Message.Ack do
+  use Ockam.Router.Protocol.Message,
+    type_id: 5
+end

--- a/implementations/elixir/lib/router/protocol/message/error.ex
+++ b/implementations/elixir/lib/router/protocol/message/error.ex
@@ -1,0 +1,16 @@
+defmodule Ockam.Router.Protocol.Message.Error do
+  use Ockam.Router.Protocol.Message,
+    type_id: 6,
+    schema: [code: :integer, description: :string]
+
+  def new(code, reason) when is_integer(code) and is_binary(reason) do
+    %__MODULE__{code: code, description: reason}
+  end
+
+  def new(code, reason) when is_integer(code) do
+    %__MODULE__{code: code, description: to_string(reason)}
+  rescue
+    Protocol.UndefinedError ->
+      %__MODULE__{code: code, description: inspect(reason)}
+  end
+end

--- a/implementations/elixir/lib/router/protocol/message/request.ex
+++ b/implementations/elixir/lib/router/protocol/message/request.ex
@@ -1,0 +1,5 @@
+defmodule Ockam.Router.Protocol.Message.Request do
+  use Ockam.Router.Protocol.Message,
+    type_id: 8,
+    schema: [data: :raw]
+end

--- a/implementations/elixir/lib/router/protocol/message/send.ex
+++ b/implementations/elixir/lib/router/protocol/message/send.ex
@@ -1,0 +1,5 @@
+defmodule Ockam.Router.Protocol.Message.Send do
+  use Ockam.Router.Protocol.Message,
+    type_id: 7,
+    schema: [data: :raw]
+end

--- a/implementations/elixir/lib/services.ex
+++ b/implementations/elixir/lib/services.ex
@@ -1,0 +1,42 @@
+defmodule Ockam.Services do
+  use DynamicSupervisor
+
+  require Logger
+
+  def start_link([services]) when is_list(services) do
+    Logger.info("Starting #{__MODULE__} with #{inspect(services)}")
+
+    {:ok, pid} = DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+    for {service_name, service_config} <- services do
+      case start_service(service_name, service_config) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.error(
+            "Failed to start preconfigured service #{service_name}: #{inspect(reason)}"
+          )
+
+          exit(reason)
+      end
+    end
+
+    {:ok, pid}
+  end
+
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @spec start_service(atom, Keyword.t()) :: {:ok, pid} | {:error, term}
+  def start_service(name, config) do
+    {service, service_opts} = Keyword.pop!(config, :service)
+
+    Logger.info("Starting service #{inspect(service)} with config: #{inspect(service_opts)}")
+
+    meta = [name: {:via, Registry, {Ockam.Registry, to_string(name), service}}]
+    spec = {service, [meta, service_opts]}
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+end

--- a/implementations/elixir/lib/services/influx.ex
+++ b/implementations/elixir/lib/services/influx.ex
@@ -1,0 +1,50 @@
+defmodule Ockam.Services.Influx do
+  use Supervisor
+
+  alias __MODULE__.Connection
+
+  def start_link([meta, opts]) when is_list(meta) and is_list(opts) do
+    name = Keyword.get(meta, :name, __MODULE__)
+
+    Supervisor.start_link(__MODULE__, [name, opts])
+  end
+
+  @impl true
+  def init([name, opts]) do
+    children = [
+      __MODULE__.Fluxter.child_spec(),
+      {__MODULE__.ConnectionSupervisor, [name, opts]}
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  @doc """
+  Connect the given process to Influx as a psuedo-client
+
+  All client operations are performed via the resulting connection, which
+  multiplexes operations over the connection pool started by the service.
+
+  Connections are automatically terminated if the originating process dies
+  """
+  @spec connect(pid | atom, pid) :: {:ok, Connection.t()} | {:error, term}
+  defdelegate connect(sup, connecting_pid), to: __MODULE__.ConnectionSupervisor
+
+  @doc "Disconnects an active connection"
+  @spec disconnect(Connection.t()) :: :ok
+  defdelegate disconnect(conn), to: __MODULE__.Connection
+
+  @doc """
+  Writes the given measurement with the provided tags and fields.
+
+  Tags may be an empty list.
+  """
+  @spec write(Connection.t(), binary(), Keyword.t(), Keyword.t()) :: :ok
+  defdelegate write(conn, measurement, tags, fields), to: __MODULE__.Connection
+
+  @doc """
+  Executes the given query (InfluxQL)
+  """
+  @spec query(Connection.t(), binary()) :: {:ok, binary()} | {:error, term}
+  defdelegate query(conn, query_text), to: __MODULE__.Connection
+end

--- a/implementations/elixir/lib/services/influx/connection.ex
+++ b/implementations/elixir/lib/services/influx/connection.ex
@@ -1,0 +1,196 @@
+defmodule Ockam.Services.Influx.Connection do
+  use GenServer
+
+  alias Ockam.Services.Influx.Message
+  alias Ockam.Services.Influx.HTTP
+  alias Ockam.Router.Protocol.Decoder
+
+  def child_spec(args) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [args]},
+      restart: :temporary,
+      shutdown: 1_000,
+      type: :worker
+    }
+  end
+
+  defmodule State do
+    defstruct [:pid, :monitor, :host, :port, :db]
+  end
+
+  defstruct [:pid, :connected]
+
+  @doc false
+  def new(connection_pid, connecting_pid)
+      when is_pid(connection_pid) and is_pid(connecting_pid) do
+    %__MODULE__{pid: connection_pid, connected: connecting_pid}
+  end
+
+  @doc "Unpack and send the encoded message"
+  def send(%__MODULE__{} = conn, encoded) do
+    with {:ok, %Message{value: decoded}, _} <- Decoder.decode(%Message{}, encoded, %{}) do
+      do_send(conn, decoded)
+    end
+  end
+
+  defp do_send(conn, %Message.Write{measurement: m, tags: tags, fields: fields}) do
+    write(conn, m, tags, fields)
+  end
+
+  defp do_send(_conn, _msg) do
+    {:error, :invalid_send_type}
+  end
+
+  @doc "Unpack and execute the encoded request"
+  def request(%__MODULE__{} = conn, encoded) do
+    with {:ok, %Message{value: decoded}, _} <- Decoder.decode(%Message{}, encoded, %{}) do
+      do_request(conn, decoded)
+    end
+  end
+
+  defp do_request(conn, %Message.Query{text: text}) do
+    query(conn, text)
+  end
+
+  defp do_request(_conn, _), do: {:error, :invalid_request_type}
+
+  @doc "Disconnect this connection"
+  def disconnect(%__MODULE__{pid: pid}) do
+    GenServer.call(pid, :disconnect)
+  catch
+    :exit, {:noproc, _} ->
+      {:error, :connection_closed}
+  end
+
+  @doc "Write data to a measurement in Influx"
+  def write(%__MODULE__{pid: pid}, measurement, tags, fields) do
+    GenServer.call(pid, {:write, measurement, tags, fields})
+  catch
+    :exit, {:noproc, _} ->
+      {:error, :connection_closed}
+  end
+
+  @doc "Execute a query against the Influx database"
+  def query(%__MODULE__{pid: pid}, text) when is_binary(text) do
+    GenServer.call(pid, {:query, text})
+  catch
+    :exit, {:noproc, _} ->
+      {:error, :connection_closed}
+  end
+
+  # GenServer impl
+
+  def start_link(opts, pid), do: GenServer.start_link(__MODULE__, [opts, pid])
+
+  def init([opts, pid]) when is_pid(pid) do
+    ref = Process.monitor(pid)
+    host = get_in(opts, [:http, :host]) || "localhost"
+    port = get_in(opts, [:http, :port]) || 8086
+    db = Keyword.fetch!(opts, :database)
+    {:ok, %State{pid: pid, monitor: ref, host: host, port: port, db: db}}
+  end
+
+  def handle_call({:write, measurement, tags, fields}, _from, %State{} = state) do
+    with {:ok, client} <- HTTP.connect(state.host, state.port),
+         {:ok, data} <- encode_write(measurement, tags, fields),
+         {:ok, client, %HTTP.Response{} = resp} <-
+           HTTP.post(client, "/write", %{"db" => state.db, "precision" => "s"}, data),
+         :ok <- HTTP.close(client) do
+      case resp.status do
+        n when n >= 200 and n < 300 ->
+          {:reply, :ok, state}
+
+        _error_status ->
+          {:reply, {:error, resp.body}, state}
+      end
+    else
+      {:error, _reason} = err ->
+        {:reply, err, state}
+
+      {:error, client, reason} ->
+        HTTP.close(client)
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:query, text}, _from, %State{} = state) do
+    with {:ok, client} <- HTTP.connect(state.host, state.port),
+         {:ok, client, %HTTP.Response{} = resp} <-
+           HTTP.get(client, "/query", %{"db" => state.db, "q" => text}),
+         :ok <- HTTP.close(client) do
+      case resp.status do
+        200 ->
+          {:reply, {:ok, resp.body}, state}
+
+        _error_status ->
+          {:reply, {:error, resp.body}, state}
+      end
+    else
+      {:error, _reason} = err ->
+        {:reply, err, state}
+
+      {:error, client, reason} ->
+        HTTP.close(client)
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call(:disconnect, from, %State{monitor: ref}) do
+    Process.demonitor(ref)
+    GenServer.reply(from, :ok)
+    {:stop, :shutdown}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, reason}, %State{pid: pid, monitor: ref}) do
+    {:stop, reason}
+  end
+
+  # measurement,tag_key=tag_value,... field_key=field_value
+  defp encode_write(measurement, [], fields) do
+    fields_encoded =
+      fields
+      |> Enum.map(fn {key, value} -> "#{escape(to_string(key))}=#{encode_value(value)}" end)
+      |> Enum.join(",")
+
+    {:ok, "#{measurement} #{fields_encoded}"}
+  end
+
+  defp encode_write(measurement, tags, fields) do
+    tags_encoded =
+      tags
+      |> Enum.map(fn {key, value} -> "#{encode_value(key)}=#{encode_value(value)}" end)
+      |> Enum.join(",")
+
+    fields_encoded =
+      fields
+      |> Enum.map(fn {key, value} -> "#{encode_value(key)}=#{encode_value(value)}" end)
+      |> Enum.join(",")
+
+    {:ok, "#{measurement},#{tags_encoded} #{fields_encoded}"}
+  end
+
+  defp escape(value) do
+    Regex.replace(~r/([,\s\\"])/, value, fn _, x -> "\\#{x}" end)
+  end
+
+  defp encode_value(s) when is_binary(s) do
+    if Regex.match?(~r/[,\s\\"]/, s) do
+      "\"#{escape(s)}\""
+    else
+      s
+    end
+  end
+
+  defp encode_value(a) when is_atom(a) do
+    encode_value(to_string(a))
+  end
+
+  defp encode_value(b) when is_boolean(b) do
+    to_string(b)
+  end
+
+  defp encode_value(n) when is_number(n) do
+    to_string(n)
+  end
+end

--- a/implementations/elixir/lib/services/influx/connection_sup.ex
+++ b/implementations/elixir/lib/services/influx/connection_sup.ex
@@ -1,0 +1,32 @@
+defmodule Ockam.Services.Influx.ConnectionSupervisor do
+  use DynamicSupervisor
+  require Logger
+
+  alias Ockam.Services.Influx.Connection
+
+  def child_spec([name, opts]) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [name, opts]},
+      restart: :permanent,
+      shutdown: :infinity,
+      type: :supervisor
+    }
+  end
+
+  def start_link(name, opts) do
+    DynamicSupervisor.start_link(__MODULE__, [opts], name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    DynamicSupervisor.init(strategy: :one_for_one, extra_arguments: opts)
+  end
+
+  @spec connect(atom() | pid(), pid()) :: {:ok, Connection.t()} | {:error, term}
+  def connect(sup, pid) do
+    with {:ok, conn_pid} <- DynamicSupervisor.start_child(sup, {Connection, pid}) do
+      {:ok, Connection.new(conn_pid, pid)}
+    end
+  end
+end

--- a/implementations/elixir/lib/services/influx/fluxter.ex
+++ b/implementations/elixir/lib/services/influx/fluxter.ex
@@ -1,0 +1,3 @@
+defmodule Ockam.Services.Influx.Fluxter do
+  use Fluxter
+end

--- a/implementations/elixir/lib/services/influx/http.ex
+++ b/implementations/elixir/lib/services/influx/http.ex
@@ -1,0 +1,86 @@
+defmodule Ockam.Services.Influx.HTTP do
+  defstruct [:conn, :host, :port]
+
+  defmodule Response do
+    defstruct [:status, :headers, :body]
+
+    def new() do
+      %__MODULE__{status: nil, headers: [], body: ""}
+    end
+  end
+
+  def connect(host, port, opts \\ [])
+
+  def connect(host, port, _opts) do
+    with {:ok, conn} <- Mint.HTTP1.connect(:http, host, port, mode: :passive) do
+      {:ok, %__MODULE__{conn: conn, host: host, port: port}}
+    end
+  end
+
+  def get(conn, path, query \\ nil)
+
+  def get(%__MODULE__{conn: conn} = state, path, nil) do
+    with {:ok, conn, _req} <- Mint.HTTP1.request(conn, "GET", path, _headers = [], _body = nil),
+         {:ok, conn, resp} <- recv(conn) do
+      {:ok, %__MODULE__{state | conn: conn}, resp}
+    else
+      {:error, conn, reason} ->
+        {:error, %__MODULE__{state | conn: conn}, reason}
+
+      {:error, conn, reason, _resp} ->
+        {:error, %__MODULE__{state | conn: conn}, reason}
+    end
+  end
+
+  def get(%__MODULE__{} = state, path, query) when is_map(query) do
+    get(state, path <> "?" <> URI.encode_query(query), nil)
+  end
+
+  def post(%__MODULE__{conn: conn} = state, path, query, body) do
+    path = path <> "?" <> URI.encode_query(query)
+
+    with {:ok, conn, _req} <- Mint.HTTP1.request(conn, "POST", path, _headers = [], body),
+         {:ok, conn, resp} <- recv(conn) do
+      {:ok, %__MODULE__{state | conn: conn}, resp}
+    else
+      {:error, conn, reason} ->
+        {:error, %__MODULE__{state | conn: conn}, reason}
+
+      {:error, conn, reason, _resp} ->
+        {:error, %__MODULE__{state | conn: conn}, reason}
+    end
+  end
+
+  def close(%__MODULE__{conn: nil}), do: :ok
+
+  def close(%__MODULE__{conn: http}) do
+    Mint.HTTP1.close(http)
+    :ok
+  end
+
+  defp recv(conn) do
+    do_recv(conn, Response.new())
+  end
+
+  defp do_recv(conn, acc) do
+    with {:ok, conn, responses} <- Mint.HTTP1.recv(conn, 0, :infinity),
+         {:more, conn, new_acc} <- handle_responses(responses, conn, acc) do
+      do_recv(conn, new_acc)
+    end
+  end
+
+  defp handle_responses([], conn, acc), do: {:more, conn, acc}
+  defp handle_responses([{:done, _}], conn, acc), do: {:ok, conn, acc}
+
+  defp handle_responses([{:status, _, status} | rest], conn, acc) do
+    handle_responses(rest, conn, %Response{acc | status: status})
+  end
+
+  defp handle_responses([{:headers, _, headers} | rest], conn, acc) do
+    handle_responses(rest, conn, %Response{acc | headers: acc.headers ++ headers})
+  end
+
+  defp handle_responses([{:data, _, chunk} | rest], conn, acc) do
+    handle_responses(rest, conn, %Response{acc | body: acc.body <> chunk})
+  end
+end

--- a/implementations/elixir/lib/services/influx/message.ex
+++ b/implementations/elixir/lib/services/influx/message.ex
@@ -1,0 +1,256 @@
+defmodule Ockam.Services.Influx.Message do
+  defstruct [:value]
+
+  defmodule Write do
+    defstruct [:measurement, :tags, :fields]
+
+    def type_id(%__MODULE__{}), do: 0
+
+    defimpl Ockam.Router.Protocol.Encoder do
+      def encode(value, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Router.Protocol.Encoding.Default.Encode
+      alias Ockam.Services.Influx.Message.Write
+
+      def encode(%Write{measurement: measurement, tags: tags, fields: fields} = value, opts) do
+        type = Encode.i1(Write.type_id(value), opts)
+        measure_len = Helpers.encode_leb128_u2(byte_size(measurement))
+        tags_len = Helpers.encode_leb128_u2(length(tags))
+
+        tags_encoded =
+          for {name, value} <- tags do
+            name_str = to_string(name)
+            value_str = to_string(value)
+            name_len = Helpers.encode_leb128_u2(byte_size(name_str))
+            value_len = Helpers.encode_leb128_u2(byte_size(value_str))
+            [name_len, name_str, value_len, value_str]
+          end
+
+        fields_len = Helpers.encode_leb128_u2(length(fields))
+
+        fields_encoded =
+          for {name, value} <- fields do
+            name_str = to_string(name)
+            name_len = Helpers.encode_leb128_u2(byte_size(name_str))
+            value_type = encode_value_type(value)
+            value_encoded = encode_value(value)
+            [name_len, name_str, value_type, value_encoded]
+          end
+
+        {:ok,
+         [type, measure_len, measurement, tags_len, tags_encoded, fields_len, fields_encoded]}
+      end
+
+      defp encode_value_type(n) when is_number(n), do: 0
+      defp encode_value_type(true), do: 1
+      defp encode_value_type(false), do: 2
+      defp encode_value_type(_), do: 3
+
+      defp encode_value(n) when is_number(n), do: <<n::big-size(8)-unit(8)>>
+      defp encode_value(b) when is_boolean(b), do: <<>>
+
+      defp encode_value(s) when is_binary(s) do
+        [Helpers.encode_leb128_u2(byte_size(s)), s]
+      end
+
+      defp encode_value(value) do
+        value_str = to_string(value)
+        [Helpers.encode_leb128_u2(byte_size(value_str)), value_str]
+      end
+    end
+
+    defimpl Ockam.Router.Protocol.Decoder do
+      def decode(value, input, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Services.Influx.Message.Write
+
+      def decode(value, input, _opts) do
+        with {:ok, measurement, rest} <- decode_measurement(input),
+             {:ok, tags, rest} <- decode_tags(rest),
+             {:ok, fields, rest} <- decode_fields(rest) do
+          {:ok, %Write{value | measurement: measurement, tags: tags, fields: fields}, rest}
+        end
+      end
+
+      defp decode_measurement(input) do
+        {measure_len, rest} = Helpers.decode_leb128_u2(input)
+
+        if measure_len > 0 do
+          <<measurement::binary-size(measure_len), rest::binary>> = rest
+          {:ok, measurement, rest}
+        else
+          {:error, :invalid_measurement_name}
+        end
+      end
+
+      defp decode_tags(input) do
+        {tags_len, rest} = Helpers.decode_leb128_u2(input)
+        do_decode_tags(tags_len, rest, [])
+      end
+
+      defp do_decode_tags(0, rest, acc), do: {:ok, acc, rest}
+
+      defp do_decode_tags(n, rest, acc) do
+        {name_len, rest} = Helpers.decode_leb128_u2(rest)
+
+        if name_len > 0 do
+          <<name_str::binary-size(name_len), rest::binary>> = rest
+          {value_len, rest} = Helpers.decode_leb128_u2(rest)
+
+          if value_len > 0 do
+            <<value_str::binary-size(value_len), rest::binary>> = rest
+            do_decode_tags(n - 1, rest, [{name_str, value_str} | acc])
+          else
+            do_decode_tags(n - 1, rest, [{name_str, nil} | acc])
+          end
+        else
+          {:error, :invalid_tag_name}
+        end
+      end
+
+      defp decode_fields(input) do
+        {fields_len, rest} = Helpers.decode_leb128_u2(input)
+
+        if fields_len > 0 do
+          do_decode_fields(fields_len, rest, [])
+        else
+          {:error, :invalid_empty_fields}
+        end
+      end
+
+      defp do_decode_fields(0, rest, acc), do: {:ok, acc, rest}
+
+      defp do_decode_fields(n, rest, acc) do
+        {name_len, rest} = Helpers.decode_leb128_u2(rest)
+
+        if name_len > 0 do
+          <<name_str::binary-size(name_len), type_id::8, rest::binary>> = rest
+
+          case type_id do
+            0 ->
+              <<value::big-size(8)-unit(8), rest::binary>> = rest
+              do_decode_fields(n - 1, rest, [{name_str, value} | acc])
+
+            1 ->
+              do_decode_fields(n - 1, rest, [{name_str, true} | acc])
+
+            2 ->
+              do_decode_fields(n - 1, rest, [{name_str, false} | acc])
+
+            3 ->
+              {value_len, rest} = Helpers.decode_leb128_u2(rest)
+              <<value_str::binary-size(value_len), rest::binary>> = rest
+              do_decode_fields(n - 1, rest, [{name_str, value_str} | acc])
+
+            _ ->
+              {:error, {:invalid_type_id, type_id}}
+          end
+        else
+          {:error, :invalid_field_name}
+        end
+      end
+    end
+  end
+
+  defmodule Query do
+    defstruct [:text]
+
+    def type_id(%__MODULE__{}), do: 1
+
+    defimpl Ockam.Router.Protocol.Encoder do
+      def encode(value, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+      alias Ockam.Router.Protocol.Encoding.Default.Encode
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Services.Influx.Message.Query
+
+      def encode(%Query{text: text} = value, opts) when is_binary(text) do
+        type = Encode.i1(Query.type_id(value), opts)
+        len = Helpers.encode_leb128_u2(byte_size(text))
+        {:ok, [type, len, text]}
+      end
+    end
+
+    defimpl Ockam.Router.Protocol.Decoder do
+      def decode(value, input, opts),
+        do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+    end
+
+    defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+      alias Ockam.Router.Protocol.DecodeError
+      alias Ockam.Router.Protocol.Encoding.Default.Decoder
+      alias Ockam.Router.Protocol.Encoding.Helpers
+      alias Ockam.Services.Influx.Message.Query
+
+      def decode(value, input, _opts) do
+        {len, rest} = Helpers.decode_leb128_u2(input)
+
+        if len > 0 do
+          <<data::binary-size(len), rest::binary>> = rest
+          {:ok, %Query{value | text: data}, rest}
+        else
+          {:ok, value, rest}
+        end
+      end
+    end
+  end
+
+  def write(measurement, tags, fields) do
+    %__MODULE__{value: %Write{measurement: measurement, tags: tags, fields: fields}}
+  end
+
+  def query(text) do
+    %__MODULE__{value: %Query{text: text}}
+  end
+
+  def value(%__MODULE__{value: value}), do: value
+
+  defimpl Ockam.Router.Protocol.Encoder do
+    def encode(value, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Encoder do
+    alias Ockam.Services.Influx.Message
+
+    def encode(%Message{value: value}, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Encoder.encode(value, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Decoder do
+    def decode(value, input, opts),
+      do: Ockam.Router.Protocol.Encoding.Default.Decoder.decode(value, input, opts)
+  end
+
+  defimpl Ockam.Router.Protocol.Encoding.Default.Decoder do
+    alias Ockam.Router.Protocol.DecodeError
+    alias Ockam.Router.Protocol.Encoding.Default.Decoder
+    alias Ockam.Services.Influx.Message
+
+    def decode(value, <<type::8, input::binary>>, opts) do
+      with {:ok, message_type_mod, opts} <- message_type(type, opts),
+           {:ok, message_type, rest} <- decode_message_type(message_type_mod, input, opts) do
+        {:ok, %Message{value | value: message_type}, rest}
+      end
+    end
+
+    defp decode_message_type(mod, input, opts) do
+      Decoder.decode(struct(mod, []), input, opts)
+    end
+
+    defp message_type(0, opts), do: {:ok, Message.Write, opts}
+    defp message_type(1, opts), do: {:ok, Message.Query, opts}
+    defp message_type(n, _opts), do: {:error, DecodeError.new({__MODULE__, {:invalid_type, n}})}
+  end
+end

--- a/implementations/elixir/mix.exs
+++ b/implementations/elixir/mix.exs
@@ -25,6 +25,8 @@ defmodule Ockam.MixProject do
     [
       {:rustler, "~> 0.21"},
       {:gen_state_machine, "~> 2.1"},
+      {:fluxter, "~> 0.9"},
+      {:mint, "~> 1.0"},
       {:jason, "~> 1.1", only: [:test]}
     ]
   end

--- a/implementations/elixir/mix.lock
+++ b/implementations/elixir/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "fluxter": {:hex, :fluxter, "0.9.0", "6b4bbb7cd038ab2dd663bf3bc3c185ffb1851fdf5af9e8485dd7717d41e05e9d", [:mix], [], "hexpm", "868d3e6df5ee5831f96711c127963c7ec79b46fa2928fb0317be73065d2b01ef"},
   "gen_state_machine": {:hex, :gen_state_machine, "2.1.0", "a38b0e53fad812d29ec149f0d354da5d1bc0d7222c3711f3a0bd5aa608b42992", [:mix], [], "hexpm", "ae367038808db25cee2f2c4b8d0531522ea587c4995eb6f96ee73410a60fa06b"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fdf843bca858203ae1de16da2ee206f53416bbda5dc8c9e78f43243de4bc3afe"},
+  "mint": {:hex, :mint, "1.0.0", "ca5ab33497ba2bdcc42f6cdd3927420a6159116be87c8173658e93c8746703da", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm", "b8943ef1e630879538dd6620bfc189d4d75fab3ad39f3fe9c50539879f7efd84"},
   "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "e5429378c397f37f1091a35593b153aee1925e197c6842d04648d802edb52f80"},
   "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm", "f1e3dabef71fb510d015fad18c0e05e7c57281001141504c6b69d94e99750a07"},
 }

--- a/implementations/elixir/test/integration/handshake_test.exs
+++ b/implementations/elixir/test/integration/handshake_test.exs
@@ -61,7 +61,7 @@ defmodule Ockam.Integration.Handshake.Test do
     assert {:ok, chan, transport} =
              Channel.negotiate_secure_channel(handshake, transport, %{timeout: 10_000})
 
-    assert {:ok, message, encrypted} = Socket.recv(transport, timeout: 10_000)
+    assert {:ok, encrypted, transport} = Socket.recv(transport, timeout: 10_000)
     assert {:ok, chan, encoded} = Channel.decrypt(chan, encrypted)
     assert {:ok, %Envelope{body: %Message.Ping{}}} = Encoding.decode(encoded)
 

--- a/implementations/elixir/test/integration/influx_test.exs
+++ b/implementations/elixir/test/integration/influx_test.exs
@@ -1,0 +1,61 @@
+defmodule Ockam.Integration.Influx.Test do
+  use ExUnit.Case, async: false
+  require Logger
+
+  alias Ockam.Vault
+  alias Ockam.Transport.Socket
+  alias Ockam.Test.Support.Influx.Client
+
+  setup context do
+    {:ok, vault} = Vault.new()
+
+    _ = start_supervised!({Ockam.Registry, []})
+
+    if transport = context[:transport] do
+      # Make sure we have a router started
+      name = Map.fetch!(context, :transport_name)
+      meta = [name: name]
+      config = Map.get(context, :transport_config, [])
+      pid = start_supervised!({transport, [meta, config]})
+
+      # Start the Influx service
+      influx_meta = [
+        name: {:via, Registry, {Ockam.Registry, "influx_example", Ockam.Services.Influx}}
+      ]
+
+      influx_opts = [database: "test", http: [host: "127.0.0.1", port: 8086]]
+      _ = start_supervised!({Ockam.Services.Influx, [influx_meta, influx_opts]})
+
+      {:ok, [vault: vault, pid: pid, service: :influx_example, config: config]}
+    else
+      {:ok, [vault: vault]}
+    end
+  end
+
+  @tag skip: true
+  @tag transport: Ockam.Transport.TCP
+  @tag transport_name: :tcp_4005
+  @tag transport_config: [listen_address: "0.0.0.0", listen_port: 4005]
+  test "influx test", %{vault: vault, config: config} = context do
+    client_opts = [{:service, context[:service]} | config]
+    assert {:ok, client} = Client.new(vault, client_opts)
+    assert {:ok, client} = Client.connect(client)
+
+    # We're connected, so write a few data points
+    assert {:ok, client} = Client.write(client, "temps", [loc: "home"], temp: 72)
+    assert {:ok, client} = Client.write(client, "temps", [loc: "home"], temp: 82)
+    assert {:ok, client} = Client.write(client, "temps", [loc: "home"], temp: 76)
+
+    Process.sleep(1_000)
+
+    # Query the data we just generated
+    assert {:ok, client, results} =
+             Client.query(client, "SELECT \"temp\" FROM \"temps\" WHERE \"loc\"='home'")
+
+    assert %{:results => [%{:series => [%{:values => values}]}]} = results
+
+    refute nil == Enum.find(values, fn [_timestamp, temp] -> temp in [72, 76, 82] end)
+
+    assert {:ok, _} = client |> Client.transport() |> Socket.close()
+  end
+end

--- a/implementations/elixir/test/support/influx_client.ex
+++ b/implementations/elixir/test/support/influx_client.ex
@@ -1,0 +1,137 @@
+defmodule Ockam.Test.Support.Influx.Client do
+  import ExUnit.Assertions
+
+  alias Ockam.Channel
+  alias Ockam.Vault.KeyPair
+  alias Ockam.Vault.SecretAttributes
+  alias Ockam.Transport.Address
+  alias Ockam.Transport.Socket
+  alias Ockam.Services.Influx
+  alias Ockam.Router.Protocol.Encoding
+  alias Ockam.Router.Protocol.Encoder
+  alias Ockam.Router.Protocol.Endpoint
+  alias Ockam.Router.Protocol.Message
+  alias Ockam.Router.Protocol.Message.Envelope
+
+  defstruct [:vault, :service, :address, :chan, :transport, :timeout]
+
+  def new(vault, config) do
+    with {:ok, addr} <- Address.new(:inet, :loopback, config[:listen_port]) do
+      {:ok,
+       %__MODULE__{
+         vault: vault,
+         service: config[:service],
+         address: addr,
+         timeout: config[:timeout] || 10_000
+       }}
+    end
+  end
+
+  def connect(%__MODULE__{vault: vault, address: addr} = state) do
+    attrs = SecretAttributes.x25519(:ephemeral)
+    s = KeyPair.new(vault, attrs)
+    e = KeyPair.new(vault, attrs)
+    rs = KeyPair.new(vault, attrs)
+    re = KeyPair.new(vault, attrs)
+
+    handshake_opts = %{protocol: "Noise_XX_25519_AESGCM_SHA256", s: s, e: e, rs: rs, re: re}
+    assert {:ok, handshake} = Channel.handshake(vault, :initiator, handshake_opts)
+    socket = Socket.new(:client, addr)
+    assert {:ok, transport} = Socket.open(socket)
+
+    assert {:ok, chan, new_transport} =
+             Channel.negotiate_secure_channel(handshake, transport, %{timeout: state.timeout})
+
+    # Await ping
+    assert {:ok, encrypted, new_transport} = Socket.recv(new_transport, timeout: state.timeout)
+    assert {:ok, new_chan, encoded} = Channel.decrypt(chan, encrypted)
+    assert {:ok, %Envelope{body: %Message.Ping{}}, _} = Encoding.decode(encoded)
+
+    # Reply with pong
+    assert {:ok, encoded} = Encoding.encode(%Message.Pong{})
+    assert {:ok, new_chan, encrypted} = Channel.encrypt(new_chan, encoded)
+    assert {:ok, new_transport} = Socket.send(new_transport, encrypted)
+
+    # Initiate influx connection
+    send_to = Endpoint.new(%Endpoint.Local{data: to_string(state.service)})
+    headers = %{:send_to => send_to}
+
+    assert {:ok, encoded} = Encoding.encode(%Envelope{headers: headers, body: %Message.Connect{}})
+
+    assert {:ok, new_chan, encrypted} = Channel.encrypt(new_chan, encoded)
+    assert {:ok, new_transport} = Socket.send(new_transport, encrypted)
+
+    await_ack(%__MODULE__{state | chan: new_chan, transport: new_transport})
+  end
+
+  def write(%__MODULE__{chan: chan, transport: transport} = state, measurement, tags, fields) do
+    assert {:ok, write_encoded} =
+             Encoder.encode(
+               %Influx.Message.Write{
+                 measurement: measurement,
+                 tags: tags,
+                 fields: fields
+               },
+               %{}
+             )
+
+    assert {:ok, encoded} =
+             Encoding.encode(%Message.Send{data: IO.iodata_to_binary(write_encoded)})
+
+    assert {:ok, new_chan, encrypted} = Channel.encrypt(chan, encoded)
+    assert {:ok, new_transport} = Socket.send(transport, encrypted)
+
+    await_ack(%__MODULE__{state | chan: new_chan, transport: new_transport})
+  end
+
+  def query(%__MODULE__{chan: chan, transport: transport} = state, query_text) do
+    assert {:ok, query_encoded} = Encoder.encode(%Influx.Message.Query{text: query_text}, %{})
+
+    assert {:ok, encoded} =
+             Encoding.encode(%Message.Request{data: IO.iodata_to_binary(query_encoded)})
+
+    assert {:ok, new_chan, encrypted} = Channel.encrypt(chan, encoded)
+    assert {:ok, new_transport} = Socket.send(transport, encrypted)
+
+    await_results(%__MODULE__{state | chan: new_chan, transport: new_transport})
+  end
+
+  def transport(%__MODULE__{transport: transport}), do: transport
+
+  defp await_ack(%__MODULE__{chan: chan, transport: transport} = state) do
+    assert {:ok, encrypted, new_transport} = Socket.recv(transport, timeout: state.timeout)
+    assert {:ok, new_chan, encoded} = Channel.decrypt(chan, encrypted)
+    assert {:ok, %Envelope{body: body}, _} = Encoding.decode(encoded)
+    new_state = %__MODULE__{state | chan: new_chan, transport: new_transport}
+
+    case body do
+      %Message.Ack{} ->
+        {:ok, new_state}
+
+      %Message.Error{description: desc} ->
+        {:error, new_state, desc}
+
+      other ->
+        {:error, new_state, {:expected_ack_or_error, other}}
+    end
+  end
+
+  defp await_results(%__MODULE__{chan: chan, transport: transport} = state) do
+    assert {:ok, encrypted, new_transport} = Socket.recv(transport, timeout: state.timeout)
+    assert {:ok, new_chan, encoded} = Channel.decrypt(chan, encrypted)
+    assert {:ok, %Envelope{body: body}, _} = Encoding.decode(encoded)
+
+    new_state = %__MODULE__{state | chan: new_chan, transport: new_transport}
+
+    case body do
+      %Message.Payload{data: results} ->
+        {:ok, new_state, Jason.decode!(results, keys: :atoms)}
+
+      %Message.Error{description: desc} ->
+        {:error, new_state, desc}
+
+      other ->
+        {:error, new_state, {:expected_payload_or_error, other}}
+    end
+  end
+end


### PR DESCRIPTION
To run:

- Make sure you have Docker installed/running
- Run `implementations/elixir/influx.sh`
- Run `cd implementations/elixir && mix test --no-start
test/integration/influx_test.exs`

The way this is put together is not ideal, but works as a rough draft to
iterate from.

## NOTES

- The infrastructure I've set up to allow dispatching from the connection handler to the router, and from there to some arbitrary servicer has not been fully fleshed out so that all errors and edge cases are checked/handled/validated. It at least keeps things relatively disconnected though.
- This draft introduces four new message types `Ack`, `Error`, `Send`, and `Request`. These can obviously be changed/removed/whatever, but here's the reason for each in this PR:
  - `Ack` - used to acknowledge that a message was received and processed successfully
  - `Error` - used to indicate to the sender that an error occurred, and what it was
  - `Send` - used to indicate that the message being sent is not expected to return a value, just an acknowledgement, the sender doesn't need to wait
  - `Request` - used to indicate that the message being sent is expected to return a value and the sender will wait for it
  - `Send` and `Request` could certainly be merged, but initially I wanted to model whether or not the request was intended to produce a value that the sender wants
- This introduces a barebones Registry module used to register and locate services, such as Influx, that can be dispatched to
- The Influx service itself is modeled to reflect one way in which all services could be structured:
  - Each "connection" to a service is managed by a process dedicated to that connection, and knows about the transport-level connection that spawned it.
  - The transport-level connection will dispatch Connect requests to the router, using the endpoint of the `send_to` header to determine what to connect to. For local endpoints, the router will consult the registry for registered services by that name, and if one is found, it will relay the connection request to that service instance.
  - The service instance itself is responsible for decoding messages it can handle; this keep the lower-level protocol unaware of the service-specific message protocol, and leaves the encoding entirely up to the service itself.
  - The API for interacting with the service is described by a set of messages wrapped in a top-level message type. For example, the `Influx.Message` type wraps the `Influx.Message.Write` and `Influx.Message.Query` message types, and knows how to decode them, and also handles invalid message types. If the Influx service tries to decode a message and does not get an `Influx.Message` to dispatch on, it returns an error. Other services can easily follow this model.
- The interactions with Influx are currently happening over HTTP for testing; the Fluxter library is present, and can be wired up easily to use UDP for writing, but it does a lot of buffering/caching of things as it is designed for high-throughput use cases, so ended up not working well for simple tests like I have set up here (since there is no way to force-flush data to Influx via Fluxter).

If I've forgotten anything, feel free to ask any questions.