### PR TITLE
feat(elixir): add key exchange to rust <-> elixir ffi

### DIFF
--- a/implementations/e/applications/ockam_vault_software/lib/kex_rust.ex
+++ b/implementations/e/applications/ockam_vault_software/lib/kex_rust.ex
@@ -1,0 +1,84 @@
+defmodule Ockam.Kex.Rust do
+  @moduledoc """
+  Ockam.Kex.Rust
+  """
+
+  use Application
+
+  @on_load :load_natively_implemented_functions
+
+  require Logger
+
+  # Called when the Ockam application is started.
+  #
+  # This function is called when an application is started using
+  # `Application.start/2`, `Application.ensure_started/2` etc.
+  #
+  @doc false
+  def start(_type, _args) do
+    Logger.info("Starting #{__MODULE__}")
+
+    # Specifications of child processes that will be started and supervised.
+    #
+    # See the "Child specification" section in the `Supervisor` module for more
+    # detailed information.
+    children = []
+
+    # Start a supervisor with the given children. The supervisor will inturn
+    # start the given children.
+    #
+    # The :one_for_one supervision strategy is used, if a child process
+    # terminates, only that process is restarted.
+    #
+    # See the "Strategies" section in the `Supervisor` module for more
+    # detailed information.
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+  end
+
+  def load_natively_implemented_functions do
+    [:code.priv_dir(:ockam_vault_software), "native", "libockam_elixir_kex_rust"]
+    |> Path.join()
+    |> to_charlist()
+    |> :erlang.load_nif(0)
+  end
+
+  def kex_init_initiator(_a) do
+    raise "natively implemented kex_init_initiator/1 not loaded"
+  end
+
+  def kex_init_responder(_a) do
+    raise "natively implemented kex_init_responder/1 not loaded"
+  end
+
+  def kex_initiator_encode_message_1(_a, _b) do
+    raise "natively implemented kex_initiator_encode_message_1/2 not loaded"
+  end
+
+  def kex_responder_encode_message_2(_a, _b) do
+    raise "natively implemented kex_responder_encode_message_2/2 not loaded"
+  end
+
+  def kex_initiator_encode_message_3(_a, _b) do
+    raise "natively implemented kex_initiator_encode_message_3/2 not loaded"
+  end
+
+  def kex_responder_decode_message_1(_a, _b) do
+    raise "natively implemented kex_responder_decode_message_1/2 not loaded"
+  end
+
+  def kex_initiator_decode_message_2(_a, _b) do
+    raise "natively implemented kex_initiator_decode_message_2/2 not loaded"
+  end
+
+  def kex_responder_decode_message_3(_a, _b) do
+    raise "natively implemented kex_responder_decode_message_3/2 not loaded"
+  end
+
+  def kex_initiator_finalize(_a) do
+    raise "natively implemented kex_initiator_finalize/1 not loaded"
+  end
+
+  def kex_responder_finalize(_a) do
+    raise "natively implemented kex_responder_finalize/1 not loaded"
+  end
+end

