### PR TITLE
feat(rust): implement basic node, test basic routing and udp transport

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -277,6 +277,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+
+[[package]]
+name = "futures-task"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +533,34 @@ name = "ockam-message"
 version = "0.1.0"
 
 [[package]]
+name = "ockam-node"
+version = "0.1.0"
+dependencies = [
+ "ockam-common",
+ "ockam-message",
+ "ockam-router",
+ "ockam-transport",
+]
+
+[[package]]
+name = "ockam-router"
+version = "0.1.0"
+dependencies = [
+ "ockam-common",
+ "ockam-message",
+]
+
+[[package]]
+name = "ockam-transport"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "ockam-common",
+ "ockam-message",
+ "ockam-router",
+]
+
+[[package]]
 name = "ockam-vault"
 version = "0.1.0"
 dependencies = [
@@ -455,6 +584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +603,32 @@ checksum = "1909a5a44a469f7d21c8dec2c634721ba15379b6cad80040d16abfaa8609b37c"
 dependencies = [
  "elliptic-curve",
 ]
+
+[[package]]
+name = "pin-project"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "polyval"
@@ -484,6 +645,18 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -591,6 +764,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "subtle"

--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "kex",
     "message",
     "vault",
-    # "router",
-    # "transport",
-    # "node",
+    "router",
+    "transport",
+    "node",
 ]

--- a/implementations/rust/common/src/commands.rs
+++ b/implementations/rust/common/src/commands.rs
@@ -1,24 +1,36 @@
 #[allow(unused)]
 pub mod commands {
-    use ockam_message::message::{AddressType, Message};
+    use ockam_message::message::{AddressType, Message, Route};
     use std::thread;
 
-    // Transport commands
+    pub enum OckamCommand {
+        Transport(TransportCommand),
+        Router(RouterCommand),
+        Channel(ChannelCommand)
+    }
+
+    // Transport commands - these can
+    // be sent to the transport_tx
     pub enum TransportCommand {
         Stop,
         Add(String, String),
         Send(Message),
     }
 
-    // Router commands
+    // Router commands - these can be sent to the
+    // router_tx
     pub enum RouterCommand {
         Stop,
-        Register(AddressType, std::sync::mpsc::Sender<RouterCommand>),
+        Register(AddressType, std::sync::mpsc::Sender<OckamCommand>),
         Route(Message),
     }
 
-    // Channel commands
+    // Channel commands - these can be sent to the
+    // channel_tx
     pub enum ChannelCommand {
-        Message(Message),
+        Stop,
+        InitializeRoute(Route),
+        ReceiveMessage(Message),
+        SendMessage(Message),
     }
 }

--- a/implementations/rust/common/src/commands.rs
+++ b/implementations/rust/common/src/commands.rs
@@ -1,12 +1,12 @@
 #[allow(unused)]
