### PR TITLE
chore(rust): add daemon to default-members list for cargo

### DIFF
--- a/implementations/rust/Cargo.toml
+++ b/implementations/rust/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 default-members = [
     "channel",
     "common",
+    "daemon",
     "kex",
     "message",
     "vault",


### PR DESCRIPTION
Adds `daemon` crate to new list of `default-members` in the workspace

This allows more convenient use of `cargo`