--- a/implementations/e/applications/ockam_vault_software/native/vault/key_exchange/CMakeLists.txt
+++ b/implementations/e/applications/ockam_vault_software/native/vault/key_exchange/CMakeLists.txt
@@ -1,0 +1,50 @@
+
+# ---
+# ockam::ex_interface
+# ---
+add_library(ockam_kex_interface INTERFACE)
+add_library(ockam::kex_interface ALIAS ockam_kex_interface)
+
+set(INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+
+target_include_directories(ockam_kex_interface INTERFACE ${INCLUDE_DIR})
+
+file(COPY ../../../../../../rust/kex/include/kex.h DESTINATION ${INCLUDE_DIR}/ockam)
+
+target_sources(
+  ockam_kex_interface
+  INTERFACE
+    ${INCLUDE_DIR}/ockam/kex.h
+)
+
+# ---
+# ockam::kex_rust
+# ---
+add_library(ockam_kex SHARED IMPORTED GLOBAL)
+add_library(ockam::kex ALIAS ockam_kex)
+
+set(kex_dylib_path ../../../../../../rust/target/debug/libockam_kex.dylib)
+get_filename_component(real_kex_dylib_path "${kex_dylib_path}" REALPATH BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+set_target_properties(
+  ockam_kex
+  PROPERTIES
+    IMPORTED_LOCATION "${real_kex_dylib_path}"
+)
+
+# ---
+# ockam::elixir_kex_rust
+# ---
+add_library(ockam_elixir_kex_rust)
+add_library(ockam::elixir_kex_rust ALIAS ockam_elixir_kex_rust)
+
+target_sources(ockam_elixir_kex_rust PRIVATE nifs.c)
+
+target_include_directories(ockam_elixir_kex_rust PUBLIC $ENV{ERL_INCLUDE_DIR})
+set_target_properties(ockam_elixir_kex_rust PROPERTIES LINK_FLAGS "-dynamiclib -undefined dynamic_lookup")
+
+target_link_libraries(
+  ockam_elixir_kex_rust
+  PUBLIC
+    ockam::kex_interface
+    ockam::kex
+)

--- a/implementations/e/applications/ockam_vault_software/native/vault/key_exchange/nifs.c
+++ b/implementations/e/applications/ockam_vault_software/native/vault/key_exchange/nifs.c
@@ -1,0 +1,302 @@
+#include <string.h>
+#include "erl_nif.h"
+#include "ockam/kex.h"
+
+// FIXME: Allocate memory chunk of exact size before each encode
+static const size_t MAX_KEX_MESSAGE_SIZE = 1024;
+
+static ERL_NIF_TERM ok_void(ErlNifEnv *env) {
+    return enif_make_atom(env, "ok");
+}
+
+static ERL_NIF_TERM ok(ErlNifEnv *env, ERL_NIF_TERM result) {
+    ERL_NIF_TERM id = enif_make_atom(env, "ok");
+    return enif_make_tuple2(env, id, result);
+}
+
+static ERL_NIF_TERM err(ErlNifEnv *env, const char* msg) {
+    ERL_NIF_TERM e = enif_make_atom(env, "error");
+    ERL_NIF_TERM m = enif_make_string(env, msg, 0);
+    return enif_make_tuple2(env, e, m);
+}
+
+static ERL_NIF_TERM kex_init_initiator(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (1 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 vault_handle;
+    if (0 == enif_get_uint64(env, argv[0], &vault_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ockam_kex_initiator_t initiator_handle;
+
+    if (0 != ockam_kex_xx_initiator(&initiator_handle, vault_handle)) {
+        return err(env, "failed to kex_init_initiator");
+    }
+
+    ERL_NIF_TERM kex_handle_term = enif_make_uint64(env, initiator_handle);
+
+    return ok(env, kex_handle_term);
+}
+
+static ERL_NIF_TERM kex_init_responder(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (1 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 vault_handle;
+    if (0 == enif_get_uint64(env, argv[0], &vault_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ockam_kex_responder_t responder_handle;
+
+    if (0 != ockam_kex_xx_responder(&responder_handle, vault_handle)) {
+        return err(env, "failed to kex_init_responder");
+    }
+
+    ERL_NIF_TERM kex_handle_term = enif_make_uint64(env, responder_handle);
+
+    return ok(env, kex_handle_term);
+}
+
+static ERL_NIF_TERM kex_initiator_encode_message_1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (2 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 initiator_handle;
+    if (0 == enif_get_uint64(env, argv[0], &initiator_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary payload;
+    if (0 == enif_inspect_binary(env, argv[1], &payload)) {
+        return enif_make_badarg(env);
+    }
+
+    uint8_t buffer[MAX_KEX_MESSAGE_SIZE];
+    size_t length = 0;
+
+    if (0 != ockam_kex_xx_initiator_encode_message_1(initiator_handle,
+                                                     payload.data,
+                                                     payload.size,
+                                                     buffer,
+                                                     MAX_KEX_MESSAGE_SIZE,
+                                                     &length)) {
+        return err(env, "failed to kex_initiator_encode_message_1");
+    }
+
+    ERL_NIF_TERM output;
+    uint8_t* bytes = enif_make_new_binary(env, length, &output);
+
+    if (0 == bytes) {
+        return err(env, "failed to create buffer for kex_initiator_encode_message_1");
+    }
+    memcpy(bytes, buffer, length);
+
+    return ok(env, output);
+}
+
+static ERL_NIF_TERM kex_responder_encode_message_2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (2 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 responder_handle;
+    if (0 == enif_get_uint64(env, argv[0], &responder_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary payload;
+    if (0 == enif_inspect_binary(env, argv[1], &payload)) {
+        return enif_make_badarg(env);
+    }
+
+    uint8_t buffer[MAX_KEX_MESSAGE_SIZE];
+    size_t length = 0;
+
+    if (0 != ockam_kex_xx_responder_encode_message_2(responder_handle,
+                                                     payload.data,
+                                                     payload.size,
+                                                     buffer,
+                                                     MAX_KEX_MESSAGE_SIZE,
+                                                     &length)) {
+        return err(env, "failed to kex_responder_encode_message_2");
+    }
+
+    ERL_NIF_TERM output;
+    uint8_t* bytes = enif_make_new_binary(env, length, &output);
+
+    if (0 == bytes) {
+        return err(env, "failed to create buffer for kex_responder_encode_message_2");
+    }
+    memcpy(bytes, buffer, length);
+
+    return ok(env, output);
+}
+
+static ERL_NIF_TERM kex_initiator_encode_message_3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (2 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 initiator_handle;
+    if (0 == enif_get_uint64(env, argv[0], &initiator_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary payload;
+    if (0 == enif_inspect_binary(env, argv[1], &payload)) {
+        return enif_make_badarg(env);
+    }
+
+    uint8_t buffer[MAX_KEX_MESSAGE_SIZE];
+    size_t length = 0;
+
+    if (0 != ockam_kex_xx_initiator_encode_message_3(initiator_handle,
+                                                     payload.data,
+                                                     payload.size,
+                                                     buffer,
+                                                     MAX_KEX_MESSAGE_SIZE,
+                                                     &length)) {
+        return err(env, "failed to kex_initiator_encode_message_3");
+    }
+
+    ERL_NIF_TERM output;
+    uint8_t* bytes = enif_make_new_binary(env, length, &output);
+
+    if (0 == bytes) {
+        return err(env, "failed to create buffer for kex_initiator_encode_message_3");
+    }
+    memcpy(bytes, buffer, length);
+
+    return ok(env, output);
+}
+
+static ERL_NIF_TERM kex_responder_decode_message_1(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (2 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 responder_handle;
+    if (0 == enif_get_uint64(env, argv[0], &responder_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary m1;
+    if (0 == enif_inspect_binary(env, argv[1], &m1)) {
+        return enif_make_badarg(env);
+    }
+
+    if (0 != ockam_kex_xx_responder_decode_message_1(responder_handle, m1.data, m1.size)) {
+        return err(env, "failed to kex_responder_decode_message_1");
+    }
+
+    return ok_void(env);
+}
+
+static ERL_NIF_TERM kex_initiator_decode_message_2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (2 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 initiator_handle;
+    if (0 == enif_get_uint64(env, argv[0], &initiator_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary m2;
+    if (0 == enif_inspect_binary(env, argv[1], &m2)) {
+        return enif_make_badarg(env);
+    }
+
+    if (0 != ockam_kex_xx_initiator_decode_message_2(initiator_handle, m2.data, m2.size)) {
+        return err(env, "failed to kex_initiator_decode_message_2");
+    }
+
+    return ok_void(env);
+}
+
+static ERL_NIF_TERM kex_responder_decode_message_3(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (2 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 responder_handle;
+    if (0 == enif_get_uint64(env, argv[0], &responder_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary m3;
+    if (0 == enif_inspect_binary(env, argv[1], &m3)) {
+        return enif_make_badarg(env);
+    }
+
+    if (0 != ockam_kex_xx_responder_decode_message_3(responder_handle, m3.data, m3.size)) {
+        return err(env, "failed to kex_responder_decode_message_3");
+    }
+
+    return ok_void(env);
+}
+
+static ERL_NIF_TERM kex_initiator_finalize(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (1 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 initiator_handle;
+    if (0 == enif_get_uint64(env, argv[0], &initiator_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ockam_kex_t kex;
+
+    if (0 != ockam_kex_xx_initiator_finalize(initiator_handle, &kex)) {
+        return err(env, "failed to kex_initiator_finalize");
+    }
+
+    ERL_NIF_TERM kex_handle_term = enif_make_uint64(env, kex);
+
+    return ok(env, kex_handle_term);
+}
+
+static ERL_NIF_TERM kex_responder_finalize(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+    if (1 != argc) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifUInt64 responder_handle;
+    if (0 == enif_get_uint64(env, argv[0], &responder_handle)) {
+        return enif_make_badarg(env);
+    }
+
+    ockam_kex_t kex;
+
+    if (0 != ockam_kex_xx_responder_finalize(responder_handle, &kex)) {
+        return err(env, "failed to ockam_kex_xx_responder_finalize");
+    }
+
+    ERL_NIF_TERM kex_handle_term = enif_make_uint64(env, kex);
+
+    return ok(env, kex_handle_term);
+}
+
+
+static ErlNifFunc nifs[] = {
+  // {erl_function_name, erl_function_arity, c_function}
+  {"kex_init_initiator", 1, kex_init_initiator},
+  {"kex_init_responder", 1, kex_init_responder},
+  {"kex_initiator_encode_message_1", 2, kex_initiator_encode_message_1},
+  {"kex_responder_encode_message_2", 2, kex_responder_encode_message_2},
+  {"kex_initiator_encode_message_3", 2, kex_initiator_encode_message_3},
+  {"kex_responder_decode_message_1", 2, kex_responder_decode_message_1},
+  {"kex_initiator_decode_message_2", 2, kex_initiator_decode_message_2},
+  {"kex_responder_decode_message_3", 2, kex_responder_decode_message_3},
+  {"kex_initiator_finalize", 1, kex_initiator_finalize},
+  {"kex_responder_finalize", 1, kex_responder_finalize},
+};
+
+ERL_NIF_INIT(Elixir.Ockam.Kex.Rust, nifs, NULL, NULL, NULL, NULL)

--- a/implementations/e/applications/ockam_vault_software/test/kex_rust_test.exs
+++ b/implementations/e/applications/ockam_vault_software/test/kex_rust_test.exs
@@ -1,0 +1,26 @@
+defmodule Ockam.Kex.Rust.Tests do
+  use ExUnit.Case, async: true
+  doctest Ockam.Kex.Rust
+
+  describe "Ockam.Kex.Rust.init/1" do
+    test "can run natively implemented functions" do
+      {:ok, initiator_vault_handle} = Ockam.Vault.Software.default_init
+      {:ok, initiator_handle} = Ockam.Kex.Rust.kex_init_initiator(initiator_vault_handle)
+
+      {:ok, responder_vault_handle} = Ockam.Vault.Software.default_init
+      {:ok, responder_handle} = Ockam.Kex.Rust.kex_init_responder(responder_vault_handle)
+
+      {:ok, m1} = Ockam.Kex.Rust.kex_initiator_encode_message_1(initiator_handle, "payload1");
+      :ok = Ockam.Kex.Rust.kex_responder_decode_message_1(responder_handle, m1);
+
+      {:ok, m2} = Ockam.Kex.Rust.kex_responder_encode_message_2(responder_handle, "payload2");
+      :ok = Ockam.Kex.Rust.kex_initiator_decode_message_2(initiator_vault_handle, m2);
+
+      {:ok, m3} = Ockam.Kex.Rust.kex_initiator_encode_message_3(initiator_handle, "payload3");
+      :ok = Ockam.Kex.Rust.kex_responder_decode_message_3(responder_handle, m3);
+
+      {:ok, initiator} = Ockam.Kex.Rust.kex_initiator_finalize(initiator_handle);
+      {:ok, responder} = Ockam.Kex.Rust.kex_responder_finalize(responder_handle);
+    end
+  end
+end

--- a/implementations/rust/kex/include/kex.h
+++ b/implementations/rust/kex/include/kex.h
@@ -1,0 +1,64 @@
+//
+// Created by Oleksandr Deundiak on 10.09.2020.
+//
+
+#ifndef RUST_KEY_EXCHANGE_H
+#define RUST_KEY_EXCHANGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint64_t ockam_vault_t;
+typedef uint64_t ockam_kex_initiator_t;
+typedef uint64_t ockam_kex_responder_t;
+typedef uint64_t ockam_kex_t;
+typedef uint64_t ockam_vault_secret_t;
+
+uint32_t ockam_kex_xx_initiator(ockam_kex_initiator_t* kex_initiator, ockam_vault_t vault);
+uint32_t ockam_kex_xx_responder(ockam_kex_responder_t* kex_responder, ockam_vault_t vault);
+
+uint32_t ockam_kex_xx_initiator_encode_message_1(ockam_kex_initiator_t kex_initiator,
+                                                 const uint8_t* payload,
+                                                 size_t payload_length,
+                                                 uint8_t* m1,
+                                                 size_t m1_size,
+                                                 size_t* m1_length);
+
+uint32_t ockam_kex_xx_responder_encode_message_2(ockam_kex_responder_t kex_responder,
+                                                 const uint8_t* payload,
+                                                 size_t payload_length,
+                                                 uint8_t* m2,
+                                                 size_t m2_size,
+                                                 size_t* m2_length);
+
+uint32_t ockam_kex_xx_initiator_encode_message_3(ockam_kex_initiator_t kex_initiator,
+                                                 const uint8_t* payload,
+                                                 size_t payload_length,
+                                                 uint8_t* m3,
+                                                 size_t m3_size,
+                                                 size_t* m3_length);
+
+uint32_t ockam_kex_xx_responder_decode_message_1(ockam_kex_responder_t kex_responder,
+                                                 const uint8_t* m1,
+                                                 size_t m1_length);
+
+uint32_t ockam_kex_xx_initiator_decode_message_2(ockam_kex_initiator_t kex_initiator,
+                                                 const uint8_t* m2,
+                                                 size_t m2_length);
+
+uint32_t ockam_kex_xx_responder_decode_message_3(ockam_kex_responder_t kex_responder,
+                                                 const uint8_t* m3,
+                                                 size_t m3_length);
+
+uint32_t ockam_kex_xx_initiator_finalize(ockam_kex_initiator_t kex_initiator,
+                                         ockam_kex_t* kex);
+
+uint32_t ockam_kex_xx_responder_finalize(ockam_kex_responder_t kex_responder,
+                                         ockam_kex_t* kex);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif //RUST_KEY_EXCHANGE_H

--- a/implementations/rust/kex/src/error.rs
+++ b/implementations/rust/kex/src/error.rs
@@ -26,3 +26,10 @@ impl ErrorKind for KeyExchangeFailErrorKind {
         }
     }
 }
+
+#[cfg(feature = "ffi")]
+impl From<KeyExchangeFailErrorKind> for ffi_support::ExternError {
+    fn from(err: KeyExchangeFailErrorKind) -> ffi_support::ExternError {
+        ffi_support::ExternError::new_error(ffi_support::ErrorCode::new(err.to_usize() as i32), "")
+    }
+}

--- a/implementations/rust/kex/src/ffi/mod.rs
+++ b/implementations/rust/kex/src/ffi/mod.rs
@@ -1,0 +1,252 @@
+use crate::error::KeyExchangeFailErrorKind;
+use ffi_support::{ByteBuffer, ConcurrentHandleMap, ExternError, IntoFfi};
+
+mod types;
+
+use crate::{Initiator, Responder, XXSymmetricState};
+use ockam_vault::software::DefaultVault;
+use types::*;
+
+fn write_bin_to_buffer(
+    bin: &[u8],
+    buffer: &mut u8,
+    buffer_size: u32,
+    buffer_length: &mut u32,
+) -> KexError {
+    if (buffer_size as usize) < bin.len() {
+        1
+    } else {
+        *buffer_length = bin.len() as u32;
+        unsafe { std::ptr::copy_nonoverlapping(bin.as_ptr(), buffer, bin.len()) };
+        ERROR_NONE
+    }
+}
+
+/// Create a new kex initiator and return it
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_initiator(context: &mut u64, vault: u64) -> KexError {
+    // TODO: obtain vault from storage using handle
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+
+    // TODO: put initiator into storage and return proper handle
+    let initiator = Initiator::new(state);
+    *context = 0;
+
+    ERROR_NONE
+}
+
+/// Create a new kex responder and return it
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_responder(context: &mut u64, vault: u64) -> KexError {
+    // TODO: obtain vault from storage using handle
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+
+    // TODO: put responder into storage and return proper handle
+    let responder = Responder::new(state);
+    *context = 0;
+
+    ERROR_NONE
+}
+
+/// Initiator encodes message 1
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_initiator_encode_message_1(
+    context: u64,
+    payload: *const u8,
+    payload_length: u32,
+    m1: &mut u8,
+    m1_size: u32,
+    m1_length: &mut u32,
+) -> KexError {
+    // TODO: obtain initiator from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut initiator = Initiator::new(state);
+
+    let payload = unsafe { std::slice::from_raw_parts(payload, payload_length as usize) };
+
+    let message1 = match initiator.encode_message_1(payload) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+
+    write_bin_to_buffer(&message1, m1, m1_size, m1_length)
+}
+
+/// Responder encodes message 2
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_responder_encode_message_2(
+    context: u64,
+    payload: *const u8,
+    payload_length: u32,
+    m2: &mut u8,
+    m2_size: u32,
+    m2_length: &mut u32,
+) -> KexError {
+    // TODO: obtain responder from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut responder = Responder::new(state);
+
+    let payload = unsafe { std::slice::from_raw_parts(payload, payload_length as usize) };
+
+    let message2 = match responder.encode_message_2(payload) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+
+    write_bin_to_buffer(&message2, m2, m2_size, m2_length)
+}
+
+/// Initiator encodes message 3
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_initiator_encode_message_3(
+    context: u64,
+    payload: *const u8,
+    payload_length: u32,
+    m3: &mut u8,
+    m3_size: u32,
+    m3_length: &mut u32,
+) -> KexError {
+    // TODO: obtain initiator from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut initiator = Initiator::new(state);
+
+    let payload = unsafe { std::slice::from_raw_parts(payload, payload_length as usize) };
+
+    let message3 = match initiator.encode_message_3(payload) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+
+    write_bin_to_buffer(&message3, m3, m3_size, m3_length)
+}
+
+/// Responder decodes message 1
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_responder_decode_message_1(
+    context: u64,
+    m1: *const u8,
+    m1_length: u32,
+) -> KexError {
+    // TODO: obtain responder from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut responder = Responder::new(state);
+
+    let message1 = unsafe { std::slice::from_raw_parts(m1, m1_length as usize) };
+
+    match responder.decode_message_1(message1) {
+        Ok(_) => ERROR_NONE,
+        Err(_) => 1,
+    }
+}
+
+/// Initiator decodes message 2
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_initiator_decode_message_2(
+    context: u64,
+    m2: *const u8,
+    m2_length: u32,
+) -> KexError {
+    // TODO: obtain initiator from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut initiator = Initiator::new(state);
+
+    let message2 = unsafe { std::slice::from_raw_parts(m2, m2_length as usize) };
+
+    match initiator.decode_message_2(message2) {
+        Ok(_) => ERROR_NONE,
+        Err(_) => 1,
+    }
+}
+
+/// Responder decodes message 3
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_responder_decode_message_3(
+    context: u64,
+    m3: *const u8,
+    m3_length: u32,
+) -> KexError {
+    // TODO: obtain responder from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut responder = Responder::new(state);
+
+    let message3 = unsafe { std::slice::from_raw_parts(m3, m3_length as usize) };
+
+    match responder.decode_message_3(message3) {
+        Ok(_) => ERROR_NONE,
+        Err(_) => 1,
+    }
+}
+
+/// Finalize initiator
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_initiator_finalize(context: u64, kex: &mut u64) -> KexError {
+    // TODO: obtain initiator from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut initiator = Initiator::new(state);
+
+    // TODO: Can we use vault from Initiator?
+    let mut vault2 = DefaultVault::default();
+    match initiator.finalize(&mut vault2) {
+        Ok(r) => *kex = 0, // TODO: Set proper context
+        Err(_) => return 1,
+    };
+
+    ERROR_NONE
+}
+
+/// Finalize responder
+#[no_mangle]
+pub extern "C" fn ockam_kex_xx_responder_finalize(context: u64, kex: &mut u64) -> KexError {
+    // TODO: obtain initiator from storage
+    let mut vault = DefaultVault::default();
+    let state = match XXSymmetricState::prologue(&mut vault) {
+        Ok(r) => r,
+        Err(_) => return 1,
+    };
+    let mut responder = Responder::new(state);
+
+    // TODO: Can we use vault from Initiator?
+    let mut vault2 = DefaultVault::default();
+    match responder.finalize(&mut vault2) {
+        Ok(r) => *kex = 0, // TODO: Set proper context
+        Err(_) => return 1,
+    };
+
+    ERROR_NONE
+}

--- a/implementations/rust/kex/src/ffi/types.rs
+++ b/implementations/rust/kex/src/ffi/types.rs
@@ -1,0 +1,4 @@
+/// Represents a kex error code
+pub type KexError = u32;
+/// No error or success
+pub const ERROR_NONE: u32 = 0;

--- a/implementations/rust/kex/src/lib.rs
+++ b/implementations/rust/kex/src/lib.rs
@@ -25,6 +25,10 @@ use ockam_vault::{
     Vault,
 };
 
+#[cfg(feature = "ffi")]
+/// FFI module
+pub mod ffi;
+
 /// The maximum bytes that will be transmitted in a single message
 pub const MAX_XX_TRANSMIT_SIZE: usize = 16384;
 /// The number of bytes in a SHA256 digest
@@ -276,6 +280,8 @@ impl<'a, V: Vault> Initiator<'a, V> {
         &mut self,
         message: B,
     ) -> Result<Vec<u8>, VaultFailError> {
+        /// FIXME: Shouldn't we provide decode functions with payload
+        /// FIXME: that will be compared to what's in message?
         let message = message.as_ref();
         let mut re = [0u8; 32];
         re.copy_from_slice(&message[..32]);


### PR DESCRIPTION
This PR adds following:
1. C header with kex interface for nifs
2. C nifs
3. Elixir functions for nifs
4. 1 very basic elixir test
5. Placeholders for all kex rust ffi functions

What needs to be done:
1. Improve storage for ffi instances, so that vault handle could be used as a dependency to rust kex
2. Finish rust ffi layer (should be pretty straightforward after 1 is done)