### PR TITLE
refactor(rust): make address types consistent, do all comms on same s…

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -143,6 +143,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8677f2d5ab29b5a4815aabd2ddb83e1899e58903a67594406893a9757f48ccae"
+checksum = "82e7e174baa250269c92f2e0d59abaeb14c7d8072abd130dee996cc61141825a"
 dependencies = [
  "bitvec",
  "ff",
@@ -419,6 +430,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,15 +551,20 @@ dependencies = [
 [[package]]
 name = "ockam-message"
 version = "0.1.0"
+dependencies = [
+ "hex",
+]
 
 [[package]]
 name = "ockam-node"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "ockam-common",
  "ockam-message",
  "ockam-router",
  "ockam-transport",
+ "structopt",
 ]
 
 [[package]]
@@ -606,18 +631,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -647,6 +672,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,9 +709,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
@@ -772,6 +821,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "structopt"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,9 +852,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -801,10 +874,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/implementations/rust/common/src/commands.rs
+++ b/implementations/rust/common/src/commands.rs
@@ -1,19 +1,19 @@
 #[allow(unused)]
 pub mod ockam_commands {
-    use ockam_message::{AddressType, Message, Route};
+    use ockam_message::message::*;
     use std::thread;
 
     pub enum OckamCommand {
         Transport(TransportCommand),
         Router(RouterCommand),
         Channel(ChannelCommand),
+        Worker(WorkerCommand),
     }
 
     // Transport commands - these can
     // be sent to the transport_tx
     pub enum TransportCommand {
         Stop,
-        Add(String, String),
         SendMessage(Message),
     }
 
@@ -29,6 +29,12 @@ pub mod ockam_commands {
     // Channel commands - these can be sent to the
     // channel_tx
     pub enum ChannelCommand {
+        Stop,
+        InitializeRoute(Route),
+        ReceiveMessage(Message),
+        SendMessage(Message),
+    }
+    pub enum WorkerCommand {
         Stop,
         InitializeRoute(Route),
         ReceiveMessage(Message),

--- a/implementations/rust/message/Cargo.toml
+++ b/implementations/rust/message/Cargo.toml
@@ -13,4 +13,4 @@ lto = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
+hex = "0.4.2"

--- a/implementations/rust/message/src/lib.rs
+++ b/implementations/rust/message/src/lib.rs
@@ -1,517 +1,593 @@
+#![allow(unused)]
+
 // Definition and implementation of an Ockam message and message components.
 // Each message component, and the message overall, implements the "Codec" trait
 // allowing it to be encoded/decoded for transmission over a transport.
 
-use std::{
-    convert::TryFrom,
-    fmt::Formatter,
-    io::ErrorKind,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    str::FromStr,
-};
+pub mod message {
+    use crate::message::Address::ChannelAddress;
+    use crate::message::MessageType::Payload;
+    use hex::*;
+    use std::convert::{Into, TryFrom};
+    use std::error::Error;
+    use std::fmt::Formatter;
+    pub use std::io::{ErrorKind, Read, Write};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::ops::Add;
+    use std::slice;
+    use std::str::FromStr;
 
-pub const WIRE_PROTOCOL_VERSION: u8 = 1;
+    const WIRE_PROTOCOL_VERSION: u8 = 1;
 
-pub trait Codec {
-    type Inner;
+    pub trait Codec {
+        type Inner;
 
-    fn encode(t: Self::Inner, v: &mut Vec<u8>) -> Result<(), String>;
-    fn decode(s: &[u8]) -> Result<(Self::Inner, &[u8]), String>;
-}
-
-// #[derive(Debug)]
-#[repr(C)]
-pub struct Message {
-    pub onward_route: Route,
-    pub return_route: Route,
-    pub message_body: Vec<u8>,
-}
-
-impl Default for Message {
-    fn default() -> Message {
-        Message {
-            onward_route: Route { addresses: vec![] },
-            return_route: Route { addresses: vec![] },
-            message_body: vec![0],
-        }
-    }
-}
-
-impl Codec for Message {
-    type Inner = Message;
-    fn encode(msg: Message, u: &mut Vec<u8>) -> Result<(), String> {
-        Route::encode(msg.onward_route, u)?;
-        Route::encode(msg.return_route, u)?;
-        u.extend(&msg.message_body[0..]);
-        Ok(())
+        fn encode(t: Self::Inner, v: &mut Vec<u8>) -> Result<(), String>;
+        fn decode(s: &[u8]) -> Result<(Self::Inner, &[u8]), String>;
     }
 
-    fn decode(u: &[u8]) -> Result<(Message, &[u8]), String> {
-        let mut msg = Message::default();
-        let mut w = u;
-        match Route::decode(w) {
-            Ok((r, u1)) => {
-                msg.onward_route = r;
-                w = u1;
-            }
-            Err(s) => {
-                return Err(s);
+    // #[derive(Debug)]
+    #[repr(C)]
+    pub struct Message {
+        pub onward_route: Route,
+        pub return_route: Route,
+        pub message_type: MessageType,
+        pub message_body: Vec<u8>,
+    }
+
+    #[repr(u8)]
+    pub enum MessageType {
+        Ping = 0,
+        Pong = 1,
+        Payload = 2,
+        KeyAgreementM1 = 3,
+        KeyAgreementM2 = 4,
+        KeyAgreementM3 = 5,
+    }
+
+    impl Default for Message {
+        fn default() -> Message {
+            Message {
+                onward_route: Route { addresses: vec![] },
+                return_route: Route { addresses: vec![] },
+                message_type: Payload,
+                message_body: vec![0],
             }
         }
-        match Route::decode(w) {
-            Ok((r, u1)) => {
-                msg.return_route = r;
-                w = u1;
-            }
-            Err(s) => {
-                return Err(s);
-            }
+    }
+
+    impl Codec for Message {
+        type Inner = Message;
+        fn encode(msg: Message, u: &mut Vec<u8>) -> Result<(), String> {
+            u.push(1);
+            Route::encode(msg.onward_route, u);
+            Route::encode(msg.return_route, u);
+            u.push(msg.message_type as u8);
+            u.extend(&msg.message_body[0..]);
+            Ok(())
         }
 
-        msg.message_body.append(&mut (w.to_vec()));
-        Ok((msg, w))
-    }
-}
-
-/* Addresses */
-#[derive(Debug, PartialEq)]
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct RouterAddress {
-    pub a_type: AddressType,
-    pub length: u8,
-    pub address: Address,
-}
-
-impl Clone for AddressType {
-    fn clone(&self) -> Self {
-        match self {
-            AddressType::Local => AddressType::Local,
-            AddressType::Tcp => AddressType::Tcp,
-            AddressType::Udp => AddressType::Udp,
-            AddressType::Channel => AddressType::Channel,
-            AddressType::Undefined => AddressType::Undefined,
-        }
-    }
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Address {
-    LocalAddress(LocalAddress),
-    TcpAddress(IpAddr, u16),
-    UdpAddress(SocketAddr),
-    ChannelAddress(u32),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct LocalAddress {
-    pub address: u32,
-}
-
-impl Address {
-    pub fn as_string(&self) -> String {
-        match self {
-            Address::UdpAddress(socket) => socket.to_string(),
-            _ => "error".to_string(),
-        }
-    }
-    pub fn size_of(&self) -> u8 {
-        match self {
-            Address::LocalAddress(_) => 4,
-            Address::UdpAddress(_) => 7,
-            Address::ChannelAddress(_) => 4,
-            _ => 0,
-        }
-    }
-}
-
-pub enum HostAddressType {
-    Ipv4 = 0,
-    Ipv6 = 1,
-}
-
-#[derive(Copy)]
-#[repr(u8)]
-pub enum AddressType {
-    Undefined = 255,
-    Local = 0,
-    Tcp = 1,
-    Udp = 2,
-    Channel = 129,
-}
-
-impl std::fmt::Debug for AddressType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        let s: String;
-        match self {
-            AddressType::Local => {
-                s = "local".to_string();
-            }
-            AddressType::Tcp => {
-                s = "Tcp".to_string();
-            }
-            AddressType::Udp => {
-                s = "Udp".to_string();
-            }
-            AddressType::Channel => {
-                s = "Channel".to_string();
-            }
-            AddressType::Undefined => {
-                s = "Undefined".to_string();
-            }
-        }
-        f.debug_struct("AddressType").field("Type", &s).finish()?;
-        Ok(())
-    }
-}
-
-impl PartialEq for AddressType {
-    fn eq(&self, other: &Self) -> bool {
-        let t: u8 = *self as u8;
-        let o = *other as u8;
-        o == t
-    }
-}
-
-impl TryFrom<u8> for HostAddressType {
-    type Error = String;
-    fn try_from(data: u8) -> Result<Self, Self::Error> {
-        match data {
-            0 => Ok(HostAddressType::Ipv4),
-            1 => Ok(HostAddressType::Ipv6),
-            _ => Err("Unknown host address type".to_string()),
-        }
-    }
-}
-
-impl TryFrom<u8> for AddressType {
-    type Error = String;
-    fn try_from(data: u8) -> Result<Self, Self::Error> {
-        match data {
-            255 => Ok(AddressType::Undefined),
-            0 => Ok(AddressType::Local),
-            1 => Ok(AddressType::Tcp),
-            2 => Ok(AddressType::Udp),
-            129 => Ok(AddressType::Channel),
-            _ => Err("Unknown address type".to_string()),
-        }
-    }
-}
-
-impl Codec for RouterAddress {
-    type Inner = RouterAddress;
-    fn encode(a: RouterAddress, v: &mut Vec<u8>) -> Result<(), String> {
-        v.push(a.a_type as u8);
-        v.push(a.length as u8);
-
-        match a.a_type {
-            AddressType::Local => {
-                if let Address::LocalAddress(la) = a.address {
-                    LocalAddress::encode(la, v)?;
+        fn decode(u: &[u8]) -> Result<(Message, &[u8]), String> {
+            let mut msg = Message::default();
+            let mut w = &u[1..];
+            match Route::decode(w) {
+                Ok((r, u1)) => {
+                    msg.onward_route = r;
+                    w = u1;
+                }
+                Err(s) => {
+                    return Err(s);
                 }
             }
-            AddressType::Udp => {
-                if let Address::UdpAddress(sock_addr) = a.address {
-                    SocketAddr::encode(sock_addr, v)?;
+            match Route::decode(w) {
+                Ok((r, u1)) => {
+                    msg.return_route = r;
+                    w = u1;
+                }
+                Err(s) => {
+                    return Err(s);
                 }
             }
-            AddressType::Channel => {
-                if let Address::ChannelAddress(a) = a.address {
-                    v.append(&mut a.to_le_bytes().to_vec());
+            msg.message_type = MessageType::try_from(w[0])?;
+            let mut w = &w[1..];
+            msg.message_body = w.to_vec();
+            Ok((msg, w))
+        }
+    }
+
+    /* Addresses */
+    #[derive(Debug, PartialEq)]
+    #[repr(C)]
+    #[derive(Clone)]
+    pub struct RouterAddress {
+        pub a_type: AddressType,
+        pub length: u8,
+        pub address: Address,
+    }
+
+    impl Clone for AddressType {
+        fn clone(&self) -> Self {
+            match self {
+                //                AddressType::Local => AddressType::Local,
+                AddressType::Tcp => AddressType::Tcp,
+                AddressType::Udp => AddressType::Udp,
+                AddressType::Channel => AddressType::Channel,
+                AddressType::Worker => AddressType::Worker,
+                AddressType::Undefined => AddressType::Undefined,
+            }
+        }
+    }
+
+    #[repr(C)]
+    //    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum Address {
+        //        LocalAddress(u32),
+        TcpAddress(IpAddr, u16),
+        UdpAddress(SocketAddr),
+        ChannelAddress(Vec<u8>),
+        WorkerAddress(Vec<u8>),
+    }
+
+    impl Address {
+        pub fn as_string(&self) -> String {
+            match self {
+                Address::UdpAddress(socket) => socket.to_string(),
+                Address::ChannelAddress(u) => hex::encode(u.as_slice()),
+                _ => "error".to_string(),
+            }
+        }
+        pub fn size_of(&self) -> u8 {
+            match self {
+                Address::WorkerAddress(a) => a.len() as u8,
+                Address::UdpAddress(s) => 7,
+                Address::ChannelAddress(a) => a.len() as u8,
+                _ => 0,
+            }
+        }
+    }
+
+    pub enum HostAddressType {
+        Ipv4 = 0,
+        Ipv6 = 1,
+    }
+
+    #[derive(Copy)]
+    #[repr(u8)]
+    pub enum AddressType {
+        Undefined = 255,
+        //        Local = 130,
+        Tcp = 1,
+        Udp = 2,
+        Channel = 129,
+        Worker = 0,
+    }
+
+    impl std::fmt::Debug for AddressType {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+            let s: String;
+            match self {
+                // AddressType::Local => {
+                //     s = "local".to_string();
+                // }
+                AddressType::Tcp => {
+                    s = "Tcp".to_string();
+                }
+                AddressType::Udp => {
+                    s = "Udp".to_string();
+                }
+                AddressType::Channel => {
+                    s = "Channel".to_string();
+                }
+                AddressType::Worker => {
+                    s = "Worker".to_string();
+                }
+                AddressType::Undefined => {
+                    s = "Undefined".to_string();
                 }
             }
-            _ => {}
-        }
-        Ok(())
-    }
-    fn decode(u: &[u8]) -> Result<(RouterAddress, &[u8]), String> {
-        let a_type;
-        match AddressType::try_from(u[0]) {
-            Ok(t) => {
-                a_type = t;
-            }
-            Err(s) => return Err(s),
-        }
-        match a_type {
-            AddressType::Channel => {
-                let address = Address::ChannelAddress(u32::from_le_bytes([u[2], u[3], u[4], u[5]]));
-                Ok((
-                    RouterAddress {
-                        a_type: AddressType::Channel,
-                        length: u[1],
-                        address,
-                    },
-                    &u[6..],
-                ))
-            }
-            AddressType::Udp => {
-                let (sock, _) = SocketAddr::decode(&u[2..])?;
-                Ok((
-                    RouterAddress {
-                        a_type: AddressType::Udp,
-                        length: u[1],
-                        address: Address::UdpAddress(sock),
-                    },
-                    &u[u[1] as usize + 2..],
-                ))
-            }
-            _ => Err("unimplemented address type".to_string()),
-        }
-    }
-}
-
-impl Codec for IpAddr {
-    type Inner = IpAddr;
-    fn encode(ip: IpAddr, v: &mut Vec<u8>) -> Result<(), String> {
-        match ip {
-            std::net::IpAddr::V4(ip4) => {
-                v.push(HostAddressType::Ipv4 as u8);
-                v.extend_from_slice(ip4.octets().as_ref());
-            }
-            std::net::IpAddr::V6(ip6) => {
-                v.push(HostAddressType::Ipv6 as u8);
-                v.extend_from_slice(ip6.octets().as_ref());
-            }
-        }
-        Ok(())
-    }
-    fn decode(u: &[u8]) -> Result<(IpAddr, &[u8]), String> {
-        match (HostAddressType::try_from(u[0])?, &u[1..]) {
-            (HostAddressType::Ipv4, addr) => {
-                let ip4 = Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]);
-                let ip_addr = IpAddr::V4(ip4);
-                Ok((ip_addr, &u[5..]))
-            }
-            _ => Err("".to_string()),
-        }
-    }
-}
-
-impl Codec for SocketAddr {
-    type Inner = SocketAddr;
-    fn encode(sock: SocketAddr, v: &mut Vec<u8>) -> Result<(), String> {
-        match sock {
-            std::net::SocketAddr::V4(sock4) => {
-                v.push(HostAddressType::Ipv4 as u8);
-                v.extend_from_slice(sock4.ip().octets().as_ref());
-                let p = sock4.port();
-                v.extend_from_slice(&p.to_le_bytes());
-            }
-            std::net::SocketAddr::V6(sock6) => {
-                v.push(HostAddressType::Ipv6 as u8);
-                v.extend_from_slice(sock6.ip().octets().as_ref());
-                let p = sock6.port();
-                v.extend_from_slice(&p.to_le_bytes());
-            }
-        }
-        Ok(())
-    }
-    fn decode(u: &[u8]) -> Result<(SocketAddr, &[u8]), String> {
-        match (HostAddressType::try_from(u[0])?, &u[1..]) {
-            (HostAddressType::Ipv4, addr) => {
-                let ip4 = Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]);
-                let port = u16::from_le_bytes([addr[4], addr[5]]);
-                let sock = SocketAddr::new(IpAddr::V4(ip4), port);
-                Ok((sock, &addr[6..]))
-            }
-            _ => Err("".to_string()),
-        }
-    }
-}
-
-impl Codec for LocalAddress {
-    type Inner = LocalAddress;
-    fn encode(la: LocalAddress, u: &mut Vec<u8>) -> Result<(), String> {
-        for le_byte in la.address.to_le_bytes().iter() {
-            u.push(*le_byte);
-        }
-        Ok(())
-    }
-    fn decode(u: &[u8]) -> Result<(LocalAddress, &[u8]), String> {
-        Ok((
-            LocalAddress {
-                address: u32::from_le_bytes([u[0], u[1], u[2], u[3]]),
-            },
-            &u[4..],
-        ))
-    }
-}
-
-impl RouterAddress {
-    pub fn size_of(&self) -> u8 {
-        match self.address {
-            Address::LocalAddress(_) => 4,
-            Address::UdpAddress(_) => 7,
-            Address::ChannelAddress(_) => 4,
-            _ => 0,
-        }
-    }
-    pub fn from_address(a: Address) -> Option<RouterAddress> {
-        match a {
-            Address::UdpAddress(sock_addr) => Some(RouterAddress {
-                a_type: AddressType::Udp,
-                length: a.size_of(),
-                address: Address::UdpAddress(sock_addr),
-            }),
-            Address::ChannelAddress(_unused) => Some(RouterAddress {
-                a_type: AddressType::Channel,
-                length: a.size_of(),
-                address: a,
-            }),
-            _ => None,
-        }
-    }
-    pub fn udp_router_address_from_str(s: &str) -> Result<RouterAddress, String> {
-        match SocketAddr::from_str(s) {
-            Ok(s) => Ok(RouterAddress {
-                a_type: AddressType::Udp,
-                length: 7,
-                address: Address::UdpAddress(s),
-            }),
-            Err(_unused) => Err("failed to parse router address".to_string()),
-        }
-    }
-    pub fn channel_router_address_from_u32(a: u32) -> Result<RouterAddress, String> {
-        Ok(RouterAddress {
-            a_type: AddressType::Channel,
-            length: 4,
-            address: Address::ChannelAddress(a),
-        })
-    }
-}
-
-/* Routes */
-#[repr(C)]
-pub struct Route {
-    pub addresses: Vec<RouterAddress>,
-}
-
-impl Clone for Route {
-    fn clone(&self) -> Self {
-        Route {
-            addresses: self.addresses.clone(),
+            f.debug_struct("AddressType").field("Type", &s).finish();
+            Ok(())
         }
     }
 
-    fn clone_from(&mut self, _: &Self) {
-        unimplemented!()
+    impl PartialEq for AddressType {
+        fn eq(&self, other: &Self) -> bool {
+            let t: u8 = *self as u8;
+            let o = *other as u8;
+            o == t
+        }
     }
-}
 
-impl Codec for Route {
-    type Inner = Route;
-    fn encode(route: Route, u: &mut Vec<u8>) -> Result<(), String> {
-        if route.addresses.is_empty() {
-            u.push(0 as u8)
-        } else {
-            u.push(route.addresses.len() as u8);
-            for i in 0..route.addresses.len() {
-                RouterAddress::encode(route.addresses[i], u)?;
+    impl TryFrom<u8> for MessageType {
+        type Error = String;
+        fn try_from(data: u8) -> Result<Self, Self::Error> {
+            match data {
+                0 => Ok(MessageType::Ping),
+                1 => Ok(MessageType::Pong),
+                2 => Ok(MessageType::Payload),
+                3 => Ok(MessageType::KeyAgreementM1),
+                4 => Ok(MessageType::KeyAgreementM2),
+                5 => Ok(MessageType::KeyAgreementM3),
+                _ => Err("Unknown message type".to_string()),
             }
         }
-        Ok(())
     }
-    fn decode(encoded: &[u8]) -> Result<(Route, &[u8]), String> {
-        let mut route = Route { addresses: vec![] };
-        let mut next_address = &encoded[1..];
-        if 0 < encoded[0] {
-            for _ in 0..encoded[0] as usize {
-                if let Ok((a, x)) = RouterAddress::decode(next_address) {
-                    route.addresses.push(a);
-                    next_address = x;
+
+    impl TryFrom<u8> for HostAddressType {
+        type Error = String;
+        fn try_from(data: u8) -> Result<Self, Self::Error> {
+            match data {
+                0 => Ok(HostAddressType::Ipv4),
+                1 => Ok(HostAddressType::Ipv6),
+                _ => Err("Unknown host address type".to_string()),
+            }
+        }
+    }
+
+    impl TryFrom<u8> for AddressType {
+        type Error = String;
+        fn try_from(data: u8) -> Result<Self, Self::Error> {
+            match data {
+                255 => Ok(AddressType::Undefined),
+                1 => Ok(AddressType::Tcp),
+                2 => Ok(AddressType::Udp),
+                129 => Ok(AddressType::Channel),
+                0 => Ok(AddressType::Worker),
+                _ => Err("Unknown address type".to_string()),
+            }
+        }
+    }
+
+    impl Codec for RouterAddress {
+        type Inner = RouterAddress;
+        fn encode(a: RouterAddress, v: &mut Vec<u8>) -> Result<(), String> {
+            v.push(a.a_type as u8);
+            v.push(a.length as u8);
+
+            match a.a_type {
+                AddressType::Worker => {
+                    if let Address::WorkerAddress(mut wa) = a.address {
+                        v.append(&mut wa);
+                    }
+                }
+                AddressType::Udp => {
+                    if let Address::UdpAddress(sock_addr) = a.address {
+                        SocketAddr::encode(sock_addr, v);
+                    }
+                }
+                AddressType::Channel => {
+                    if let Address::ChannelAddress(mut a) = a.address {
+                        v.append(&mut a);
+                    }
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+        fn decode(u: &[u8]) -> Result<(RouterAddress, &[u8]), String> {
+            let mut a_type = AddressType::Undefined;
+            match AddressType::try_from(u[0]) {
+                Ok(t) => {
+                    a_type = t;
+                }
+                Err(s) => return Err(s),
+            }
+            match a_type {
+                AddressType::Channel => {
+                    let length = u[1] as usize;
+                    let addr: Vec<u8> = u[2..(length + 2)].to_vec();
+                    Ok((
+                        RouterAddress {
+                            a_type: AddressType::Channel,
+                            length: addr.len() as u8,
+                            address: Address::ChannelAddress(addr),
+                        },
+                        &u[(length + 2)..],
+                    ))
+                }
+                AddressType::Worker => {
+                    let length = u[1] as usize;
+                    let addr: Vec<u8> = u[2..(length + 2)].to_vec();
+                    Ok((
+                        RouterAddress {
+                            a_type: AddressType::Worker,
+                            length: addr.len() as u8,
+                            address: Address::WorkerAddress(addr),
+                        },
+                        &u[(length + 2)..],
+                    ))
+                }
+                AddressType::Udp => {
+                    let (sock, v) = SocketAddr::decode(&u[2..])?;
+                    let address = Address::UdpAddress(sock);
+                    Ok((
+                        RouterAddress {
+                            a_type: AddressType::Udp,
+                            length: u[1],
+                            address: Address::UdpAddress(sock),
+                        },
+                        &u[u[1] as usize + 2..],
+                    ))
+                }
+                _ => Err("unimplemented address type".to_string()),
+            }
+        }
+    }
+
+    impl Codec for IpAddr {
+        type Inner = IpAddr;
+        fn encode(ip: IpAddr, v: &mut Vec<u8>) -> Result<(), String> {
+            match ip {
+                std::net::IpAddr::V4(ip4) => {
+                    v.push(HostAddressType::Ipv4 as u8);
+                    v.extend_from_slice(ip4.octets().as_ref());
+                }
+                std::net::IpAddr::V6(ip6) => {
+                    v.push(HostAddressType::Ipv6 as u8);
+                    v.extend_from_slice(ip6.octets().as_ref());
+                }
+            }
+            Ok(())
+        }
+        fn decode(u: &[u8]) -> Result<(IpAddr, &[u8]), String> {
+            match (HostAddressType::try_from(u[0])?, &u[1..]) {
+                (HostAddressType::Ipv4, addr) => {
+                    let ip4 = Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]);
+                    let ip_addr = IpAddr::V4(ip4);
+                    Ok((ip_addr, &u[5..]))
+                }
+                _ => Err("".to_string()),
+            }
+        }
+    }
+
+    impl Codec for SocketAddr {
+        type Inner = SocketAddr;
+        fn encode(sock: SocketAddr, v: &mut Vec<u8>) -> Result<(), String> {
+            match sock {
+                std::net::SocketAddr::V4(sock4) => {
+                    v.push(HostAddressType::Ipv4 as u8);
+                    v.extend_from_slice(sock4.ip().octets().as_ref());
+                    let p = sock4.port();
+                    v.extend_from_slice(&p.to_le_bytes());
+                }
+                std::net::SocketAddr::V6(sock6) => {
+                    v.push(HostAddressType::Ipv6 as u8);
+                    v.extend_from_slice(sock6.ip().octets().as_ref());
+                    let p = sock6.port();
+                    v.extend_from_slice(&p.to_le_bytes());
+                }
+            }
+            Ok(())
+        }
+        fn decode(u: &[u8]) -> Result<(SocketAddr, &[u8]), String> {
+            match (HostAddressType::try_from(u[0])?, &u[1..]) {
+                (HostAddressType::Ipv4, addr) => {
+                    let ip4 = Ipv4Addr::new(addr[0], addr[1], addr[2], addr[3]);
+                    let port = u16::from_le_bytes([addr[4], addr[5]]);
+                    let sock = SocketAddr::new(IpAddr::V4(ip4), port);
+                    Ok((sock, &addr[6..]))
+                }
+                _ => Err("".to_string()),
+            }
+        }
+    }
+
+    impl Route {
+        pub fn print_route(&self) {
+            for a in &self.addresses {
+                match &a.address {
+                    Address::UdpAddress(udp) => {
+                        println!("Udp: {}", udp.to_string());
+                    }
+                    Address::WorkerAddress(wa) => {
+                        println!("Worker: {}", hex::encode(wa));
+                    }
+                    Address::ChannelAddress(ca) => {
+                        println!("Channel: {}", hex::encode(ca));
+                    }
+                    _ => {
+                        println!("print_route not implementd for type");
+                    }
                 }
             }
         }
-        Ok((route, next_address))
     }
-}
 
-// ToDo: Implement PartialEq, Eq, Copy, Clone
-
-// u16's are encoded as variable-length.
-// - If the value is < 0x80, it is encoded as-is, in one byte
-// - If the value is <= 0x80, the highest-order of the low-order byte is moved to the lowest-order
-//   bit in the high-order byte, and the high-order byte is shifted left by one to make room.
-impl Codec for u16 {
-    type Inner = u16;
-    fn encode(ul2: u16, u: &mut Vec<u8>) -> Result<(), String> {
-        if ul2 >= 0xC000 {
-            return Err("Maximum value exceeded".to_string());
-        }
-        let mut bytes = ul2.to_le_bytes();
-
-        if ul2 < 0x80 {
-            u.push(bytes[0])
-        } else {
-            bytes[1] <<= 0x01;
-            if 0 != (bytes[0] & 0x80) {
-                bytes[1] |= 0x01;
+    impl RouterAddress {
+        pub fn size_of(&self) -> u8 {
+            match &self.address {
+                Address::WorkerAddress(a) => a.len() as u8,
+                Address::UdpAddress(_unused) => 7,
+                Address::ChannelAddress(a) => a.len() as u8,
+                _ => 0,
             }
-            bytes[0] |= 0x80;
-            u.push(bytes[0]);
-            u.push(bytes[1])
         }
-        Ok(())
+        pub fn from_address(a: Address) -> Option<RouterAddress> {
+            match &a {
+                Address::UdpAddress(sock_addr) => Some(RouterAddress {
+                    a_type: AddressType::Udp,
+                    length: a.size_of(),
+                    address: Address::UdpAddress(*sock_addr),
+                }),
+                Address::ChannelAddress(ca) => Some(RouterAddress {
+                    a_type: AddressType::Channel,
+                    length: ca.len() as u8,
+                    address: Address::ChannelAddress(ca.clone()),
+                }),
+                _ => None,
+            }
+        }
+        pub fn udp_router_address_from_str(s: &str) -> Result<RouterAddress, String> {
+            match SocketAddr::from_str(s) {
+                Ok(s) => Ok(RouterAddress {
+                    a_type: AddressType::Udp,
+                    length: 7,
+                    address: Address::UdpAddress(s),
+                }),
+                Err(_unused) => Err("failed to parse router address".to_string()),
+            }
+        }
+        pub fn channel_router_address_from_str(a: &str) -> Result<RouterAddress, String> {
+            match hex::decode(a) {
+                Ok(h) => Ok(RouterAddress {
+                    a_type: AddressType::Channel,
+                    length: h.len() as u8,
+                    address: Address::ChannelAddress(h),
+                }),
+                Err(_unused) => Err("string contains non-hex chars".to_string()),
+            }
+        }
+        pub fn worker_router_address_from_str(a: &str) -> Result<RouterAddress, String> {
+            match hex::decode(a) {
+                Ok(h) => Ok(RouterAddress {
+                    a_type: AddressType::Worker,
+                    length: h.len() as u8,
+                    address: Address::WorkerAddress(h),
+                }),
+                Err(_unused) => Err("string contains non-hex chars".to_string()),
+            }
+        }
     }
 
-    fn decode(u: &[u8]) -> Result<(u16, &[u8]), String> {
-        let mut bytes = [0, 0];
-        let mut i = 1;
-
-        bytes[0] = u[0] & 0x7f;
-        if (u[0] & 0x80) == 0x80 as u8 {
-            bytes[0] += (u[1] & 0x01) << 7;
-            bytes[1] = u[1] >> 1;
-            i = 2;
-        }
-        let ul2 = ((bytes[1] as u16) << 8) + bytes[0] as u16;
-
-        Ok((ul2, &u[i..]))
+    /* Routes */
+    #[repr(C)]
+    pub struct Route {
+        pub addresses: Vec<RouterAddress>,
     }
-}
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct WireProtocolVersion {
-    pub v: u16,
-}
+    impl Clone for Route {
+        fn clone(&self) -> Self {
+            Route {
+                addresses: self.addresses.clone(),
+            }
+        }
 
-impl Default for WireProtocolVersion {
-    fn default() -> WireProtocolVersion {
-        WireProtocolVersion { v: 1 }
+        fn clone_from(&mut self, source: &Self) {
+            unimplemented!()
+        }
     }
-}
 
-// std::io::Read & std::io::Write trait implementation
-impl std::io::Read for Message {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
-        if buf.len() < self.message_body.len() {
-            return Err(std::io::Error::new(ErrorKind::Other, "buffer too small"));
+    impl Codec for Route {
+        type Inner = Route;
+        fn encode(route: Route, u: &mut Vec<u8>) -> Result<(), String> {
+            if route.addresses.is_empty() {
+                u.push(0 as u8)
+            } else {
+                u.push(route.addresses.len() as u8);
+                for i in 0..route.addresses.len() {
+                    RouterAddress::encode(route.addresses[i].clone(), u);
+                }
+            }
+            Ok(())
         }
-        buf[..self.message_body.len()].clone_from_slice(&self.message_body[..]);
-        Ok(self.message_body.len())
+        fn decode(encoded: &[u8]) -> Result<(Route, &[u8]), String> {
+            let mut route = Route { addresses: vec![] };
+            let mut next_address = &encoded[1..];
+            if 0 < encoded[0] {
+                for i in 0..encoded[0] as usize {
+                    match RouterAddress::decode(next_address) {
+                        Ok((a, x)) => {
+                            route.addresses.push(a);
+                            next_address = x;
+                        }
+                        Err(s) => {}
+                    }
+                }
+            }
+            Ok((route, next_address))
+        }
     }
-}
-impl std::io::Write for Message {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
-        if !self.message_body.is_empty() {
-            return Err(std::io::Error::new(ErrorKind::Other, "no message body"));
+
+    // ToDo: Implement PartialEq, Eq, Copy, Clone
+
+    // u16's are encoded as variable-length.
+    // - If the value is < 0x80, it is encoded as-is, in one byte
+    // - If the value is <= 0x80, the highest-order of the low-order byte is moved to the
+    //   lowest-order bit in the high-order byte, and the high-order byte is shifted left by one to
+    //   make room.
+    impl Codec for u16 {
+        type Inner = u16;
+        fn encode(ul2: u16, u: &mut Vec<u8>) -> Result<(), String> {
+            if ul2 >= 0xC000 {
+                return Err("Maximum value exceeded".to_string());
+            }
+            let mut bytes = ul2.to_le_bytes();
+
+            if ul2 < 0x80 {
+                u.push(bytes[0])
+            } else {
+                bytes[1] <<= 0x01;
+                if 0 != (bytes[0] & 0x80) {
+                    bytes[1] |= 0x01;
+                }
+                bytes[0] |= 0x80;
+                u.push(bytes[0]);
+                u.push(bytes[1])
+            }
+            Ok(())
         }
-        for b in buf {
-            self.message_body.push(*b);
+
+        fn decode(u: &[u8]) -> Result<(u16, &[u8]), String> {
+            let mut bytes = [0, 0];
+            let mut i = 1;
+
+            bytes[0] = u[0] & 0x7f;
+            if (u[0] & 0x80) == 0x80 as u8 {
+                bytes[0] += (u[1] & 0x01) << 7;
+                bytes[1] = u[1] >> 1;
+                i = 2;
+            }
+            let ul2 = ((bytes[1] as u16) << 8) + bytes[0] as u16;
+
+            Ok((ul2, &u[i..]))
         }
-        Ok(self.message_body.len())
     }
-    fn flush(&mut self) -> Result<(), std::io::Error> {
-        Ok(())
+
+    #[derive(Debug)]
+    #[repr(C)]
+    pub struct WireProtocolVersion {
+        pub v: u16,
+    }
+
+    impl Default for WireProtocolVersion {
+        fn default() -> WireProtocolVersion {
+            WireProtocolVersion { v: 1 }
+        }
+    }
+
+    // std::io::Read & std::io::Write trait implementation
+    impl std::io::Read for Message {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+            if buf.len() < self.message_body.len() {
+                return Err(std::io::Error::new(ErrorKind::Other, "buffer too small"));
+            }
+            buf[..self.message_body.len()].clone_from_slice(&self.message_body[..]);
+            Ok(self.message_body.len())
+        }
+    }
+    impl std::io::Write for Message {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
+            if !self.message_body.is_empty() {
+                return Err(std::io::Error::new(ErrorKind::Other, "no message body"));
+            }
+            for b in buf {
+                self.message_body.push(*b);
+            }
+            Ok(self.message_body.len())
+        }
+        fn flush(&mut self) -> Result<(), std::io::Error> {
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use crate::message::*;
+    use std::net::{AddrParseError, IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
 
     #[test]
@@ -536,35 +612,14 @@ mod tests {
     }
 
     #[test]
-    fn local_address_codec() {
-        let local_in = LocalAddress {
-            address: 0x00010203,
-        };
-        let mut v: Vec<u8> = vec![];
-        LocalAddress::encode(local_in, &mut v).unwrap();
-        assert_eq!(v, [3, 2, 1, 0]);
-        match LocalAddress::decode(&v) {
-            Ok((local_out, _)) => assert_eq!(
-                local_out,
-                LocalAddress {
-                    address: 0x00010203
-                }
-            ),
-            Err(s) => {
-                println!("{:?}", s);
-            }
-        }
-    }
-
-    #[test]
     fn ip4_address_codec() {
         let mut v: Vec<u8> = vec![];
-        let ip4a: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        IpAddr::encode(ip4a, &mut v).unwrap();
+        let mut ip4a: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        IpAddr::encode(ip4a, &mut v);
         assert_eq!(v, vec![0, 127, 0, 0, 1]);
-        let v = vec![0u8, 127u8, 0u8, 0u8, 1u8];
+        let mut v: Vec<u8> = vec![0, 127, 0, 0, 1];
         match IpAddr::decode(&v) {
-            Ok((ip4a, _)) => {
+            Ok((ip4a, w)) => {
                 assert_eq!(ip4a, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
             }
             Err(s) => {
@@ -575,21 +630,23 @@ mod tests {
 
     #[test]
     fn address_codec() {
+        // Socket address
         let sa = SocketAddr::from_str("127.0.0.1:32896").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
-            address: udp_address,
+            address: udp_address.clone(),
         };
         assert_eq!(udp_address.as_string(), "127.0.0.1:32896");
         router_address.length = router_address.size_of();
         let mut v: Vec<u8> = vec![];
-        RouterAddress::encode(router_address, &mut v).unwrap();
+        RouterAddress::encode(router_address, &mut v);
         assert_eq!(v, vec![2, 7, 0, 127, 0, 0, 1, 0x80, 0x80]);
+
         let mut v = vec![2, 7, 0, 127, 0, 0, 1, 0x80, 0x80];
         match RouterAddress::decode(&mut v) {
-            Ok((ra, _)) => {
+            Ok((ra, w)) => {
                 assert_eq!(ra.a_type, AddressType::Udp);
                 assert_eq!(ra.length, 7);
                 match ra.address {
@@ -611,16 +668,14 @@ mod tests {
                 println!("{}", s);
             }
         }
-        let channel_address = Address::ChannelAddress(0x00010203);
-        let mut router_address = RouterAddress {
-            a_type: AddressType::Channel,
-            length: 0,
-            address: channel_address,
-        };
-        router_address.length = router_address.size_of();
+
+        // Channel address
+        let mut router_channel_address =
+            RouterAddress::channel_router_address_from_str("00010203").unwrap();
         let mut v: Vec<u8> = vec![];
-        RouterAddress::encode(router_address, &mut v).unwrap();
-        assert_eq!(v, vec![129, 4, 3, 2, 1, 0]);
+        RouterAddress::encode(router_channel_address, &mut v);
+        assert_eq!(v, vec![129, 4, 0, 1, 2, 3]);
+
         let mut v = vec![129, 4, 3, 2, 1, 0];
         match RouterAddress::decode(&mut v) {
             Ok((ra, _unused)) => {
@@ -628,7 +683,7 @@ mod tests {
                 assert_eq!(ra.length, 4);
                 match ra.address {
                     Address::ChannelAddress(c) => {
-                        assert_eq!(c, 0x00010203);
+                        assert_eq!(c, vec![3 as u8, 2 as u8, 1 as u8, 0 as u8]);
                     }
                     _ => {}
                 }
@@ -643,7 +698,7 @@ mod tests {
     fn route_codec() {
         let mut route = Route { addresses: vec![] };
         let sa = SocketAddr::from_str("127.0.0.1:32896").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
@@ -653,7 +708,7 @@ mod tests {
         route.addresses.push(router_address);
 
         let sa = SocketAddr::from_str("10.0.1.10:32912").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
@@ -662,7 +717,7 @@ mod tests {
         router_address.length = router_address.size_of();
         route.addresses.push(router_address);
 
-        let channel_address = Address::ChannelAddress(0x00010203);
+        let mut channel_address = Address::ChannelAddress(vec![0, 1, 2, 3]);
         let mut router_address = RouterAddress {
             a_type: AddressType::Channel,
             length: 0,
@@ -672,16 +727,16 @@ mod tests {
         route.addresses.push(router_address);
 
         let mut v: Vec<u8> = vec![];
-        Route::encode(route, &mut v).unwrap();
+        Route::encode(route, &mut v);
         assert_eq!(
             v,
             vec![
-                3, 2, 7, 0, 127, 0, 0, 1, 0x80, 0x80, 2, 7, 0, 10, 0, 1, 10, 0x90, 0x80, 129, 4, 3,
-                2, 1, 0
+                3, 2, 7, 0, 127, 0, 0, 1, 0x80, 0x80, 2, 7, 0, 10, 0, 1, 10, 0x90, 0x80, 129, 4, 0,
+                1, 2, 3
             ]
         );
         match Route::decode(&v) {
-            Ok((r, _)) => {
+            Ok((r, u)) => {
                 assert_eq!(r.addresses.len(), 3);
 
                 match r.addresses[0].a_type {
@@ -731,9 +786,9 @@ mod tests {
                 match r.addresses[2].a_type {
                     AddressType::Channel => {
                         assert_eq!(r.addresses[2].length, 4);
-                        match r.addresses[2].address {
+                        match &r.addresses[2].address {
                             Address::ChannelAddress(a) => {
-                                assert_eq!(a, 0x00010203);
+                                assert_eq!(a, &vec![0 as u8, 1 as u8, 2 as u8, 3 as u8]);
                             }
                             _ => {
                                 assert!(false);
@@ -748,7 +803,7 @@ mod tests {
                 assert_eq!(v.len(), 25);
             }
             Err(s) => {
-                panic!("{:?}", s);
+                panic!();
             }
         }
     }
@@ -756,28 +811,28 @@ mod tests {
     #[test]
     fn u16_codec() {
         let mut u: Vec<u8> = vec![];
-        let n: u16 = 0x7f;
-        u16::encode(n, &mut u).unwrap();
+        let mut n: u16 = 0x7f;
+        u16::encode(n, &mut u);
         assert_eq!(u.len(), 1);
         assert_eq!(u[0], 0x7f);
         match u16::decode(&u) {
-            Ok((_, v)) => {
+            Ok((m, v)) => {
                 assert_eq!(u[0], 0x7f);
                 assert_eq!(v.len(), 0);
             }
-            Err(s) => panic!("{:?}", s),
+            Err(s) => panic!(),
         }
 
-        let too_big: u16 = 0xC000;
+        let mut too_big: u16 = 0xC000;
         let mut u: Vec<u8> = vec![];
         match u16::encode(too_big, &mut u) {
             Ok(()) => panic!(),
-            Err(_) => {}
+            Err(s) => {}
         }
 
-        let n = 0x80;
+        let mut n = 0x80;
         let mut u: Vec<u8> = vec![];
-        u16::encode(n, &mut u).unwrap();
+        u16::encode(n, &mut u);
         assert_eq!(u.len(), 2);
         assert_eq!(u[0], 0x80);
         assert_eq!(u[1], 0x01);
@@ -786,12 +841,12 @@ mod tests {
                 assert_eq!(m, 0x80);
                 assert_eq!(v.len(), 0);
             }
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!(),
         }
 
-        let n = 0x1300;
+        let mut n = 0x1300;
         let mut u: Vec<u8> = vec![];
-        u16::encode(n, &mut u).unwrap();
+        u16::encode(n, &mut u);
         assert_eq!(u.len(), 2);
         assert_eq!(u[1], 0x13 << 1);
         assert_eq!(u[0], 0x80);
@@ -800,12 +855,12 @@ mod tests {
                 assert_eq!(m, 0x1300);
                 assert_eq!(v.len(), 0);
             }
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!(),
         }
 
-        let n = 0x1381;
+        let mut n = 0x1381;
         let mut u: Vec<u8> = vec![];
-        u16::encode(n, &mut u).unwrap();
+        u16::encode(n, &mut u);
         assert_eq!(u.len(), 2);
         assert_eq!(u[1], (0x13 << 1) | 1);
         assert_eq!(u[0], 0x81);
@@ -814,15 +869,16 @@ mod tests {
                 assert_eq!(m, 0x1381);
                 assert_eq!(v.len(), 0);
             }
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!(),
         }
     }
 
     #[test]
     fn message_codec() {
         let mut onward_route = Route { addresses: vec![] };
+        let mut route = Route { addresses: vec![] };
         let sa = SocketAddr::from_str("127.0.0.1:32896").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
@@ -832,7 +888,7 @@ mod tests {
         onward_route.addresses.push(router_address);
 
         let sa = SocketAddr::from_str("10.0.1.10:32912").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
@@ -841,7 +897,7 @@ mod tests {
         router_address.length = router_address.size_of();
         onward_route.addresses.push(router_address);
 
-        let channel_address = Address::ChannelAddress(0x00010203);
+        let mut channel_address = Address::ChannelAddress(vec![0, 1, 2, 3]);
         let mut router_address = RouterAddress {
             a_type: AddressType::Channel,
             length: 0,
@@ -852,7 +908,7 @@ mod tests {
 
         let mut return_route = Route { addresses: vec![] };
         let sa = SocketAddr::from_str("127.0.0.1:32896").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
@@ -862,7 +918,7 @@ mod tests {
         return_route.addresses.push(router_address);
 
         let sa = SocketAddr::from_str("10.0.1.10:32912").unwrap();
-        let udp_address = Address::UdpAddress(sa);
+        let mut udp_address = Address::UdpAddress(sa);
         let mut router_address = RouterAddress {
             a_type: AddressType::Udp,
             length: 0,
@@ -871,7 +927,7 @@ mod tests {
         router_address.length = router_address.size_of();
         return_route.addresses.push(router_address);
 
-        let channel_address = Address::ChannelAddress(0x00010203);
+        let mut channel_address = Address::ChannelAddress(vec![0, 1, 2, 3]);
         let mut router_address = RouterAddress {
             a_type: AddressType::Channel,
             length: 0,
@@ -880,25 +936,26 @@ mod tests {
         router_address.length = router_address.size_of();
         return_route.addresses.push(router_address);
 
-        let message_body = vec![0];
-        let msg = Message {
+        let mut message_body = vec![1, 1, 1, 1];
+        let mut msg = Message {
             onward_route,
             return_route,
+            message_type: MessageType::Payload,
             message_body,
         };
         let mut u: Vec<u8> = vec![];
-        Message::encode(msg, &mut u).unwrap();
+        Message::encode(msg, &mut u);
         assert_eq!(
             u,
             vec![
-                3, 2, 7, 0, 127, 0, 0, 1, 0x80, 0x80, 2, 7, 0, 10, 0, 1, 10, 0x90, 0x80, 129, 4, 3,
-                2, 1, 0, 3, 2, 7, 0, 127, 0, 0, 1, 0x80, 0x80, 2, 7, 0, 10, 0, 1, 10, 0x90, 0x80,
-                129, 4, 3, 2, 1, 0, 0,
+                1, 3, 2, 7, 0, 127, 0, 0, 1, 0x80, 0x80, 2, 7, 0, 10, 0, 1, 10, 0x90, 0x80, 129, 4,
+                0, 1, 2, 3, 3, 2, 7, 0, 127, 0, 0, 1, 0x80, 0x80, 2, 7, 0, 10, 0, 1, 10, 0x90,
+                0x80, 129, 4, 0, 1, 2, 3, 2, 1, 1, 1, 1,
             ]
         );
 
         match Message::decode(&u) {
-            Ok((m, _)) => {
+            Ok((m, v)) => {
                 assert_eq!(m.onward_route.addresses.len(), 3);
 
                 match m.onward_route.addresses[0].a_type {
@@ -948,9 +1005,9 @@ mod tests {
                 match m.onward_route.addresses[2].a_type {
                     AddressType::Channel => {
                         assert_eq!(m.onward_route.addresses[2].length, 4);
-                        match m.onward_route.addresses[2].address {
+                        match &m.onward_route.addresses[2].address {
                             Address::ChannelAddress(a) => {
-                                assert_eq!(a, 0x00010203);
+                                assert_eq!(a, &vec![0 as u8, 1 as u8, 2 as u8, 3 as u8]);
                             }
                             _ => {
                                 assert!(false);
@@ -961,7 +1018,8 @@ mod tests {
                         assert!(false);
                     }
                 }
-                assert_eq!(m.message_body[0], 0);
+                assert_eq!(m.message_type as u8, MessageType::Payload as u8);
+                assert_eq!(&m.message_body[0..4], [1, 1, 1, 1]);
             }
             _ => {}
         }

--- a/implementations/rust/node/Cargo.toml
+++ b/implementations/rust/node/Cargo.toml
@@ -17,3 +17,5 @@ ockam-router = { version = "0.1", path = "../router" }
 ockam-transport = { version = "0.1", path = "../transport"}
 ockam-message = { version = "0.1", path = "../message"}
 ockam-common = { version = "0.1", path = "../common"}
+hex = "0.4.2"
+structopt = { version = "0.3.17", default-features = false }

--- a/implementations/rust/node/src/node.rs
+++ b/implementations/rust/node/src/node.rs
@@ -1,31 +1,58 @@
+#![allow(dead_code)]
 use ockam_common::commands::ockam_commands::*;
-use ockam_message::*;
-use ockam_router::*;
-use ockam_transport::*;
+use ockam_message::message::*;
+use ockam_router::router::*;
+use ockam_transport::transport::*;
+use std::net::SocketAddr;
 use std::str;
-use std::thread::sleep;
+use std::str::FromStr;
 use std::{thread, time};
+use structopt::StructOpt;
 
-pub struct TestChannel {
+#[derive(StructOpt, Debug)]
+#[structopt(author = "Ockam Developers (ockam.io)")]
+pub struct Args {
+    /// Local address to bind socket
+    #[structopt(short = "l", long = "local")]
+    local_socket: Option<String>,
+
+    /// Remote address to send to
+    #[structopt(short = "r", long = "remote")]
+    remote_socket: Option<String>,
+
+    /// Via - intermediate router
+    #[structopt(short = "v", long = "via")]
+    via_socket: Option<String>,
+
+    /// Worker
+    #[structopt(short = "w", long = "worker")]
+    worker_addr: Option<String>,
+
+    /// Message - message to send
+    #[structopt(short = "m", long = "message")]
+    message: Option<String>,
+}
+
+pub struct TestWorker {
     rx: std::sync::mpsc::Receiver<OckamCommand>,
     _tx: std::sync::mpsc::Sender<OckamCommand>,
     router_tx: std::sync::mpsc::Sender<OckamCommand>,
     toggle: u16,
 }
 
-impl TestChannel {
+impl TestWorker {
     pub fn new(
         rx: std::sync::mpsc::Receiver<OckamCommand>,
         tx: std::sync::mpsc::Sender<OckamCommand>,
         router_tx: std::sync::mpsc::Sender<OckamCommand>,
     ) -> Self {
         if let Err(_error) = router_tx.send(OckamCommand::Router(RouterCommand::Register(
-            AddressType::Channel,
+            AddressType::Worker,
             tx.clone(),
         ))) {
             println!("send failed in TestChannel::new")
         }
-        TestChannel {
+        TestWorker {
             rx,
             _tx: tx,
             router_tx,
@@ -41,10 +68,9 @@ impl TestChannel {
             if let Ok(c) = self.rx.try_recv() {
                 got = true;
                 match c {
-                    OckamCommand::Channel(ChannelCommand::SendMessage(mut m)) => {
+                    OckamCommand::Worker(WorkerCommand::SendMessage(mut m)) => {
                         // encrypt message body here
-                        let address = Address::ChannelAddress(1234);
-                        if let Some(r) = RouterAddress::from_address(address) {
+                        if let Ok(r) = RouterAddress::worker_router_address_from_str("01020304") {
                             m.return_route.addresses.push(r);
                         } else {
                             return false;
@@ -60,10 +86,10 @@ impl TestChannel {
                             }
                         }
                     }
-                    OckamCommand::Channel(ChannelCommand::ReceiveMessage(m)) => {
+                    OckamCommand::Worker(WorkerCommand::ReceiveMessage(m)) => {
                         // decrypt message body here
                         println!(
-                            "Channel received message: {}",
+                            "Worker received message: {}",
                             str::from_utf8(&m.message_body).unwrap()
                         );
                         let s: &str;
@@ -76,11 +102,11 @@ impl TestChannel {
                         let mut reply: Message = Message {
                             onward_route: Route { addresses: vec![] },
                             return_route: Route { addresses: vec![] },
+                            message_type: MessageType::Payload,
                             message_body: s.as_bytes().to_vec(),
                         };
                         reply.onward_route.addresses = m.return_route.addresses.clone();
-                        let address = Address::ChannelAddress(1234);
-                        if let Some(r) = RouterAddress::from_address(address) {
+                        if let Ok(r) = RouterAddress::worker_router_address_from_str("01020304") {
                             reply.return_route.addresses.push(r);
                         } else {
                             return false;
@@ -96,10 +122,10 @@ impl TestChannel {
                             }
                         }
                     }
-                    OckamCommand::Channel(ChannelCommand::Stop) => {
+                    OckamCommand::Worker(WorkerCommand::Stop) => {
                         keep_going = false;
                     }
-                    _ => println!("Channel got bad message"),
+                    _ => println!("Worker got bad message"),
                 }
             }
         }
@@ -115,78 +141,161 @@ pub fn get_route() -> Option<Route> {
         return None;
     };
 
-    if let Ok(channel_addr) = RouterAddress::channel_router_address_from_u32(1234) {
+    if let Ok(channel_addr) = RouterAddress::channel_router_address_from_str("01020304") {
         r.addresses.push(channel_addr);
     } else {
         return None;
-    }
+    };
 
     Some(r)
 }
 
-fn main() {
-    // Start transport thread, pass rx ownership
+fn start_thread(local_address: &str, route: Route, payload: String) {
     let (transport_tx, transport_rx) = std::sync::mpsc::channel();
     let (router_tx, router_rx) = std::sync::mpsc::channel();
     let (channel_tx, channel_rx) = std::sync::mpsc::channel();
     let channel_tx_for_node = channel_tx.clone();
     let router_tx_for_channel = router_tx.clone();
-    let transport_tx_for_node = transport_tx.clone();
 
     let mut router = Router::new(router_rx);
-    let mut transport = UdpTransport::new(transport_rx, transport_tx, router_tx);
-    let mut channel = TestChannel::new(channel_rx, channel_tx, router_tx_for_channel);
+    let mut channel = TestWorker::new(channel_rx, channel_tx, router_tx_for_channel);
 
-    let join_thread: thread::JoinHandle<_> = thread::spawn(move || {
-        println!("in closure");
+    let mut transport =
+        UdpTransport::new(transport_rx, transport_tx, router_tx, local_address).unwrap();
+
+    let _join_thread: thread::JoinHandle<_> = thread::spawn(move || {
         while transport.poll() && router.poll() & channel.poll() {
             thread::sleep(time::Duration::from_millis(100));
         }
     });
 
-    // Establish transport
-    let command = TransportCommand::Add("127.0.0.1:4050".to_string(), "127.0.0.1:4051".to_string());
-    match transport_tx_for_node.send(OckamCommand::Transport(command)) {
-        Ok(_unused) => println!("sent socket 1 command to transport"),
-        Err(_unused) => println!("failed to send command to transport"),
-    }
-
-    let command = TransportCommand::Add("127.0.0.1:4051".to_string(), "127.0.0.1:4050".to_string());
-    match transport_tx_for_node.send(OckamCommand::Transport(command)) {
-        Ok(_unused) => println!("sent socket 2 command to transport"),
-        Err(_unused) => println!("failed to send command to transport"),
-    }
-
-    // Create route
-    let route = match get_route() {
-        Some(r) => r,
-        None => {
-            println!("get_route failed");
-            return;
-        }
-    };
-
     let m = Message {
         onward_route: route,
         return_route: Route { addresses: vec![] },
-        message_body: "Hello Ockam".to_string().as_bytes().to_vec(),
+        message_type: MessageType::Payload,
+        message_body: payload.as_bytes().to_vec(),
     };
     let command = OckamCommand::Channel(ChannelCommand::SendMessage(m));
     match channel_tx_for_node.send(command) {
         Ok(_unused) => {}
-        Err(_unused) => {}
+        Err(_unused) => {
+            println!("failed send to channel");
+        }
+    }
+}
+
+pub fn parse_args(args: Args) -> Result<(RouterAddress, Route, String), String> {
+    let mut local_socket: RouterAddress = RouterAddress {
+        a_type: AddressType::Udp,
+        length: 7,
+        address: (Address::UdpAddress(SocketAddr::from_str("127.0.0.1:4050").unwrap())),
+    };
+    if let Some(l) = args.local_socket {
+        if let Ok(sa) = SocketAddr::from_str(&l) {
+            if let Some(ra) = RouterAddress::from_address(Address::UdpAddress(sa)) {
+                local_socket = ra;
+            }
+        }
+    } else {
+        return Err("local socket address required: -l xxx.xxx.xxx.xxx:pppp".to_string());
     }
 
-    sleep(time::Duration::from_millis(5000));
+    let mut route = Route { addresses: vec![] };
 
-    let command = TransportCommand::Stop;
-    match transport_tx_for_node.send(OckamCommand::Transport(command)) {
-        Ok(_unused) => println!("sent stop command to transport"),
-        Err(_unused) => println!("failed to send command to transport"),
+    if let Some(vs) = args.via_socket {
+        if let Ok(sa) = SocketAddr::from_str(&vs) {
+            if let Some(ra) = RouterAddress::from_address(Address::UdpAddress(sa)) {
+                route.addresses.push(ra);
+            }
+        }
+    };
+
+    if let Some(rs) = args.remote_socket {
+        if let Ok(sa) = SocketAddr::from_str(&rs) {
+            if let Some(ra) = RouterAddress::from_address(Address::UdpAddress(sa)) {
+                route.addresses.push(ra);
+            }
+        }
+    };
+
+    if let Some(wa) = args.worker_addr {
+        if let Ok(ra) = RouterAddress::worker_router_address_from_str(&wa) {
+            route.addresses.push(ra);
+        }
+    };
+
+    let mut message = "Hello Ockam".to_string();
+    if let Some(m) = args.message {
+        message = m;
+    };
+
+    Ok((local_socket, route, message))
+}
+
+pub fn start_node(local_socket: RouterAddress, onward_route: Route, payload: String) {
+    let (transport_tx, transport_rx) = std::sync::mpsc::channel();
+    let (router_tx, router_rx) = std::sync::mpsc::channel();
+    let (worker_tx, worker_rx) = std::sync::mpsc::channel();
+    let worker_tx_for_node = worker_tx.clone();
+    let router_tx_for_worker = router_tx.clone();
+
+    let mut router = Router::new(router_rx);
+    let mut worker = TestWorker::new(worker_rx, worker_tx, router_tx_for_worker);
+
+    let sock_str: String;
+    match local_socket.address {
+        Address::UdpAddress(udp) => {
+            sock_str = udp.to_string();
+            println!("{}", udp.to_string());
+        }
+        _ => return,
     }
 
-    match join_thread.join() {
-        Ok(_unused) => {}
-        Err(_unused) => {}
+    let mut transport =
+        UdpTransport::new(transport_rx, transport_tx, router_tx, &sock_str).unwrap();
+
+    let _join_thread: thread::JoinHandle<_> = thread::spawn(move || {
+        while transport.poll() && router.poll() & worker.poll() {
+            thread::sleep(time::Duration::from_millis(100));
+        }
+    });
+
+    if !onward_route.addresses.is_empty() && !payload.is_empty() {
+        let m = Message {
+            onward_route,
+            return_route: Route { addresses: vec![] },
+            message_type: MessageType::Payload,
+            message_body: payload.as_bytes().to_vec(),
+        };
+        let command = OckamCommand::Worker(WorkerCommand::SendMessage(m));
+        match worker_tx_for_node.send(command) {
+            Ok(_unused) => {}
+            Err(_unused) => {
+                println!("failed send to channel");
+            }
+        }
     }
+}
+
+fn main() {
+    let args = Args::from_args();
+    println!("{:?}", args);
+    let local_socket: RouterAddress;
+    let route: Route;
+    let message: String;
+    match parse_args(args) {
+        Ok((ls, r, m)) => {
+            local_socket = ls;
+            route = r;
+            message = m;
+        }
+        Err(s) => {
+            println!("{}", s);
+            return;
+        }
+    }
+
+    start_node(local_socket, route, message);
+
+    thread::sleep(time::Duration::from_millis(1000000));
 }


### PR DESCRIPTION
…ocket

- Message: now support the following types: Udp, Channel, Worker
- Message: has a new field, message_type, to indicate what is in the message
  body. The following types are recognized: Ping(0), Pong(1), Payload(2),
  KeyAgreementM1..M3(3,4,..)
- UdpTransport: now performs all io over the same socket. When creating a
  new transport, provide the local address/port to bind to.
- UdpTransport: The "Add" command is no longer supported. The transport will
  attempt to send the message to whatever address is in the
  route, from the socket it is bound to
- Node: Redesign the node test to support being run as a separate process.
  Node now takes command line arguments as follows:
  "-l xxx.xxx.xxx.xxx:pppp" - binds local socket to given address (required)
  "-v xxx.xxx.xxx.xxx:pppp" - routes message via this address
  "-r xxx.xxx.xxx.xxx:pppp" - remote (destination) IP address
  "-w xxx..." - worker address
  To wait for incoming message (e.g. responder) you only need "-l". For example,
    ./node -l 127.0.0.1:4052
  To create a route for a message, "-l" and "-r" are required, with "-v" and "-w"
    optional. For example,
    ./node -l 127.0.0.1:4050 -v 127.0.0.1:4051 -r 127.0.0.1:4052 -w 1234
    will create a route 127.0.0.1:4050->127.0.0.1:4051->1234

