### PR TITLE
refactor(rust): remove some std dependencies, update message_handler per design spec

### DIFF
--- a/implementations/rust/router/src/router.rs
+++ b/implementations/rust/router/src/router.rs
@@ -61,13 +61,13 @@ pub mod router {
                 return Err("Not Implemented".to_string());
             }
 
-            let handler_ref: Arc<Mutex<dyn MessageHandler+Send>>;
+            let handler_ref: Arc<Mutex<dyn MessageHandler + Send>>;
             match self.registry.get_mut(&key) {
                 Some(r) => {
                     handler_ref = Arc::clone(r);
                     match handler_ref.lock().unwrap().message_handler(m, address) {
-                        Ok(()) => { Ok(()) },
-                        Err(s) => { Err("message_handler failed".to_string()) },
+                        Ok(()) => Ok(()),
+                        Err(s) => Err("message_handler failed".to_string()),
                     }
                 }
                 None => Err("key not found".to_string()),

--- a/implementations/rust/router/src/router.rs
+++ b/implementations/rust/router/src/router.rs
@@ -61,15 +61,14 @@ pub mod router {
                 return Err("Not Implemented".to_string());
             }
 
+            let handler_ref: Arc<Mutex<dyn MessageHandler+Send>>;
             match self.registry.get_mut(&key) {
                 Some(r) => {
-                    let r = Arc::clone(r);
-                    let j: thread::JoinHandle<_> = thread::spawn(move || {
-                        r.lock().unwrap().message_handler(m, address);
-                    });
-
-                    j.join().expect("panic");
-                    Ok(())
+                    handler_ref = Arc::clone(r);
+                    match handler_ref.lock().unwrap().message_handler(m, address) {
+                        Ok(()) => { Ok(()) },
+                        Err(s) => { Err("message_handler failed".to_string()) },
+                    }
                 }
                 None => Err("key not found".to_string()),
             }

--- a/implementations/rust/router/src/router.rs
+++ b/implementations/rust/router/src/router.rs
@@ -145,7 +145,7 @@ mod tests {
         });
         let mut router: Router = Router::new();
         let udp_socket = UdpSocket::bind("127.0.0.1:4050").expect("couldn't bind to address");
-        let udp_handler: Arc<Mutex<MessageHandler + Send>> =
+        let udp_handler: Arc<Mutex<dyn MessageHandler + Send>> =
             Arc::new(Mutex::new(TestUdpHandler { socket: udp_socket }));
         match router.register_handler(udp_handler, AddressType::Udp) {
             Ok(()) => {

--- a/implementations/rust/transport/src/transport.rs
+++ b/implementations/rust/transport/src/transport.rs
@@ -1,24 +1,86 @@
 #[allow(unused)]
 
 pub mod transport {
+    use ockam_message::message::Address::UdpAddress;
+    use ockam_message::message::AddressType::Udp;
     use ockam_message::message::{Address, Message};
     use ockam_router::router::MessageHandler;
-    use std::collections::HashMap;
-    use std::net::UdpSocket;
+    use std::io::{Read, Write};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::net::{SocketAddrV4, UdpSocket};
+    use std::str::FromStr;
+    use std::sync::Arc;
 
-    pub struct UdpAddressHandler {
-        pub socket: UdpSocket,
+    pub struct UdpConnection {
+        socket: UdpSocket,
     }
 
-    impl MessageHandler for UdpAddressHandler {
-        fn message_handler(
-            &self,
-            mut m: Box<Message>,
-            address: Address,
-        ) -> Result<(), std::io::Error> {
-            println!("In UdpAddressHandler!");
-            Ok(())
+    impl UdpConnection {
+        pub fn new(local: &str, remote: &str) -> Result<UdpConnection, String> {
+            let mut socket = UdpSocket::bind(local).expect("couldn't bind to local socket");
+            let remote_socket = SocketAddrV4::from_str(remote).expect("bad remote address");
+            match socket.connect(remote_socket) {
+                Ok(s) => Ok(UdpConnection { socket }),
+                Err(_a) => Err("couldn't connect to remote address".to_string()),
+            }
         }
+
+        pub fn send(&mut self, buff: &[u8]) -> Result<usize, String> {
+            match self.socket.send(buff) {
+                Ok(s) => Ok(s),
+                Err(_0) => Err("udp send failed".to_string()),
+            }
+        }
+        pub fn receive(&mut self, buff: &mut [u8]) -> Result<usize, String> {
+            match self.socket.recv(buff) {
+                Ok(s) => Ok(s),
+                Err(_0) => Err("udp receive failed".to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::transport::*;
+    use std::net::UdpSocket;
+    use std::{thread, time};
+
+    fn recv_thread(addr: &str) {
+        let socket = UdpSocket::bind(addr).expect("couldn't bind to local socket");
+        let mut buff: [u8; 100] = [0; 100];
+        println!("calling recv");
+        match socket.recv(&mut buff) {
+            Ok(n) => println!(
+                "received {} bytes: {}",
+                n,
+                std::str::from_utf8(&buff).expect("bad string")
+            ),
+            Err(_0) => println!("receive failed"),
+        }
+    }
+
+    #[test]
+    fn test_connect() {
+        let j: thread::JoinHandle<_> = thread::spawn(|| {
+            //println!("spawned");
+            recv_thread("127.0.0.1:4051")
+        });
+
+        let half_sec = time::Duration::from_millis(500);
+        thread::sleep(half_sec);
+
+        match UdpConnection::new("127.0.0.1:4050", "127.0.0.1:4051") {
+            Ok(mut t) => {
+                println!("Connected");
+                let buff = "hello ockam".as_bytes();
+                match t.send(buff) {
+                    Ok(s) => println!("Sent {} bytes: {}", s, "hello ockam"),
+                    Err(_e) => println!("Send failed"),
+                }
+            }
+            Err(s) => println!("Failed to connect {}", s),
+        }
+        j.join().expect("panic");
     }
 }


### PR DESCRIPTION

- router: change registry from hashmap to array, removes std::hashmap
          dependency
- router: remove address from message_handler signature
- router: pass entire route to message handler (don't pop first address)
- address: remove address length from local address, add type to addresses