### PR TITLE
ci: reorder steps to avoid multiple builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # v2.3.1
 
+      - id: Lint
+        run: ./gradlew lint
+
       - id: Build
         run: ./gradlew build
 
@@ -23,6 +26,3 @@ jobs:
 
       - id: Clean
         run: ./gradlew clean
-
-      - id: Lint
-        run: ./gradlew lint


### PR DESCRIPTION
This will fix the CI sequencing so we only build Rust code once and then clean up at the end. 
