### PR TITLE
feat(rust): use basic worker to process message

### DIFF
--- a/implementations/rust/common/src/commands.rs
+++ b/implementations/rust/common/src/commands.rs
@@ -3,6 +3,7 @@ pub mod ockam_commands {
     use ockam_message::message::*;
     use std::thread;
 
+    #[derive(Debug)]
     pub enum OckamCommand {
         Transport(TransportCommand),
         Router(RouterCommand),
@@ -12,6 +13,7 @@ pub mod ockam_commands {
 
     // Transport commands - these can
     // be sent to the transport_tx
+    #[derive(Debug)]
     pub enum TransportCommand {
         Stop,
         SendMessage(Message),
@@ -19,6 +21,7 @@ pub mod ockam_commands {
 
     // Router commands - these can be sent to the
     // router_tx
+    #[derive(Debug)]
     pub enum RouterCommand {
         Stop,
         Register(AddressType, std::sync::mpsc::Sender<OckamCommand>),
@@ -28,12 +31,15 @@ pub mod ockam_commands {
 
     // Channel commands - these can be sent to the
     // channel_tx
+    #[derive(Debug)]
     pub enum ChannelCommand {
         Stop,
         InitializeRoute(Route),
         ReceiveMessage(Message),
         SendMessage(Message),
     }
+
+    #[derive(Debug)]
     pub enum WorkerCommand {
         Stop,
         InitializeRoute(Route),

--- a/implementations/rust/daemon/src/bin/ockamd.rs
+++ b/implementations/rust/daemon/src/bin/ockamd.rs
@@ -19,7 +19,7 @@ fn main() {
             let vault =
                 FilesystemVault::new(config.vault_path()).expect("failed to initialize vault");
 
-            // create the server using the input type and get encrypted message from server
+            // configure a node, providing it access to the vault
             let tx_input = Node::new(vault, config);
 
             // using stdin as example input

--- a/implementations/rust/daemon/src/lib.rs
+++ b/implementations/rust/daemon/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cli;
 pub mod node;
 pub mod vault;
+pub mod worker;

--- a/implementations/rust/daemon/src/worker.rs
+++ b/implementations/rust/daemon/src/worker.rs
@@ -1,0 +1,12 @@
+use std::sync::mpsc::{self, Receiver, Sender};
+
+use ockam_common::commands::ockam_commands::*;
+
+pub struct Worker {
+    router_tx: Sender<OckamCommand>,
+    rx: Receiver<OckamCommand>,
+}
+
+impl Worker {
+    fn new(router_tx: Sender<OckamCommand>, rx: Receiver<OckamCommand>) -> Self {}
+}

--- a/implementations/rust/daemon/src/worker.rs
+++ b/implementations/rust/daemon/src/worker.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 
 use ockam_common::commands::ockam_commands::*;
 use ockam_message::message::{AddressType, Message as OckamMessage};
@@ -39,10 +39,13 @@ impl Worker {
                     false
                 }
             },
-            Err(e) => {
-                eprintln!("failed to recv worker rx: {:?}", e);
-                true
-            }
+            Err(e) => match e {
+                TryRecvError::Empty => true,
+                _ => {
+                    eprintln!("failed to recv worker rx: {:?}", e);
+                    false
+                }
+            },
         }
     }
 }

--- a/implementations/rust/daemon/src/worker.rs
+++ b/implementations/rust/daemon/src/worker.rs
@@ -1,6 +1,7 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 
 use ockam_common::commands::ockam_commands::*;
+use ockam_message::message::{AddressType, Message as OckamMessage};
 
 pub struct Worker {
     router_tx: Sender<OckamCommand>,
@@ -8,5 +9,37 @@ pub struct Worker {
 }
 
 impl Worker {
-    fn new(router_tx: Sender<OckamCommand>, rx: Receiver<OckamCommand>) -> Self {}
+    pub fn new<'a>(
+        router_tx: Sender<OckamCommand>,
+        tx: Sender<OckamCommand>,
+        rx: Receiver<OckamCommand>,
+    ) -> Self {
+        let cmd = OckamCommand::Router(RouterCommand::Register(AddressType::Worker, tx.clone()));
+        router_tx
+            .send(cmd)
+            .expect("worker failed to send register command to router");
+
+        Worker { router_tx, rx }
+    }
+
+    pub fn poll(&self) -> bool {
+        match self.rx.try_recv() {
+            Ok(cmd) => match cmd {
+                // TODO: change worker command variant to recv before testing remote
+                OckamCommand::Worker(WorkerCommand::SendMessage(msg)) => {
+                    if let Ok(message) = String::from_utf8(msg.message_body) {
+                        println!("worker: {}", message);
+                    } else {
+                        eprintln!("worker-error: bad data");
+                    }
+                    true
+                }
+                _ => {
+                    eprintln!("unrecognized worker command");
+                    false
+                }
+            },
+            Err(_) => true,
+        }
+    }
 }

--- a/implementations/rust/daemon/src/worker.rs
+++ b/implementations/rust/daemon/src/worker.rs
@@ -35,11 +35,14 @@ impl Worker {
                     true
                 }
                 _ => {
-                    eprintln!("unrecognized worker command");
+                    eprintln!("unrecognized worker command: {:?}", cmd);
                     false
                 }
             },
-            Err(_) => true,
+            Err(e) => {
+                eprintln!("failed to recv worker rx: {:?}", e);
+                true
+            }
         }
     }
 }

--- a/implementations/rust/message/src/lib.rs
+++ b/implementations/rust/message/src/lib.rs
@@ -134,7 +134,7 @@ pub mod message {
         pub fn as_string(&self) -> String {
             match self {
                 Address::UdpAddress(socket) => socket.to_string(),
-                Address::ChannelAddress(u) => hex::encode(u.as_slice()),
+                Address::ChannelAddress(u) | Address::WorkerAddress(u) => hex::encode(u.as_slice()),
                 _ => "error".to_string(),
             }
         }


### PR DESCRIPTION
To test, use these commands from `implementations/rust`:
---
no transport, echo stdin -> stdout:
```sh
cargo  run --bin ockamd -- \
        --role=init \
        --output=stdout \
        --channel-responder-address=33333333 \
        --worker-address=01242020 \
        --identity-name=default \
        --responder-public-key=1234
```
---
over UDP transport, no secure channels:
1. start ockamd,
```sh
cargo  run --bin ockamd -- \
        --role=init \
        --output=udp://127.0.0.1:34254 \
        --channel-responder-address=33333333 \
        --worker-address=01242020 \
        --identity-name=default \
        --responder-public-key=1234
```
2. and separately, run:
```rust
use std::net::UdpSocket;

fn main() {
        let socket = UdpSocket::bind("127.0.0.1:34254").expect("failed to bind socket address");
	println!("udp socket: 127.0.0.1:34254");

	loop {
		let mut buf = [0; 32];
                socket.recv_from(&mut buf).expect("failed to read from socket");

		println!("got: {:?}", buf);
	}
}
```