### PR TITLE
mrinal/umbrella

### DIFF
--- a/implementations/e/applications/ockam/lib/ockam/router/address.ex
+++ b/implementations/e/applications/ockam/lib/ockam/router/address.ex
@@ -22,5 +22,8 @@ defprotocol Ockam.Router.Address do
 end
 
 defimpl Ockam.Router.Address, for: Any do
+  import Ockam.Router.Guards
+
+  def type({address_type, _}) when is_address_type(address_type), do: address_type
   def type(_address), do: nil
 end

--- a/implementations/e/applications/ockam/lib/ockam/router/gaurds.ex
+++ b/implementations/e/applications/ockam/lib/ockam/router/gaurds.ex
@@ -11,7 +11,7 @@ defmodule Ockam.Router.Guards do
   Allowed in guard tests. Inlined by the compiler.
   """
   @doc guard: true
-  defguard is_address_type(term) when is_integer(term) and term >= 0 and term <= 65_535
+  defguard is_address_type(term) when is_integer(term) and term >= 0 and term <= 255
 
   @doc """
   Returns `true` if `term` is a valid `t:Ockam.Router.Message.t/0`;


### PR DESCRIPTION
- refactor(elixir): fix router address type guard range
- refactor(elixir): define router address type fallback for a two tuple
