### PR TITLE
Transport integer casts fixes, udp test hanging fix

### DIFF
--- a/implementations/c/ockam/transport/posix_socket/socket.h
+++ b/implementations/c/ockam/transport/posix_socket/socket.h
@@ -14,6 +14,8 @@
 #include "ockam/transport/impl.h"
 #include "socket.h"
 
+// TODO: add ockam_ prefix to types declared here. Review which of them indeed need to be public.
+
 /**
  * The PosixSocket is the posix socket specific class data for a posix socket
  * connection (TCP or UDP). Note that TCP sockets are further defined by the

--- a/implementations/c/ockam/transport/posix_socket/socket_tcp.h
+++ b/implementations/c/ockam/transport/posix_socket/socket_tcp.h
@@ -8,6 +8,8 @@
 
 ockam_error_t ockam_transport_socket_tcp_init(ockam_transport_t* transport, ockam_transport_socket_attributes_t* attrs);
 
+// TODO: add ockam_ prefix to types declared here. Review which of them indeed need to be public.
+
 /**
  * One Transmission instance is assigned for each read or write
  */

--- a/implementations/c/ockam/transport/posix_socket/socket_udp.h
+++ b/implementations/c/ockam/transport/posix_socket/socket_udp.h
@@ -7,6 +7,8 @@
 ockam_error_t ockam_transport_socket_udp_init(ockam_transport_t*                   p_transport,
                                               ockam_transport_socket_attributes_t* p_cfg);
 
+// TODO: add ockam_ prefix to types declared here. Review which of them indeed need to be public.
+
 typedef struct socket_udp_ctx {
   posix_socket_t posix_socket;
 } socket_udp_ctx_t;

--- a/implementations/c/ockam/transport/posix_socket/tests/server.c
+++ b/implementations/c/ockam/transport/posix_socket/tests/server.c
@@ -1,6 +1,4 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdbool.h>
+#include <unistd.h>
 #include "ockam/log.h"
 #include "ockam/io.h"
 #include "ockam/transport.h"
@@ -25,16 +23,18 @@ int run_test_server(test_cli_params_t* p_params)
   transport_attributes.p_memory = &p_params->memory;
 
   if (p_params->run_tcp_test) {
-    printf("Running TCP Server Test\n");
+    ockam_log_debug("Running TCP Server Init");
     error = ockam_transport_socket_tcp_init(&transport, &transport_attributes);
   } else {
-    printf("Running UDP Server Test\n");
+    ockam_log_debug("Running UDP Server Init");
     error = ockam_transport_socket_udp_init(&transport, &transport_attributes);
   }
   if (error) goto exit;
 
+  ockam_log_debug("Running Server Accept");
   error = ockam_transport_accept(&transport, &p_transport_reader, &p_transport_writer, &remote_address);
   if (0 != error) goto exit;
+  ockam_log_debug("Server Accept Finished");
 
   FILE* p_file_to_receive;
   error = open_files_for_server_receive(p_params->fixture_path, &p_file_to_receive);
@@ -43,19 +43,23 @@ int run_test_server(test_cli_params_t* p_params)
   while (true) {
     size_t bytes_received = 0;
     uint8_t receive_buffer[64];
+    ockam_log_info("Server loop read start");
     error = ockam_read(p_transport_reader, receive_buffer, sizeof(receive_buffer), &bytes_received);
+    ockam_log_info("Server loop read finish");
     if ((error) && (TRANSPORT_ERROR_MORE_DATA != error)) {
       ockam_log_error("%s", "Receive failed");
       goto exit;
     }
     // Look for special "the end" buffer
     if (0 == strncmp(ENDING_LINE, (char*) receive_buffer, strlen(ENDING_LINE))) {
+      ockam_log_debug("Server loop found ending line");
       break;
     }
     else {
       size_t bytes_written = fwrite(receive_buffer, 1, bytes_received, p_file_to_receive);
       if (bytes_written != bytes_received) {
         ockam_log_error("%s", "failed write to output file");
+        error = TRANSPORT_ERROR_TEST;
         goto exit;
       }
     }
@@ -63,32 +67,49 @@ int run_test_server(test_cli_params_t* p_params)
 
   fclose(p_file_to_receive);
 
+  ockam_log_debug("Server receive finished");
+
   FILE* p_file_to_send;
   error = open_files_for_server_send(p_params->fixture_path, &p_file_to_send);
   if (error) goto exit;
+
+  int i = 0;
 
   // Send the test data file
   while (true) {
     if (feof(p_file_to_send)) {
       break;
     }
+
+    if (++i == 100) {
+      i = 0;
+      ockam_log_debug("Server send sleep start");
+      usleep(100*1000);
+      ockam_log_debug("Server send sleep finish");
+    }
+
     uint8_t send_buffer[64];
     size_t send_length = fread(send_buffer, 1, sizeof(send_buffer), p_file_to_send);
+
+    ockam_log_info("Server loop write start");
     error = ockam_write(p_transport_writer, &send_buffer[0], send_length);
     if (TRANSPORT_ERROR_NONE != error) {
       ockam_log_error("%s", "Send failed");
       goto exit;
     }
+    ockam_log_info("Server loop write finish");
   }
 
   fclose(p_file_to_send);
 
   // Send special "the end" buffer
-  error = ockam_write(p_transport_writer, (uint8_t*) "that's all", strlen("that's all") + 1);
+  error = ockam_write(p_transport_writer, (uint8_t*) ENDING_LINE, strlen(ENDING_LINE) + 1);
   if (TRANSPORT_ERROR_NONE != error) {
     ockam_log_error("%s", "Send failed");
     goto exit;
   }
+
+  ockam_log_debug("Server send finished");
 
   FILE* p_sent_file;
   FILE* p_received_file;
@@ -104,7 +125,7 @@ int run_test_server(test_cli_params_t* p_params)
   }
 
   ockam_transport_deinit(&transport);
-  printf("Server test successful!\n");
+  ockam_log_debug("Server file compare finished");
 
   fclose(p_sent_file);
   fclose(p_received_file);


### PR DESCRIPTION
1. Transport integer casts fixes: posix recv/send socket functions return ssize_t which should be checked for negative values before assigning to size_t variable, because that causes integer overflow for buffer_size variables, which can lead to all sorts of problems (including security)
2. UDP test hanging fix: udp doesn't involve acknowledges, so it's possible to send any amount of data to udp socket and this data should be put into some OS buffer, waiting for user program to get it from there. Consequently this buffer can overflow, this way receiving side won't get termination string (which is defined by our test logic) and just hang on some read(). Size of this buffer is adjusted by OS and who knows what the value is for GitHub actions. Proposed fix: add occasional delays on sending side to give receiving side some time to get data from the buffer.