### PR TITLE
avoid string allocation to prevent memory leaks

### DIFF
--- a/implementations/c/ockam/vault/rust/tests/vault.c
+++ b/implementations/c/ockam/vault/rust/tests/vault.c
@@ -75,10 +75,10 @@ int main(void) {
     fflush(stdout);
 
     if (0 == result) {
-        printf("fail. Computed SHA-256 digest is zero\n");
+        printf("...fail. Computed SHA-256 digest is zero\n");
         goto Fail;
     } else {
-        printf("pass.\n");
+        printf("...pass.\n");
     }
 
     printf("Generate secret key...");

--- a/implementations/rust/vault/include/vault.h
+++ b/implementations/rust/vault/include/vault.h
@@ -63,7 +63,7 @@ typedef struct {
 
 typedef struct {
     ockam_vault_secret_attributes_t attributes;
-    char* handle;
+    uint64_t handle;
 } ockam_vault_secret_t;
 
 /**
@@ -240,7 +240,7 @@ uint32_t ockam_vault_aead_aes_gcm_encrypt(ockam_vault_t        vault,
  * @param   plaintext_length[out]         Amount of data placed in the plaintext buffer.
  * @return  OCKAM_ERROR_NONE on success.
  */
-uin32_t ockam_vault_aead_aes_gcm_decrypt(ockam_vault_t        vault,
+uint32_t ockam_vault_aead_aes_gcm_decrypt(ockam_vault_t        vault,
                                          ockam_vault_secret_t key,
                                          uint16_t              nonce,
                                          const uint8_t* const  additional_data,

--- a/implementations/rust/vault/src/ffi/types.rs
+++ b/implementations/rust/vault/src/ffi/types.rs
@@ -127,7 +127,7 @@ pub type VaultHandle = u64;
 /// Represents a Vault error code
 pub type VaultError = u32;
 ///
-pub type SecretKeyHandle = *mut std::os::raw::c_char;
+pub type SecretKeyHandle = u64;
 /// No error or success
 pub const ERROR_NONE: u32 = 0;
 
@@ -144,19 +144,6 @@ pub struct OckamVaultContext {
 pub struct OckamSecret {
     pub(crate) attributes: FfiSecretKeyAttributes,
     pub(crate) handle: SecretKeyHandle,
-}
-
-impl OckamSecret {
-    /// Get the string handle represented by this Secret
-    pub fn get_handle(&self) -> String {
-        if self.handle.is_null() {
-            String::new()
-        } else {
-            unsafe { std::ffi::CStr::from_ptr(self.handle) }
-                .to_string_lossy()
-                .to_string()
-        }
-    }
 }
 
 pub struct OckamSecretList(pub(crate) Vec<OckamSecret>);

--- a/implementations/rust/vault/src/types.rs
+++ b/implementations/rust/vault/src/types.rs
@@ -208,18 +208,13 @@ pub enum SecretKeyContext {
 #[cfg(feature = "ffi")]
 /// Converts the secret key context to an id that can be passed across the FFI boundary
 unsafe impl IntoFfi for SecretKeyContext {
-    type Value = *mut std::os::raw::c_char;
+    type Value = u64;
 
-    fn ffi_default() -> Self::Value {
-        std::ptr::null_mut()
-    }
+    fn ffi_default() -> Self::Value { 0 }
 
     fn into_ffi_value(self) -> Self::Value {
         match self {
-            SecretKeyContext::Memory(id) => {
-                let id_str = format!("{}", id);
-                id_str.into_ffi_value()
-            }
+            SecretKeyContext::Memory(id) => id as u64,
             _ => Self::ffi_default(),
         }
     }


### PR DESCRIPTION
Change ffi handle from C string to unsigned int 64. This removes the necessity of freeing the string handle once finished.