### PR TITLE
Added errors

### DIFF
--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -3,5 +3,8 @@
 members = [
   "crates/ockam-vault-sys",
   "crates/ockam",
-  "vault"
+]
+
+exclude = [
+    "vault"
 ]

--- a/implementations/rust/vault/Cargo.toml
+++ b/implementations/rust/vault/Cargo.toml
@@ -11,4 +11,9 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [profile.release]
 lto = true
 
+[features]
+default = []
+ffi = []
+
 [dependencies]
+failure = "0.1"

--- a/implementations/rust/vault/src/error.rs
+++ b/implementations/rust/vault/src/error.rs
@@ -1,0 +1,281 @@
+use failure::{Backtrace, Context, Fail};
+use std::{fmt, io};
+
+/// Represents the failures that can occur in
+/// an Ockam Vault
+#[derive(Clone, Copy, Fail, Debug)]
+pub enum VaultFailErrorKind {
+    /// Failed to initialize the vault
+    #[fail(display = "Failed to initialize the vault")]
+    Init,
+    /// Failed to generate random bytes
+    #[fail(display = "Failed to generate random bytes")]
+    Random,
+    /// Failed to compute SHA-256 digest
+    #[fail(display = "Failed to compute SHA-256 digest")]
+    Sha256,
+    /// Failed to generate a secret
+    #[fail(display = "Failed to generate a secret")]
+    SecretGenerate,
+    /// Failed to import a key
+    #[fail(display = "Failed to import a key")]
+    Import,
+    /// Failed to export a key
+    #[fail(display = "Failed to export a key")]
+    Export,
+    /// Failed to read attributes
+    #[fail(display = "Failed to read attributes")]
+    GetAttributes,
+    /// Failed to find the specified public key
+    #[fail(display = "Failed to find the specified public key")]
+    PublicKey,
+    /// Failed to compute elliptic curve diffie-hellman
+    #[fail(display = "Failed to compute elliptic curve diffie-hellman")]
+    Ecdh,
+    /// Failed to compute HKDF SHA-256 digest
+    #[fail(display = "Failed to compute HKDF SHA-256 digest")]
+    HkdfSha256,
+    /// Failed to encrypt data with AES-GCM
+    #[fail(display = "Failed to encrypt data with AES-GCM")]
+    AeadAesGcmEncrypt,
+    /// Failed to decrypt data with AES-GCM
+    #[fail(display = "Failed to decrypt data with AES-GCM")]
+    AeadAesGcmDecrypt,
+    /// Could not use the AES-GCM cipher scheme
+    #[fail(display = "Could not use the AES-GCM cipher scheme")]
+    AeadAesGcm,
+    /// An invalid parameter was supplied: {}
+    #[fail(display = "An invalid parameter was supplied: {}", 0)]
+    InvalidParam(usize),
+    /// Invalid attributes were specified
+    #[fail(display = "Invalid attributes were specified")]
+    InvalidAttributes,
+    /// An invalid context was supplied
+    #[fail(display = "An invalid context was supplied")]
+    InvalidContext,
+    /// An invalid buffer was supplied
+    #[fail(display = "An invalid buffer was supplied")]
+    InvalidBuffer,
+    /// An invalid size was supplied
+    #[fail(display = "An invalid size was supplied")]
+    InvalidSize,
+    /// An invalid key regeneration occurred
+    #[fail(display = "An invalid key regeneration occurred")]
+    InvalidRegenerate,
+    /// An invalid secret was supplied
+    #[fail(display = "An invalid secret was supplied")]
+    InvalidSecret,
+    /// Invalid secret attributes were supplied
+    #[fail(display = "Invalid secret attributes were supplied")]
+    InvalidSecretAttributes,
+    /// An invalid secret type was supplied that is not supported
+    #[fail(display = "An invalid secret type was supplied that is not supported")]
+    InvalidSecretType,
+    /// An invalid tag was supplied for decryption
+    #[fail(display = "An invalid tag was supplied for decryption")]
+    InvalidTag,
+    /// The supplied buffer was too small
+    #[fail(display = "The supplied buffer was too small")]
+    BufferTooSmall,
+    /// Default requires a specified random generator
+    #[fail(display = "Default requires a specified random generator")]
+    DefaultRandomRequired,
+    /// Default requires a specified memory handler
+    #[fail(display = "Default requires a specified memory handler")]
+    MemoryRequired,
+    /// The secret size specified does not match the expected value
+    #[fail(display = "The secret size specified does not match the expected value")]
+    SecretSizeMismatch,
+    /// An error occurred while reading from I/O
+    #[fail(display = "An error occurred while reading from I/O")]
+    IOError,
+}
+
+impl VaultFailErrorKind {
+    pub(crate) const ERROR_INTERFACE_VAULT: usize = 3 << 24;
+    /// Convert to an integer
+    pub fn to_usize(&self) -> usize {
+        match *self {
+            VaultFailErrorKind::Init => Self::ERROR_INTERFACE_VAULT | 1,
+            VaultFailErrorKind::Random => Self::ERROR_INTERFACE_VAULT | 2,
+            VaultFailErrorKind::Sha256 => Self::ERROR_INTERFACE_VAULT | 3,
+            VaultFailErrorKind::SecretGenerate => Self::ERROR_INTERFACE_VAULT | 4,
+            VaultFailErrorKind::Import => Self::ERROR_INTERFACE_VAULT | 5,
+            VaultFailErrorKind::Export => Self::ERROR_INTERFACE_VAULT | 6,
+            VaultFailErrorKind::GetAttributes => Self::ERROR_INTERFACE_VAULT | 7,
+            VaultFailErrorKind::PublicKey => Self::ERROR_INTERFACE_VAULT | 8,
+            VaultFailErrorKind::Ecdh => Self::ERROR_INTERFACE_VAULT | 9,
+            VaultFailErrorKind::HkdfSha256 => Self::ERROR_INTERFACE_VAULT | 10,
+            VaultFailErrorKind::AeadAesGcmEncrypt => Self::ERROR_INTERFACE_VAULT | 11,
+            VaultFailErrorKind::AeadAesGcmDecrypt => Self::ERROR_INTERFACE_VAULT | 12,
+            VaultFailErrorKind::AeadAesGcm => Self::ERROR_INTERFACE_VAULT | 13,
+            VaultFailErrorKind::InvalidParam(..) => Self::ERROR_INTERFACE_VAULT | 20,
+            VaultFailErrorKind::InvalidAttributes => Self::ERROR_INTERFACE_VAULT | 21,
+            VaultFailErrorKind::InvalidContext => Self::ERROR_INTERFACE_VAULT | 22,
+            VaultFailErrorKind::InvalidBuffer => Self::ERROR_INTERFACE_VAULT | 23,
+            VaultFailErrorKind::InvalidSize => Self::ERROR_INTERFACE_VAULT | 24,
+            VaultFailErrorKind::InvalidRegenerate => Self::ERROR_INTERFACE_VAULT | 25,
+            VaultFailErrorKind::InvalidSecret => Self::ERROR_INTERFACE_VAULT | 26,
+            VaultFailErrorKind::InvalidSecretAttributes => Self::ERROR_INTERFACE_VAULT | 27,
+            VaultFailErrorKind::InvalidSecretType => Self::ERROR_INTERFACE_VAULT | 28,
+            VaultFailErrorKind::InvalidTag => Self::ERROR_INTERFACE_VAULT | 29,
+            VaultFailErrorKind::BufferTooSmall => Self::ERROR_INTERFACE_VAULT | 30,
+            VaultFailErrorKind::DefaultRandomRequired => Self::ERROR_INTERFACE_VAULT | 31,
+            VaultFailErrorKind::MemoryRequired => Self::ERROR_INTERFACE_VAULT | 32,
+            VaultFailErrorKind::SecretSizeMismatch => Self::ERROR_INTERFACE_VAULT | 33,
+            VaultFailErrorKind::IOError => Self::ERROR_INTERFACE_VAULT | 40,
+        }
+    }
+}
+
+/// Wraps an error kind with context and backtrace logic
+#[derive(Debug)]
+pub struct VaultFailError {
+    inner: Context<VaultFailErrorKind>
+}
+
+impl VaultFailError {
+    /// Convert from an error kind and a static string
+    pub fn from_msg<D>(kind: VaultFailErrorKind, msg: D) -> Self
+    where D: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static
+    {
+        Self {
+            inner: Context::new(msg).context(kind)
+        }
+    }
+
+    /// Convert to an integer, reused in From trait implementations
+    fn to_usize(&self) -> usize {
+        self.inner.get_context().to_usize()
+    }
+}
+
+impl From<VaultFailErrorKind> for VaultFailError {
+    fn from(kind: VaultFailErrorKind) -> Self {
+        Self {
+            inner: Context::new("").context(kind)
+        }
+    }
+}
+
+impl From<VaultFailError> for VaultFailErrorKind {
+    fn from(err: VaultFailError) -> Self {
+        *err.inner.get_context()
+    }
+}
+
+impl From<io::Error> for VaultFailError {
+    fn from(err: io::Error) -> Self {
+        Self::from_msg(VaultFailErrorKind::IOError, format!("{:?}", err))
+    }
+}
+
+impl From<Context<VaultFailErrorKind>> for VaultFailError {
+    fn from(inner: Context<VaultFailErrorKind>) -> Self {
+        Self { inner }
+    }
+}
+
+macro_rules! from_int_impl {
+    ($src:ident, $ty:ty) => {
+        impl From<$src> for $ty {
+            fn from(err: $src) -> $ty {
+                err.to_usize() as $ty
+            }
+        }
+    };
+}
+
+from_int_impl!(VaultFailError, u32);
+from_int_impl!(VaultFailError, u64);
+from_int_impl!(VaultFailError, u128);
+from_int_impl!(VaultFailErrorKind, u32);
+from_int_impl!(VaultFailErrorKind, u64);
+from_int_impl!(VaultFailErrorKind, u128);
+
+impl Fail for VaultFailError {
+    fn cause(&self) -> Option<&dyn Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl fmt::Display for VaultFailError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut first = true;
+
+        for cause in Fail::iter_chain(&self.inner) {
+            if first {
+                first = false;
+                writeln!(f, "Error: {}", cause)?;
+            } else {
+                writeln!(f, "Caused by: {}", cause)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn into_unsigned() {
+        let errors = vec![
+            (VaultFailErrorKind::Init, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 1),
+            (VaultFailErrorKind::Random, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 2),
+            (VaultFailErrorKind::Sha256, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 3),
+            (VaultFailErrorKind::SecretGenerate, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 4),
+            (VaultFailErrorKind::Import, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 5),
+            (VaultFailErrorKind::Export, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 6),
+            (VaultFailErrorKind::GetAttributes, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 7),
+            (VaultFailErrorKind::PublicKey, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 8),
+            (VaultFailErrorKind::Ecdh, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 9),
+            (VaultFailErrorKind::HkdfSha256, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 10),
+            (VaultFailErrorKind::AeadAesGcmEncrypt, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 11),
+            (VaultFailErrorKind::AeadAesGcmDecrypt, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 12),
+            (VaultFailErrorKind::AeadAesGcm, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 13),
+            (VaultFailErrorKind::InvalidParam(0), VaultFailErrorKind::ERROR_INTERFACE_VAULT | 20),
+            (VaultFailErrorKind::InvalidAttributes, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 21),
+            (VaultFailErrorKind::InvalidContext, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 22),
+            (VaultFailErrorKind::InvalidBuffer, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 23),
+            (VaultFailErrorKind::InvalidSize, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 24),
+            (VaultFailErrorKind::InvalidRegenerate, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 25),
+            (VaultFailErrorKind::InvalidSecret, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 26),
+            (VaultFailErrorKind::InvalidSecretAttributes, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 27),
+            (VaultFailErrorKind::InvalidSecretType, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 28),
+            (VaultFailErrorKind::InvalidTag, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 29),
+            (VaultFailErrorKind::BufferTooSmall, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 30),
+            (VaultFailErrorKind::DefaultRandomRequired, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 31),
+            (VaultFailErrorKind::MemoryRequired, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 32),
+            (VaultFailErrorKind::SecretSizeMismatch, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 33),
+            (VaultFailErrorKind::IOError, VaultFailErrorKind::ERROR_INTERFACE_VAULT | 40),
+        ];
+
+        for err in &errors {
+            assert_eq!(err.0.to_usize(), err.1);
+            assert_eq!(Into::<u32>::into(err.0), err.1 as u32);
+            assert_eq!(Into::<u64>::into(err.0), err.1 as u64);
+            assert_eq!(Into::<u128>::into(err.0), err.1 as u128);
+
+            let verr: VaultFailError = err.0.into();
+            assert_eq!(verr.to_usize(), err.1);
+            assert_eq!(Into::<u32>::into(verr), err.1 as u32);
+            let verr: VaultFailError = err.0.into();
+            assert_eq!(Into::<u64>::into(verr), err.1 as u64);
+            let verr: VaultFailError = err.0.into();
+            assert_eq!(Into::<u128>::into(verr), err.1 as u128);
+        }
+    }
+
+    #[test]
+    fn display() {
+        let verr: VaultFailError = VaultFailErrorKind::Sha256.into();
+        let verr_str = format!("{}", verr);
+        assert_eq!("Error: Failed to compute SHA-256 digest\nCaused by: \n", verr_str.as_str());
+    }
+}

--- a/implementations/rust/vault/src/lib.rs
+++ b/implementations/rust/vault/src/lib.rs
@@ -1,0 +1,24 @@
+//! Implements the Ockam vault interface and provides
+//! a C FFI version.
+//!
+//! Vault represents a location where cryptographic keys live such
+//! as secure enclaves, TPMs, HSMs, Keyrings, files, memory, etc.
+
+#![deny(
+missing_docs,
+trivial_casts,
+trivial_numeric_casts,
+unconditional_recursion,
+unused_import_braces,
+unused_lifetimes,
+unused_qualifications,
+unused_extern_crates,
+unused_parens,
+while_true
+)]
+
+/// Represents the errors that occur within a vault
+pub mod error;
+#[cfg(feature = "ffi")]
+/// The ffi functions, structs, and constants
+pub mod ffi;


### PR DESCRIPTION
Adds crate specific error that also converts to FFI integer values found in implementations/c/include/ockam/{vault.h, error.h}