### PR TITLE
feat(rust): make ockamd panic if supplied public key doesn't match computed key

### DIFF
--- a/implementations/rust/channel/src/lib.rs
+++ b/implementations/rust/channel/src/lib.rs
@@ -68,6 +68,7 @@ pub struct ChannelManager<
     phantom_i: PhantomData<I>,
     phantom_r: PhantomData<R>,
     secret_key_context: Option<SecretKeyContext>,
+    remote_public_key: Option<PublicKey>,
 }
 
 impl<I: KeyExchanger, R: KeyExchanger, E: NewKeyExchanger<I, R>> std::fmt::Debug
@@ -91,6 +92,7 @@ impl<I: KeyExchanger, R: KeyExchanger, E: NewKeyExchanger<I, R>> ChannelManager<
         vault: Arc<Mutex<dyn DynVault + Send>>,
         new_key_exchanger: E,
         secret_key_context: Option<SecretKeyContext>,
+        remote_public_key: Option<PublicKey>,
     ) -> Result<Self, ChannelError> {
         // register ChannelManager with the router as the handler for all Channel address types
         if let Err(_error) = router.send(Router(RouterCommand::Register(
@@ -111,6 +113,7 @@ impl<I: KeyExchanger, R: KeyExchanger, E: NewKeyExchanger<I, R>> ChannelManager<
             phantom_i: PhantomData,
             phantom_r: PhantomData,
             secret_key_context,
+            remote_public_key,
         })
     }
 

--- a/implementations/rust/daemon/src/cli.rs
+++ b/implementations/rust/daemon/src/cli.rs
@@ -122,7 +122,6 @@ impl Default for Args {
             vault: VaultKind::Filesystem,
             vault_path: PathBuf::from("ockamd_vault"),
             role: ChannelRole::Responder,
-            //            service_address: Some("01020304".into()),
             service_address: None,
             identity_name: None,
             service_public_key: None,

--- a/implementations/rust/daemon/src/config.rs
+++ b/implementations/rust/daemon/src/config.rs
@@ -49,6 +49,8 @@ impl Config {
         self.remote_public_key.clone()
     }
 
+    pub fn role(&self) -> Role { self.role }
+
     pub fn service_address(&self) -> Option<String> {
         self.service_address.clone()
     }

--- a/implementations/rust/daemon/src/config.rs
+++ b/implementations/rust/daemon/src/config.rs
@@ -49,7 +49,9 @@ impl Config {
         self.remote_public_key.clone()
     }
 
-    pub fn role(&self) -> Role { self.role }
+    pub fn role(&self) -> Role {
+        self.role
+    }
 
     pub fn service_address(&self) -> Option<String> {
         self.service_address.clone()

--- a/implementations/rust/daemon/src/node.rs
+++ b/implementations/rust/daemon/src/node.rs
@@ -45,8 +45,8 @@ impl<'a> Node<'a> {
         ));
 
         // if responder, generate keypair and display static public key
-        let mut public_key_opt = None;
-        let mut secret_key_ctx_opt = None;
+        let mut resp_key_opt = None;
+        let mut resp_key_ctx_opt = None;
         match config.role() {
             Role::Responder => {
                 let attributes = SecretKeyAttributes {
@@ -55,14 +55,11 @@ impl<'a> Node<'a> {
                     persistence: SecretPersistenceType::Persistent,
                 };
                 let mut v = vault.lock().unwrap();
-                if let static_secret_handle = v.secret_generate(attributes).unwrap() {
-                    if let static_public_key = v
-                        .secret_public_key_get(static_secret_handle.clone())
-                        .unwrap()
-                    {
-                        public_key_opt = Some(static_public_key);
-                        secret_key_ctx_opt = Some(static_secret_handle);
-                        println!("Responder public key: {}", public_key_opt.unwrap());
+                if let resp_key_ctx = v.secret_generate(attributes).unwrap() {
+                    if let resp_key = v.secret_public_key_get(resp_key_ctx.clone()).unwrap() {
+                        resp_key_opt = Some(resp_key);
+                        resp_key_ctx_opt = Some(resp_key_ctx);
+                        println!("Responder public key: {}", resp_key_opt.unwrap());
                     }
                 }
             }
@@ -85,8 +82,8 @@ impl<'a> Node<'a> {
             router_tx.clone(),
             vault.clone(),
             new_key_exchanger,
-            secret_key_ctx_opt,
-            public_key_opt,
+            resp_key_ctx_opt,
+            None,
         )
         .unwrap();
 

--- a/implementations/rust/daemon/src/node.rs
+++ b/implementations/rust/daemon/src/node.rs
@@ -16,8 +16,11 @@ use ockam_message::message::AddressType;
 use ockam_router::router::Router;
 use ockam_system::commands::commands::{OckamCommand, RouterCommand};
 use ockam_transport::transport::UdpTransport;
-use ockam_vault::types::{SecretKeyContext, SecretKeyAttributes, SecretKeyType, SecretPurposeType, SecretPersistenceType, PublicKey};
-use ockam_vault::{Vault, DynVault};
+use ockam_vault::types::{
+    PublicKey, SecretKeyAttributes, SecretKeyContext, SecretKeyType, SecretPersistenceType,
+    SecretPurposeType,
+};
+use ockam_vault::{DynVault, Vault};
 
 pub struct Node<'a> {
     config: &'a Config,
@@ -53,7 +56,10 @@ impl<'a> Node<'a> {
                 };
                 let mut v = vault.lock().unwrap();
                 if let static_secret_handle = v.secret_generate(attributes).unwrap() {
-                    if let static_public_key = v.secret_public_key_get(static_secret_handle.clone()).unwrap() {
+                    if let static_public_key = v
+                        .secret_public_key_get(static_secret_handle.clone())
+                        .unwrap()
+                    {
                         public_key_opt = Some(static_public_key);
                         secret_key_ctx_opt = Some(static_secret_handle);
                         println!("Responder public key: {}", public_key_opt.unwrap());

--- a/implementations/rust/daemon/src/responder.rs
+++ b/implementations/rust/daemon/src/responder.rs
@@ -7,6 +7,10 @@ use crate::worker::Worker;
 use ockam_message::message::RouterAddress;
 
 pub fn run(config: Config) {
+    // 1. generate key pair
+    // 2. print the public key
+    // 3.
+
     let (mut node, router_tx) = Node::new(&config);
 
     let worker_addr = RouterAddress::worker_router_address_from_str("01242020").unwrap();

--- a/implementations/rust/node/src/node.rs
+++ b/implementations/rust/node/src/node.rs
@@ -260,6 +260,7 @@ pub mod node {
                 vault,
                 new_key_exchanger,
                 None,
+                None,
             )
             .unwrap();
 


### PR DESCRIPTION

- channel now sends responder public key in message-body of channel
  completion message
- ockamd-initiator will panic if a responder public key is supplied and
  it doesn't match the computed responder key