### PR TITLE
docs: fix the links to proposals

### DIFF
--- a/documentation/concepts/secure_channels.md
+++ b/documentation/concepts/secure_channels.md
@@ -79,4 +79,4 @@ have end-to-end secure channels, minimizes the attack surface and helps us to bu
 better end-to-end secure and private systems.
 
 The precise design of the secure channel protocol is being discussed as part of
-Ockam Proposal [OP-0002](https://git.io/JvYxB).
+Ockam Proposal [OP-0002](https://github.com/ockam-network/proposals/tree/master/design/0002-secure-channels).

--- a/documentation/concepts/transports.md
+++ b/documentation/concepts/transports.md
@@ -24,6 +24,3 @@ Transport. Over time there will be many such implementations.
 This loose coupling between Ockam's higher level protocols and how a specific
 transport sends or receives messages allows us to design secure protocols
 that can provide consistent guarantees in complex IoT topologies.
-
-The precise design of the `Transport` interface is being discussed as part of
-Ockam Proposal [OP-0005](https://git.io/JvOLf).

--- a/documentation/concepts/vaults.md
+++ b/documentation/concepts/vaults.md
@@ -25,4 +25,4 @@ message authentication, digital signatures, Diffie-Hellman key exchange,
 authenticated encryption etc.
 
 The precise design of the `Vault` interface is being discussed as part of
-a draft Ockam Proposal [OP-000N](https://git.io/JfcYQ).
+a draft Ockam Proposal [OP-0005](https://github.com/ockam-network/proposals/tree/main/design/0005-vault-interface).


### PR DESCRIPTION
* Shortened URLs (git.io) are opaque. Replace them with actual URLs.
* vaults.md: fix broken link.
* transports.md: remove the link to nonexistent "Transport interface" proposal.