### PR TITLE
feat(rust): make ockamd responder check for valid worker address

### DIFF
--- a/implementations/rust/channel/src/lib.rs
+++ b/implementations/rust/channel/src/lib.rs
@@ -187,7 +187,11 @@ impl<I: KeyExchanger, R: KeyExchanger, E: NewKeyExchanger<I, R>> ChannelManager<
                         let mut vault = self.vault.lock().unwrap();
 
                         let mut new_message_body: Vec<u8> = vec![];
-                        u16::encode(&channel.nonce, &mut new_message_body);
+                        if let Err(e) = u16::encode(&channel.nonce, &mut new_message_body)
+                            .map_err(|e| ChannelError::from_msg(ChannelErrorKind::CantSend, e))
+                        {
+                            return Err(e);
+                        }
 
                         let nonce = Channel::nonce_16_to_96(channel.nonce);
                         let mut ciphertext_and_tag = vault.aead_aes_gcm_encrypt(

--- a/implementations/rust/daemon/src/initiator.rs
+++ b/implementations/rust/daemon/src/initiator.rs
@@ -24,10 +24,6 @@ pub fn run(config: Config) {
 
     // kick off the key exchange process. The result will be that the worker is notified
     // when the secure channel is created.
-    println!(
-        "Worker address: {:?}",
-        hex::decode(config.service_address().unwrap()).unwrap()
-    );
     node.channel_tx
         .send(OckamCommand::Channel(ChannelCommand::Initiate(
             config.onward_route().unwrap(),

--- a/implementations/rust/daemon/src/initiator.rs
+++ b/implementations/rust/daemon/src/initiator.rs
@@ -16,7 +16,7 @@ pub fn run(config: Config) {
     let (node, router_tx) = Node::new(&node_config);
 
     let mut worker = StdinWorker::new(
-        RouterAddress::worker_router_address_from_str("01242020")
+        RouterAddress::worker_router_address_from_str(&config.service_address().unwrap())
             .expect("failed to create worker address for kex"),
         router_tx,
         config.clone(),
@@ -24,6 +24,10 @@ pub fn run(config: Config) {
 
     // kick off the key exchange process. The result will be that the worker is notified
     // when the secure channel is created.
+    println!(
+        "Worker address: {:?}",
+        hex::decode(config.service_address().unwrap()).unwrap()
+    );
     node.channel_tx
         .send(OckamCommand::Channel(ChannelCommand::Initiate(
             config.onward_route().unwrap(),

--- a/implementations/rust/daemon/src/worker.rs
+++ b/implementations/rust/daemon/src/worker.rs
@@ -45,6 +45,11 @@ impl Worker {
                 OckamCommand::Worker(WorkerCommand::ReceiveMessage(msg)) => {
                     match msg.message_type {
                         MessageType::Payload => {
+                            // Confirm address
+                            if self.addr != msg.onward_route.addresses[0] {
+                                println!("Received bad worker address");
+                                return true;
+                            }
                             (self.work_fn)(&self, msg);
                             true
                         }


### PR DESCRIPTION

if the address isn't valid, drop the message and print a warning
