### PR TITLE
fix(c): use proper field

### DIFF
--- a/implementations/c/ockam/vault/atecc608a/atecc608a.c
+++ b/implementations/c/ockam/vault/atecc608a/atecc608a.c
@@ -260,7 +260,7 @@ ockam_error_t ockam_vault_atecc608a_init(ockam_vault_t* vault, ockam_vault_atecc
 
   context->memory = attributes->memory;
 
-  if((attributes->io_protection->key == 0) ||
+  if((attributes->io_protection->key_size == 0) ||
      (attributes->io_protection->slot > VAULT_ATECC608A_NUM_SLOTS) ||
      (attributes->io_protection->key_size > g_vault_atecc608a_slot_size[attributes->io_protection->slot])) {
     error = OCKAM_VAULT_ERROR_INVALID_ATTRIBUTES;


### PR DESCRIPTION
```
/Users/mrinal/Workspace/ockam-network/codebase/ockam/implementations/c/ockam/vault/atecc608a/atecc608a.c:263:34: warning: comparison of array 'attributes->io_protection->key' equal to a null pointer is always false [-Wtautological-pointer-compare]
  if((attributes->io_protection->key == 0) ||
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~    ~
1 warning generated.
```

`io_protection->key` is an array, it is never 0.  What we actually want to check is that `io_protection->key_size` is nonzero.

```c
typedef struct {
  uint8_t key[OCKAM_VAULT_ATECC608A_IO_PROTECTION_KEY_SIZE];
  uint8_t key_size;
  uint8_t slot;
} ockam_vault_atecc608a_io_protection_t;
```

Closes #292.


Thank you for sending a pull request :heart:

### Proposed Changes
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
