### PR TITLE
feat(rust): add optional identity key when creating exchange

### DIFF
--- a/implementations/rust/channel/src/lib.rs
+++ b/implementations/rust/channel/src/lib.rs
@@ -317,7 +317,8 @@ impl<I: KeyExchanger, R: KeyExchanger, E: NewKeyExchanger<I, R>> ChannelManager<
 
         m.onward_route.addresses.remove(0);
 
-        let mut channel = Channel::new(channel_id, Box::new(self.new_key_exchanger.initiator()));
+        let mut channel =
+            Channel::new(channel_id, Box::new(self.new_key_exchanger.initiator(None)));
         let ka_m1 = channel.agreement.process(&[])?;
 
         m.onward_route
@@ -342,7 +343,7 @@ impl<I: KeyExchanger, R: KeyExchanger, E: NewKeyExchanger<I, R>> ChannelManager<
         let mut rng = thread_rng();
         let channel_id = rng.gen::<u32>();
         let channel_address = Address::ChannelAddress(channel_id.to_le_bytes().to_vec());
-        let channel = Channel::new(channel_id, Box::new(self.new_key_exchanger.responder()));
+        let channel = Channel::new(channel_id, Box::new(self.new_key_exchanger.responder(None)));
         self.channels.insert(channel_address.as_string(), channel);
         Ok(channel_address.as_string())
     }

--- a/implementations/rust/kex/src/error.rs
+++ b/implementations/rust/kex/src/error.rs
@@ -34,6 +34,12 @@ pub enum KeyExchangeFailErrorKind {
         /// What was received
         actual: String,
     },
+    /// A general purpose error to string method
+    #[fail(display = "{}", msg)]
+    GeneralError {
+        /// The message that describes the error
+        msg: String,
+    },
 }
 
 impl ErrorKind for KeyExchangeFailErrorKind {
@@ -45,6 +51,7 @@ impl ErrorKind for KeyExchangeFailErrorKind {
             KeyExchangeFailErrorKind::InvalidParam(..) => Self::ERROR_INTERFACE | 3,
             KeyExchangeFailErrorKind::MethodCalledOutOfSequence { .. } => Self::ERROR_INTERFACE | 4,
             KeyExchangeFailErrorKind::InvalidHash { .. } => Self::ERROR_INTERFACE | 5,
+            KeyExchangeFailErrorKind::GeneralError { .. } => Self::ERROR_INTERFACE | 6,
         }
     }
 }
@@ -91,6 +98,7 @@ impl From<KexExchangeFailError> for VaultFailError {
                 VaultFailErrorKind::InvalidContext.into()
             }
             KeyExchangeFailErrorKind::InvalidHash { .. } => VaultFailErrorKind::Ecdh.into(),
+            KeyExchangeFailErrorKind::GeneralError { .. } => VaultFailErrorKind::IOError.into(),
         }
     }
 }

--- a/implementations/rust/kex/src/lib.rs
+++ b/implementations/rust/kex/src/lib.rs
@@ -95,9 +95,9 @@ pub enum CipherSuite {
 /// Instantiate a stateful key exchange vault instance
 pub trait NewKeyExchanger<E: KeyExchanger = Self, F: KeyExchanger = Self> {
     /// Create a new Key Exchanger with the initiator role
-    fn initiator(&self) -> E;
+    fn initiator(&self, identity_key: Option<SecretKeyContext>) -> E;
     /// Create a new Key Exchanger with the responder role
-    fn responder(&self) -> F;
+    fn responder(&self, identity_key: Option<SecretKeyContext>) -> F;
 }
 
 /// A Completed Key Exchange elements
@@ -144,8 +144,8 @@ mod tests {
             vault_responder.clone(),
         );
 
-        let mut initiator = key_exchanger.initiator();
-        let mut responder = key_exchanger.responder();
+        let mut initiator = key_exchanger.initiator(None);
+        let mut responder = key_exchanger.responder(None);
 
         let m1 = initiator.process(&[]).unwrap();
         let _ = responder.process(&m1).unwrap();


### PR DESCRIPTION
Update key exchange to allow an predefined identity key