-pub mod commands {
+pub mod ockam_commands {
     use ockam_message::message::{AddressType, Message, Route};
     use std::thread;
 
     pub enum OckamCommand {
         Transport(TransportCommand),
         Router(RouterCommand),
-        Channel(ChannelCommand)
+        Channel(ChannelCommand),
     }
 
     // Transport commands - these can

--- a/implementations/rust/message/src/message.rs
+++ b/implementations/rust/message/src/message.rs
@@ -20,9 +20,6 @@ pub mod message {
 
         fn encode(t: Self::Inner, v: &mut Vec<u8>) -> Result<(), String>;
         fn decode(s: &[u8]) -> Result<(Self::Inner, &[u8]), String>;
-        fn decode_boxed(s: &[u8]) -> Result<(Box<Self::Inner>, &[u8]), String> {
-            Err("not implemented".to_string())
-        }
     }
 
     // #[derive(Debug)]
@@ -815,11 +812,11 @@ mod tests {
         return_route.addresses.push(router_address);
 
         let mut message_body = vec![0];
-        let mut msg = Box::new(Message {
+        let mut msg = Message {
             onward_route,
             return_route,
             message_body,
-        });
+        };
         let mut u: Vec<u8> = vec![];
         Message::encode(msg, &mut u);
         assert_eq!(

--- a/implementations/rust/node/Cargo.toml
+++ b/implementations/rust/node/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ockam-node"
+version = "0.1.0"
+authors = ["Ockam Developers"]
+edition = "2018"
+
+[[bin]]
+name = "node"
+path = "src/node.rs"
+test = false
+bench = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ockam-router = { version = "0.1", path = "../router" }
+ockam-transport = { version = "0.1", path = "../transport"}
+ockam-message = { version = "0.1", path = "../message"}
+ockam-common = { version = "0.1", path = "../common"}

--- a/implementations/rust/node/src/node.rs
+++ b/implementations/rust/node/src/node.rs
@@ -1,0 +1,172 @@
+use ockam_common::commands::commands::*;
+#[allow(unused)]
+use ockam_message::message::*;
+use ockam_router::router::*;
+use ockam_transport::transport::*;
+use std::net::IpAddr;
+use std::str;
+use std::str::FromStr;
+use std::thread::sleep;
+use std::{thread, time};
+
+pub struct TestChannel {
+    rx: std::sync::mpsc::Receiver<OckamCommand>,
+    _tx: std::sync::mpsc::Sender<OckamCommand>,
+    router_tx: std::sync::mpsc::Sender<OckamCommand>,
+}
+
+impl TestChannel {
+    pub fn new(
+        rx: std::sync::mpsc::Receiver<OckamCommand>,
+        tx: std::sync::mpsc::Sender<OckamCommand>,
+        router_tx: std::sync::mpsc::Sender<OckamCommand>,
+    ) -> Self {
+        match router_tx.send(OckamCommand::Router(RouterCommand::Register(
+            AddressType::Channel,
+            tx.clone(),
+        ))) {
+            _ => {}
+        }
+        TestChannel {
+            rx,
+            _tx: tx,
+            router_tx,
+        }
+    }
+
+    pub fn poll(&mut self) -> bool {
+        let mut keep_going = true;
+        let mut got = true;
+        while got {
+            got = false;
+            match self.rx.try_recv() {
+                Ok(c) => {
+                    got = true;
+                    match c {
+                        OckamCommand::Channel(ChannelCommand::SendMessage(m)) => {
+                            // encrypt message body here
+                            match self
+                                .router_tx
+                                .send(OckamCommand::Router(RouterCommand::Route(m)))
+                            {
+                                Ok(()) => {}
+                                Err(_0) => {
+                                    println!("send to router failed");
+                                    keep_going = false;
+                                }
+                            }
+                        }
+                        OckamCommand::Channel(ChannelCommand::ReceiveMessage(m)) => {
+                            // decrypt message body here
+                            println!(
+                                "Channel receive message: {}",
+                                str::from_utf8(&m.message_body).unwrap()
+                            );
+                        }
+                        OckamCommand::Channel(ChannelCommand::Stop) => {
+                            keep_going = false;
+                        }
+                        _ => println!("Channel got bad message"),
+                    }
+                }
+                _ => {}
+            }
+        }
+        keep_going
+    }
+}
+
+pub fn get_route() -> Option<Route> {
+    let ip_addr_0 = match IpAddr::from_str("127.0.0.1") {
+        Ok(a) => a,
+        Err(_0) => return None,
+    };
+    let udp_addr_0 = Address::UdpAddress(ip_addr_0, 4050);
+    let router_addr_0: RouterAddress = match RouterAddress::from_address(udp_addr_0) {
+        Some(a) => a,
+        None => return None,
+    };
+
+    let ip_addr_1 = match IpAddr::from_str("127.0.0.1") {
+        Ok(a) => a,
+        Err(_0) => return None,
+    };
+    let udp_addr_1 = Address::UdpAddress(ip_addr_1, 4051);
+    let router_addr_1 = match RouterAddress::from_address(udp_addr_1) {
+        Some(a) => a,
+        None => return None,
+    };
+
+    let mut r = Route { addresses: vec![] };
+    r.addresses.push(router_addr_0);
+    r.addresses.push(router_addr_1);
+    Some(r)
+}
+
+fn main() {
+    // Start transport thread, pass rx ownership
+    let (transport_tx, transport_rx) = std::sync::mpsc::channel();
+    let (router_tx, router_rx) = std::sync::mpsc::channel();
+    let (channel_tx, channel_rx) = std::sync::mpsc::channel();
+    let channel_tx_for_node = channel_tx.clone();
+    let router_tx_for_channel = router_tx.clone();
+    let router_tx_for_transport = router_tx.clone();
+    let transport_tx_for_node = transport_tx.clone();
+
+    let mut router = Router::new(router_rx);
+    let mut transport = UdpTransport::new(transport_rx, transport_tx, router_tx_for_transport);
+    let mut channel = TestChannel::new(channel_rx, channel_tx, router_tx_for_channel);
+
+    let join_thread: thread::JoinHandle<_> = thread::spawn(move || {
+        println!("in closure");
+        while transport.poll() && router.poll() & channel.poll() {
+            thread::sleep(time::Duration::from_millis(100));
+        }
+    });
+
+    // Establish transport
+    let command = TransportCommand::Add("127.0.0.1:4050".to_string(), "127.0.0.1:4051".to_string());
+    match transport_tx_for_node.send(OckamCommand::Transport(command)) {
+        Ok(_0) => println!("sent socket 1 command to transport"),
+        Err(_0) => println!("failed to send command to transport"),
+    }
+
+    let command = TransportCommand::Add("127.0.0.1:4051".to_string(), "127.0.0.1:4050".to_string());
+    match transport_tx_for_node.send(OckamCommand::Transport(command)) {
+        Ok(_0) => println!("sent socket 2 command to transport"),
+        Err(_0) => println!("failed to send command to transport"),
+    }
+
+    // Create route
+    let route = match get_route() {
+        Some(r) => r,
+        None => {
+            println!("get_route failed");
+            return;
+        }
+    };
+
+    let m = Message {
+        onward_route: route,
+        return_route: Route { addresses: vec![] },
+        message_body: "Hello Ockam".to_string().as_bytes().to_vec(),
+    };
+    let command = OckamCommand::Channel(ChannelCommand::SendMessage(m));
+    match channel_tx_for_node.send(command) {
+        Ok(_0) => {}
+        Err(_0) => {}
+    }
+
+    sleep(time::Duration::from_millis(1000));
+
+    let command = TransportCommand::Stop;
+    match transport_tx_for_node.send(OckamCommand::Transport(command)) {
+        Ok(_0) => println!("sent stop command to transport"),
+        Err(_0) => println!("failed to send command to transport"),
+    }
+
+    match join_thread.join() {
+        Ok(_0) => {}
+        Err(_0) => {}
+    }
+}

--- a/implementations/rust/router/Cargo.toml
+++ b/implementations/rust/router/Cargo.toml
@@ -15,4 +15,5 @@ lto = true
 
 [dependencies]
 ockam-message = { version = "0.1", path = "../message" }
+ockam-common = { version = "0.1", path = "../common" }
 

--- a/implementations/rust/router/src/router.rs
+++ b/implementations/rust/router/src/router.rs
@@ -1,151 +1,362 @@
-// #![allow(unused)]
+#![allow(unused)]
 pub mod router {
+    use ockam_common::commands::commands::*;
     use ockam_message::message::*;
+    use std::sync::mpsc::channel;
     use std::sync::{Arc, Mutex};
-
-    pub trait MessageHandler {
-        fn message_handler(&self, m: Box<Message>) -> Result<(), String>;
-    }
+    use std::{thread, time};
 
     pub struct Router {
-        registry: Vec<Option<Arc<Mutex<dyn MessageHandler + Send>>>>,
+        //        registry: Vec<Option<Arc<Mutex<std::sync::mpsc::Sender<commands::ChannelCommand>>>>>,
+        registry: Vec<Option<std::sync::mpsc::Sender<OckamCommand>>>,
+        rx: std::sync::mpsc::Receiver<OckamCommand>,
     }
 
     impl Router {
-        pub fn new() -> Router {
+        pub fn new(rx: std::sync::mpsc::Receiver<OckamCommand>) -> Router {
             Router {
                 registry: vec![Option::None; 256],
+                rx,
             }
         }
 
-        pub fn register_handler(
-            &mut self,
-            handler: Arc<Mutex<dyn MessageHandler + Send>>,
-            address_type: AddressType,
-        ) -> Result<(), String> {
-            self.registry[address_type as usize] = Option::Some(handler);
-            Ok(())
-        }
-
-        pub fn route(&mut self, m: Box<Message>) -> Result<(), String> {
-            // Pop the first address in the list
-            // If there are no addresses, route to the controller
-            // Controller key is always 0
-            let handler_ref: Arc<Mutex<dyn MessageHandler + Send>>;
-            let mut address_type: u8 = 0;
-            let address: Address;
-            if !m.onward_route.addresses.is_empty() {
-                address = m.onward_route.addresses[0];
-                match address {
-                    Address::LocalAddress(t, _0) => {
-                        address_type = t as u8;
+        pub fn poll(&mut self) -> bool {
+            let mut keep_going = true;
+            let mut got = true;
+            while got {
+                got = false;
+                match self.rx.try_recv() {
+                    Ok(rc) => {
+                        println!("got rx");
+                        match rc {
+                            OckamCommand::Router(RouterCommand::Stop) => {
+                                println!("quit!");
+                                got = true;
+                                keep_going = false;
+                                break;
+                            }
+                            OckamCommand::Router(RouterCommand::Register(a_type, tx)) => {
+                                println!("Registering");
+                                got = true;
+                                self.registry[a_type as usize] = Option::Some(tx);
+                            }
+                            OckamCommand::Router(RouterCommand::Route(m)) => {
+                                println!("Routing");
+                                got = true;
+                                self.route(m);
+                            }
+                            _ => println!("Transport received bad command"),
+                        }
                     }
-                    Address::UdpAddress(t, _0, _1) => {
-                        address_type = t as u8;
-                    }
-                    Address::TcpAddress(t, _0, _1) => {
-                        address_type = t as u8;
-                    }
+                    Err(e) => {}
                 }
             }
-            match &self.registry[address_type as usize] {
-                Some(a) => {
-                    handler_ref = Arc::clone(a);
-                }
+            keep_going
+        }
+
+        fn route(&mut self, m: Message) -> Result<(), String> {
+            if m.onward_route.addresses.is_empty() {
+                return Err("no route supplied".to_string());
+            }
+
+            let destination_address = m.onward_route.addresses[0];
+            let address_type = destination_address.a_type;
+            let handler_tx = match &self.registry[address_type as usize] {
+                Some(a) => a,
                 None => return Err("no handler".to_string()),
-            }
-            let r = handler_ref.lock().unwrap().message_handler(m);
-            match r {
-                Ok(()) => Ok(()),
-                Err(s) => Err(s),
+            };
+            match address_type {
+                AddressType::Channel => {
+                    handler_tx.send(OckamCommand::Channel(ChannelCommand::SendMessage(m)));
+                    Ok(())
+                }
+                AddressType::Udp => {
+                    handler_tx.send(OckamCommand::Transport(TransportCommand::Send(m)));
+                    Ok(())
+                }
+                _ => Err("not implemented".to_string()),
             }
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::router::*;
-    use ockam_message::message::*;
-    use std::net::UdpSocket;
-    use std::net::{IpAddr, Ipv4Addr};
-    use std::sync::{Arc, Mutex};
+// #[cfg(test)]
+// mod tests {
+//     use crate::router::*;
+//     use ockam_message::message::*;
+//     use std::net::UdpSocket;
+//     use std::net::{IpAddr, Ipv4Addr};
+//     use std::str;
+//     use std::sync::mpsc::channel;
+//     use std::sync::{Arc, Mutex};
+//     use std::{thread, time};
 
-    struct TestUdpHandler {
-        pub socket: UdpSocket,
-    }
+//     #[test]
+//     fn test_udp_handler() {
+//         let mut onward_addresses: Vec<Address> = vec![];
+//         onward_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+//             0x8080,
+//         ));
+//         onward_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 10)),
+//             0x7070,
+//         ));
+//         onward_addresses.push(Address::LocalAddress(
+//             AddressType::Local as u8,
+//             4,
+//             LocalAddress {
+//                 address: 0x00010203,
+//             },
+//         ));
+//         let mut return_addresses: Vec<Address> = vec![];
+//         return_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+//             0x8080,
+//         ));
+//         return_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 11)),
+//             0x7070,
+//         ));
+//         return_addresses.push(Address::LocalAddress(
+//             AddressType::Local as u8,
+//             4,
+//             LocalAddress {
+//                 address: 0x00010203,
+//             },
+//         ));
+//         let onward_route = Route {
+//             addresses: onward_addresses,
+//         };
+//         let return_route = Route {
+//             addresses: return_addresses,
+//         };
+//         let mut message_body = vec![0];
+//         let mut msg = Box::new(Message {
+//             onward_route,
+//             return_route,
+//             message_body,
+//         });
+//         let (tx, rx) = std::sync::mpsc::channel();
+//         let join_router: thread::JoinHandle<_> = thread::spawn(|| Router::start(rx));
+//
+//         let udp_socket = UdpSocket::bind("127.0.0.1:4050").expect("couldn't bind to address");
+//         let udp_handler: Arc<Mutex<dyn MessageHandler + Send>> =
+//             Arc::new(Mutex::new(TestUdpHandler { socket: udp_socket }));
+//         let cmd: commands::RouterCommand = commands::RouterCommand::Register(udp_handler, AddressType::Udp);
+//         tx.send(cmd);
+//         let cmd: RouterCommand = RouterCommand::Route(msg);
+//         tx.send(cmd);
+//         let cmd: RouterCommand = RouterCommand::None;
+//         tx.send(cmd);
+//         join_router.join();
+//     }
+// }
 
-    impl MessageHandler for TestUdpHandler {
-        fn message_handler(&self, _m: Box<Message>) -> Result<(), String> {
-            println!("In TestAddressHandler!");
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn test_handler() {
-        let mut onward_addresses: Vec<Address> = vec![];
-        onward_addresses.push(Address::UdpAddress(
-            AddressType::Udp,
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            0x8080,
-        ));
-        onward_addresses.push(Address::UdpAddress(
-            AddressType::Udp,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 1, 10)),
-            0x7070,
-        ));
-        onward_addresses.push(Address::LocalAddress(
-            AddressType::Local,
-            LocalAddress {
-                address: 0x00010203,
-            },
-        ));
-        let mut return_addresses: Vec<Address> = vec![];
-        return_addresses.push(Address::UdpAddress(
-            AddressType::Udp,
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-            0x8080,
-        ));
-        return_addresses.push(Address::UdpAddress(
-            AddressType::Udp,
-            IpAddr::V4(Ipv4Addr::new(10, 0, 1, 11)),
-            0x7070,
-        ));
-        return_addresses.push(Address::LocalAddress(
-            AddressType::Local,
-            LocalAddress {
-                address: 0x00010203,
-            },
-        ));
-        let onward_route = Route {
-            addresses: onward_addresses,
-        };
-        let return_route = Route {
-            addresses: return_addresses,
-        };
-        let message_body = vec![0];
-        let msg = Box::new(Message {
-            onward_route,
-            return_route,
-            message_body,
-        });
-        let mut router: Router = Router::new();
-        let udp_socket = UdpSocket::bind("127.0.0.1:4050").expect("couldn't bind to address");
-        let udp_handler: Arc<Mutex<dyn MessageHandler + Send>> =
-            Arc::new(Mutex::new(TestUdpHandler { socket: udp_socket }));
-        match router.register_handler(udp_handler, AddressType::Udp) {
-            Ok(()) => {
-                println!("udp handler registered");
-            }
-            Err(s) => {
-                println!("{}", s);
-                return;
-            }
-        }
-        match router.route(msg) {
-            Ok(()) => println!("success!"),
-            Err(s) => println!("{}", s),
-        }
-    }
-}
+// #![allow(unused)]
+// pub mod router {
+//     use ockam_message::message::*;
+//     use std::sync::mpsc::channel;
+//     use std::sync::{Arc, Mutex};
+//     use std::{thread, time};
+//
+//     pub struct RouterCommandRegister {
+//         //registry: Option<Arc<Mutex<dyn MessageHandler + Send>>>,
+//         registry: Option<Box<std::sync::mpsc::Sender<Message>>>,
+//         address_type: AddressType,
+//     }
+//
+//     pub enum RouterCommand {
+//         None,
+//         Register(std::sync::mpsc::Sender<Message>, AddressType),
+//         //Register(std::sync::mpsc::Sender<RouterCommand>, AddressType),
+//         Route(Message),
+//         DeRegister(AddressType),
+//     }
+//
+//     // pub trait MessageHandler {
+//     //     fn message_handler(&mut self, m: Message) -> Result<(), String>;
+//     // }
+//
+//     pub struct Router {
+//         registry: Vec<Option<Arc<Mutex<std::sync::mpsc::Sender<Message>>>>>,
+//     }
+//
+//     impl Router {
+//         pub fn start(rx: std::sync::mpsc::Receiver<RouterCommand>) {
+//             let mut router = Router {
+//                 registry: vec![Option::None; 256],
+//             };
+//             let mut router_command = RouterCommand::None;
+//             loop {
+//                 match rx.try_recv() {
+//                     Ok(rc) => {
+//                         println!("got rx");
+//                         match rc {
+//                             RouterCommand::None => {
+//                                 println!("quit!");
+//                                 break;
+//                             }
+//                             RouterCommand::Register(r, a) => {
+//                                 println!("Registering");
+//                                 router.register_handler(r, a);
+//                             }
+//                             RouterCommand::Route(m) => {
+//                                 println!("Routing");
+//                                 router.route(m);
+//                             }
+//                             _ => {
+//                                 println!("unknown command");
+//                             }
+//                         }
+//                     }
+//                     Err(e) => {
+//                         thread::sleep(time::Duration::from_millis(100));
+//                     }
+//                 }
+//             }
+//         }
+//
+//         fn register_handler(
+//             &mut self,
+//             handler: Arc<Mutex<dyn MessageHandler + Send>>,
+//             address_type: AddressType,
+//         ) -> Result<(), String> {
+//             self.registry[address_type as usize] = Option::Some(handler);
+//             Ok(())
+//         }
+//
+//         fn route(&mut self, m: Message) -> Result<(), String> {
+//             // If there are no addresses, route to the controller
+//             // Controller key is always 0
+//             let handler_ref: Arc<Mutex<dyn MessageHandler + Send>>;
+//             let mut address_type: u8 = 0;
+//             let address: Address;
+//             if !m.onward_route.addresses.is_empty() {
+//                 address = m.onward_route.addresses[0];
+//                 match address {
+//                     Address::LocalAddress(t, _l, _0) => {
+//                         address_type = t as u8;
+//                     }
+//                     Address::UdpAddress(t, _l, _0, _1) => {
+//                         address_type = t as u8;
+//                     }
+//                     Address::TcpAddress(t, _l, _0, _1) => {
+//                         address_type = t as u8;
+//                     }
+//                 }
+//             }
+//             match &self.registry[address_type as usize] {
+//                 Some(a) => {
+//                     handler_ref = Arc::clone(a);
+//                 }
+//                 None => return Err("no handler".to_string()),
+//             }
+//             let r = handler_ref.lock().unwrap().message_handler(m);
+//             match r {
+//                 Ok(()) => Ok(()),
+//                 Err(s) => Err(s),
+//             }
+//         }
+//     }
+// }
+//
+// #[cfg(test)]
+// mod tests {
+//     use crate::router::*;
+//     use ockam_message::message::*;
+//     use std::net::UdpSocket;
+//     use std::net::{IpAddr, Ipv4Addr};
+//     use std::str;
+//     use std::sync::mpsc::channel;
+//     use std::sync::{Arc, Mutex};
+//     use std::{thread, time};
+//
+//     struct TestUdpHandler {
+//         pub socket: UdpSocket,
+//     }
+//
+//     impl MessageHandler for TestUdpHandler {
+//         fn message_handler(&mut self, mut m: Message) -> Result<(), String> {
+//             println!("In TestAddressHandler!");
+//             Ok(())
+//         }
+//     }
+//
+//     #[test]
+//     fn test_udp_handler() {
+//         let mut onward_addresses: Vec<Address> = vec![];
+//         onward_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+//             0x8080,
+//         ));
+//         onward_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 10)),
+//             0x7070,
+//         ));
+//         onward_addresses.push(Address::LocalAddress(
+//             AddressType::Local as u8,
+//             4,
+//             LocalAddress {
+//                 address: 0x00010203,
+//             },
+//         ));
+//         let mut return_addresses: Vec<Address> = vec![];
+//         return_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+//             0x8080,
+//         ));
+//         return_addresses.push(Address::UdpAddress(
+//             AddressType::Udp as u8,
+//             7,
+//             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 11)),
+//             0x7070,
+//         ));
+//         return_addresses.push(Address::LocalAddress(
+//             AddressType::Local as u8,
+//             4,
+//             LocalAddress {
+//                 address: 0x00010203,
+//             },
+//         ));
+//         let onward_route = Route {
+//             addresses: onward_addresses,
+//         };
+//         let return_route = Route {
+//             addresses: return_addresses,
+//         };
+//         let mut message_body = vec![0];
+//         let mut msg = Box::new(Message {
+//             onward_route,
+//             return_route,
+//             message_body,
+//         });
+//         let (tx, rx) = std::sync::mpsc::channel();
+//         let join_router: thread::JoinHandle<_> = thread::spawn(|| Router::start(rx));
+//
+//         let udp_socket = UdpSocket::bind("127.0.0.1:4050").expect("couldn't bind to address");
+//         let udp_handler: Arc<Mutex<dyn MessageHandler + Send>> =
+//             Arc::new(Mutex::new(TestUdpHandler { socket: udp_socket }));
+//         let cmd: RouterCommand = RouterCommand::Register(udp_handler, AddressType::Udp);
+//         tx.send(cmd);
+//         let cmd: RouterCommand = RouterCommand::Route(msg);
+//         tx.send(cmd);
+//         let cmd: RouterCommand = RouterCommand::None;
+//         tx.send(cmd);
+//         join_router.join();
+//     }
+// }

--- a/implementations/rust/router/src/router.rs
+++ b/implementations/rust/router/src/router.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 pub mod router {
-    use ockam_common::commands::commands::*;
+    use ockam_common::commands::ockam_commands::*;
     use ockam_message::message::*;
     use std::sync::mpsc::channel;
     use std::sync::{Arc, Mutex};

--- a/implementations/rust/transport/Cargo.toml
+++ b/implementations/rust/transport/Cargo.toml
@@ -5,14 +5,8 @@ authors = ["Ockam Developers"]
 edition = "2018"
 
 [lib]
-name = "transport"           # The name of the target.
-path = "src/transport.rs"    # The source file of the target.
-test = true            # Is tested by default.
-doctest = true         # Documentation examples are tested by default.
-bench = true           # Is benchmarked by default.
-doc = true             # Is documented by default.
-crate-type = ["lib"]   # The crate types to generate.
-
+crate-type = ["staticlib", "rlib", "cdylib"]
+path = "src/transport.rs"
 
 [profile.release]
 lto = true
@@ -22,4 +16,5 @@ lto = true
 [dependencies]
 ockam-router = { version = "0.1", path = "../router" }
 ockam-message = { version = "0.1", path = "../message" }
-
+ockam-common = { version = "0.1", path = "../common" }
+futures = "0.3"

--- a/implementations/rust/transport/src/transport.rs
+++ b/implementations/rust/transport/src/transport.rs
@@ -1,15 +1,134 @@
 #[allow(unused)]
 
 pub mod transport {
-    use ockam_message::message::Address::UdpAddress;
-    use ockam_message::message::AddressType::Udp;
-    use ockam_message::message::{Address, Message};
-    use ockam_router::router::MessageHandler;
+    use ockam_common::commands::commands::*;
+    use ockam_common::commands::*;
+    use ockam_message::message::*;
+    use ockam_router::router::Router;
+    use std::collections::HashMap;
     use std::io::{Read, Write};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::net::{SocketAddrV4, UdpSocket};
+    use std::str;
     use std::str::FromStr;
+    use std::sync::mpsc::channel;
     use std::sync::Arc;
+    use std::{io, thread, time};
+
+    pub struct UdpTransport {
+        connections: std::collections::HashMap<String, UdpConnection>,
+        rx: std::sync::mpsc::Receiver<OckamCommand>,
+        tx: std::sync::mpsc::Sender<OckamCommand>,
+        router_tx: std::sync::mpsc::Sender<OckamCommand>,
+        buffer: [u8; 16384],
+    }
+
+    impl UdpTransport {
+        pub fn new(
+            rx: std::sync::mpsc::Receiver<OckamCommand>,
+            tx: std::sync::mpsc::Sender<OckamCommand>,
+            router_tx: std::sync::mpsc::Sender<OckamCommand>,
+        ) -> UdpTransport {
+            router_tx.send(OckamCommand::Router(RouterCommand::Register(
+                AddressType::Udp,
+                tx.clone(),
+            )));
+            UdpTransport {
+                connections: std::collections::HashMap::new(),
+                rx,
+                tx,
+                router_tx,
+                buffer: [0; 16384],
+            }
+        }
+
+        pub fn poll(&mut self) -> bool {
+            let mut got: bool = true;
+            let mut keep_going = true;
+            let mut buff = [0; 16348];
+            while got {
+                got = false;
+                for (_, mut c) in self.connections.iter_mut() {
+                    match c.receive(&mut buff) {
+                        Ok(size) => {
+                            if size > 0 {
+                                match Message::decode(&buff) {
+                                    Ok((m, _0)) => {
+                                        // // send message to router
+                                        // let cmd = RouterCommand::Route(m);
+                                        // router_tx.send(cmd);
+                                        // got = true;
+                                        println!(
+                                            "received {}",
+                                            str::from_utf8(&m.message_body).unwrap()
+                                        );
+                                    }
+                                    Err(s) => {
+                                        println!("message decode failed");
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            println!("udp receive error");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            got = true;
+            while got {
+                got = false;
+                match self.rx.try_recv() {
+                    Ok(tc) => match tc {
+                        OckamCommand::Transport(TransportCommand::Add(local, remote)) => {
+                            got = true;
+                            println!("creating udp connection");
+                            let c = match UdpConnection::new(&local, &remote) {
+                                Ok(c) => c,
+                                Err(s) => return false,
+                            };
+                            println!("Added {} to transport", c.address_as_string());
+                            self.connections.insert(c.address_as_string(), c);
+                        }
+                        OckamCommand::Transport((TransportCommand::Send(m))) => {
+                            let mut udp = match self
+                                .connections
+                                .get_mut(&m.onward_route.addresses[0].address.to_string())
+                            {
+                                Some(c) => c,
+                                None => {
+                                    println!("connection not found");
+                                    return false;
+                                }
+                            };
+                            let mut v = vec![];
+                            Message::encode(m, &mut v);
+                            match udp.socket.send(v.as_slice()) {
+                                Ok(n) => {
+                                    println!("Sent {} bytes!", n);
+                                }
+                                Err(s) => {
+                                    println!("socket.send error {}", s);
+                                }
+                            }
+                        }
+                        OckamCommand::Transport(TransportCommand::Stop) => {
+                            keep_going = false;
+                            break;
+                        }
+                        _ => {
+                            println!("unrecognized command");
+                        }
+                    },
+                    _ => {}
+                } // end match rx.try_recv()
+            }
+            return keep_going;
+        }
+    }
 
     pub struct UdpConnection {
         socket: UdpSocket,
@@ -18,12 +137,31 @@ pub mod transport {
     impl UdpConnection {
         pub fn new(local: &str, remote: &str) -> Result<UdpConnection, String> {
             let mut socket = UdpSocket::bind(local).expect("couldn't bind to local socket");
-            let remote_socket = SocketAddrV4::from_str(remote).expect("bad remote address");
-            match socket.connect(remote_socket) {
-                Ok(s) => Ok(UdpConnection { socket }),
+            let remote_address = SocketAddrV4::from_str(remote).expect("bad remote address");
+            match socket.connect(remote_address) {
+                Ok(s) => {
+                    socket.set_nonblocking(true);
+                    Ok(UdpConnection { socket })
+                }
                 Err(_a) => Err("couldn't connect to remote address".to_string()),
             }
         }
+
+        pub fn address_as_string(&self) -> String {
+            let mut s = self.socket.local_addr().unwrap().to_string();
+            return s;
+        }
+        // pub fn new_from_initiator(local: &str) -> Result<UdpConnection, String> {
+        //     let mut socket = UdpSocket::bind(local).expect("couldn't bind to local socket");
+        //     let mut u: [u8; 1024] = [0; 1024];
+        //     match socket.recv_from(&mut u) {
+        //         Ok((_0, remote_address)) => match socket.connect(remote_address) {
+        //             Ok(s) => Ok(UdpConnection { socket }),
+        //             Err(_0) => Err("connect failed".to_string()),
+        //         },
+        //         Err(_0) => Err("recv_from failed".to_string()),
+        //     }
+        // }
 
         pub fn send(&mut self, buff: &[u8]) -> Result<usize, String> {
             match self.socket.send(buff) {
@@ -31,56 +169,148 @@ pub mod transport {
                 Err(_0) => Err("udp send failed".to_string()),
             }
         }
+
         pub fn receive(&mut self, buff: &mut [u8]) -> Result<usize, String> {
             match self.socket.recv(buff) {
                 Ok(s) => Ok(s),
-                Err(_0) => Err("udp receive failed".to_string()),
+                Err(e) => match e.kind() {
+                    io::ErrorKind::WouldBlock => Ok(0),
+                    _ => Err("udp receive error".to_string()),
+                },
             }
         }
-    }
-}
 
-#[cfg(test)]
-mod tests {
-    use crate::transport::*;
-    use std::net::UdpSocket;
-    use std::{thread, time};
-
-    fn recv_thread(addr: &str) {
-        let socket = UdpSocket::bind(addr).expect("couldn't bind to local socket");
-        let mut buff: [u8; 100] = [0; 100];
-        println!("calling recv");
-        match socket.recv(&mut buff) {
-            Ok(n) => println!(
-                "received {} bytes: {}",
-                n,
-                std::str::from_utf8(&buff).expect("bad string")
-            ),
-            Err(_0) => println!("receive failed"),
+        pub fn receive_message(&mut self, buff: &mut [u8]) -> Result<Message, String> {
+            return match self.socket.recv(buff) {
+                Ok(_0) => match Message::decode(buff) {
+                    Ok(m) => Ok(m.0),
+                    Err(s) => Err(s),
+                },
+                Err(_0) => Err("recv failed".to_string()),
+            };
         }
     }
 
-    #[test]
-    fn test_connect() {
-        let j: thread::JoinHandle<_> = thread::spawn(|| {
-            //println!("spawned");
-            recv_thread("127.0.0.1:4051")
-        });
-
-        let half_sec = time::Duration::from_millis(500);
-        thread::sleep(half_sec);
-
-        match UdpConnection::new("127.0.0.1:4050", "127.0.0.1:4051") {
-            Ok(mut t) => {
-                println!("Connected");
-                let buff = "hello ockam".as_bytes();
-                match t.send(buff) {
-                    Ok(s) => println!("Sent {} bytes: {}", s, "hello ockam"),
-                    Err(_e) => println!("Send failed"),
-                }
-            }
-            Err(s) => println!("Failed to connect {}", s),
-        }
-        j.join().expect("panic");
-    }
+    // impl MessageHandler for UdpConnection {
+    //     fn message_handler(&mut self, mut m: Message) -> Result<(), String> {
+    //         // pop first address
+    //         // send message
+    //         let router_address = m.onward_route.addresses.remove(0);
+    //         match router_address.a_type {
+    //             AddressType::Udp => match router_address.address {
+    //                 Address::UdpAddress(ip, p) => {
+    //                     let mut u: Vec<u8> = vec![];
+    //                     match Message::encode(m, &mut u) {
+    //                         Ok(_0) => (),
+    //                         Err(_0) => return Err("failed to encode message".to_string()),
+    //                     }
+    //                     match self.socket.send(&u) {
+    //                         Ok(_0) => Ok(()),
+    //                         Err(_0) => Err("udp send failed".to_string()),
+    //                     }
+    //                 }
+    //                 _ => {
+    //                     assert!(false);
+    //                 }
+    //             },
+    //             _ => Err("wrong address type".to_string()),
+    //         }
+    //     }
+    //}
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::transport::*;
+//     use ockam_message::message::*;
+//     use ockam_router::router::{MessageHandler, Router};
+//     use std::net::UdpSocket;
+//     use std::sync::{Arc, Mutex};
+//     use std::{thread, time};
+//
+//     fn recv_thread(addr: &str) {
+//         let socket = UdpSocket::bind(addr).expect("couldn't bind to local socket");
+//         let mut buff: [u8; 100] = [0; 100];
+//         println!("calling recv");
+//         match socket.recv(&mut buff) {
+//             Ok(n) => println!(
+//                 "received {} bytes: {}",
+//                 n,
+//                 std::str::from_utf8(&buff).expect("bad string")
+//             ),
+//             Err(_0) => println!("receive failed"),
+//         }
+//     }
+//    #[test]
+//     fn test_connect() {
+//         let j: thread::JoinHandle<_> = thread::spawn(|| {
+//             //println!("spawned");
+//             recv_thread("127.0.0.1:4051")
+//         });
+//
+//         let half_sec = time::Duration::from_millis(500);
+//         thread::sleep(half_sec);
+//
+//         match UdpConnection::new("127.0.0.1:4050", "127.0.0.1:4051") {
+//             Ok(mut t) => {
+//                 println!("Connected");
+//                 let buff = "hello ockam".as_bytes();
+//                 match t.send(buff) {
+//                     Ok(s) => println!("Sent {} bytes: {}", s, "hello ockam"),
+//                     Err(_e) => println!("Send failed"),
+//                 }
+//             }
+//             Err(s) => println!("Failed to connect {}", s),
+//         }
+//         j.join().expect("panic");
+//     }
+//
+//     pub struct LocalProcess {
+//         counter: u32,
+//     }
+//
+//     impl MessageHandler for LocalProcess {
+//         fn message_handler(&mut self, m: Message) -> Result<(), String> {
+//             unimplemented!()
+//         }
+//     }
+//
+//     fn udp_responder(address: &str, router: Arc<Mutex<&mut Router>>) {
+//         // register message handler
+//         let mut udp_handler: Arc<Mutex<UdpConnection>>;
+//         match UdpConnection::new_from_initiator(address) {
+//             Ok(u) => {
+//                 udp_handler = Arc::new(Mutex::new(u));
+//                 let udp_connection = udp_handler.clone();
+//                 match router
+//                     .lock()
+//                     .unwrap()
+//                     .register_handler(udp_handler, AddressType::Udp)
+//                 {
+//                     Ok(()) => (),
+//                     Err(s) => return,
+//                 }
+//
+//                 loop {
+//                     let mut u: [u8; 1024] = [0; 1024];
+//                     let r = udp_connection.lock().unwrap().receive_message(&mut u);
+//                     match r {
+//                         Ok(message) => match router.lock().unwrap().route(message) {
+//                             Ok(()) => {}
+//                             Err(s) => {
+//                                 println!("router.route failed");
+//                                 return;
+//                             }
+//                         },
+//                         Err(s) => {
+//                             println!("receive_message failed {}", s);
+//                         }
+//                     }
+//                 }
+//             }
+//             Err(s) => return,
+//         }
+//     }
+//
+//     fn test_handler() {}
+// }


### PR DESCRIPTION

- node: Spin up a thread for router channels and transport.
        Implement prototype channel, register channel with router
        Send message to channel, channel sends to router, router
        sends to transport
- commands: combine all ockam command types into a single enum
- message: implement helper functions for manipulating routes and addresses
- udp transport: implement mapping of ip address string to socket, implement
                 polling loop to process ockam commands and socket events
- router: implement polling loop to process routing commands
