### PR TITLE
build: add dockerfile for telegraf-ockamd and influxdb-ockamd

### DIFF
--- a/implementations/rust/daemon/README.md
+++ b/implementations/rust/daemon/README.md
@@ -33,24 +33,27 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-        --identity-name <identity-name>
-            Name of the private key to use for the identity of the channel initiator
+    --addon <addon>
+        Pre-defined configuration for an official Ockam Add-on, e.g. "influx,http://localhost:8086"
 
-        --input <input>                              Data source providing input to `ockamd` [default: stdin]
-        --local-socket <local-socket>                Local node address and port to bind [default: 127.0.0.1:0]
-        --role <role>
-            Start `ockamd` as an "initiator" or a "responder" of a secure channel [default: initiator]
+    --identity-name <identity-name>
+        Name of the private key to use for the identity of the channel initiator [default: 1.key]
 
-        --route <route>
-            Route to channel responder, e.g. udp://host:port[,udp://host:port] (note comma-separation) or "stdout"
-            [default: stdout]
-        --service-address <service-address>          Address used to reach the service on remote machine
-        --service-public-key <service-public-key>    The public key provided by the remote service
-        --vault <vault>
-            Specify which type of Ockam vault to use for this instance of `ockamd` [default: FILESYSTEM]
+    --input <input>                              Data source providing input to `ockamd` [default: stdin]
+    --local-socket <local-socket>                Local node address and port to bind [default: 127.0.0.1:0]
+    --role <role>
+        Start `ockamd` as an "initiator" or a "responder" of a secure channel [default: initiator]
 
-        --vault-path <vault-path>
-            Filepath on disk to pre-existing private keys to be used by the filesystem vault [default: ockamd_vault]
+    --route <route>
+        Route to channel responder, e.g. udp://host:port[,udp://host:port] (note comma-separation) or "stdout"
+        [default: stdout]
+    --service-address <service-address>          Address used to reach the service on remote machine
+    --service-public-key <service-public-key>    The public key provided by the remote service
+    --vault <vault>
+        Specify which type of Ockam vault to use for this instance of `ockamd` [default: FILESYSTEM]
+
+    --vault-path <vault-path>
+        Filepath on disk to pre-existing private keys to be used by the filesystem vault [default: ockamd_vault]
 ```
 
 

--- a/implementations/rust/daemon/src/cli.rs
+++ b/implementations/rust/daemon/src/cli.rs
@@ -99,7 +99,7 @@ pub struct Args {
 
     #[structopt(
         long,
-        help = r#"Pre-defined configuration for an official Ockam Add-on, e.g. "influx,http://localhost:8086""#
+        help = r#"Pre-defined configuration for an official Ockam Add-on, e.g. "influxdb,database_name,http://localhost:8086""#
     )]
     addon: Option<Addon>,
 

--- a/tools/docker/demo/influxdb.sh
+++ b/tools/docker/demo/influxdb.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+
+if [[ -z "$1" ]]; then
+    echo "Ockam Demo: InfluxDB Add-on"
+    echo "" 
+    echo "USAGE"
+    echo "" 
+    echo "$ ./tools/docker/demo/influxdb.sh [COMPONENT] [ARGS]"
+    echo "" 
+    echo "COMPONENTS"
+    echo ""
+    echo "  influxdb-ockamd"
+    echo "      starts the responder (sink) end, containing \`influxdb\` and \`ockamd\`, with configuration to send \`influxdb\` measurement data via \`ockamd\` over HTTP."
+    echo "" 
+    echo "  telegraf-ockamd [RESPONDER-PUBLIC-KEY]"
+    echo "      starts the initiator (source) end, containing \`telegraf\` and \`ockamd\`, with configuration to start \`telegraf\` to use \`ockamd\` as an \"execd\" output plugin."
+    echo ""
+    echo "  telegraf-write"
+    echo "      sends a random 'temperature' measurement to \`telegraf\` agent, which is encrypted by \`ockamd\` and written to \`influxdb\`."
+    echo ""
+    echo "  influxdb-query"
+    echo "      executes a 'SELECT * FROM temperature' query within the 'ockam_demo' database in \`influxdb\`."
+    echo ""
+    echo "  kill-all"
+    echo "      kills and removes all demo containers."
+    echo ""
+fi
+
+case $1 in 
+    influxdb-ockamd)
+        # start the responder (sink) end, containing `influxdb` and `ockamd`, with configuration to 
+        # send `influxdb` measurement data via `ockamd` over HTTP.
+        docker run -d --network="host" --name="influxdb-ockamd" ockam/influxdb-ockamd:0.1.0 \
+            --role=responder \
+            --local-socket=127.0.0.1:52440 \
+            --addon=influxdb,ockam_demo,http://localhost:8086 > /dev/null
+        docker logs influxdb-ockamd
+        docker exec influxdb-ockamd influx -execute 'CREATE DATABASE ockam_demo'
+
+        echo ""
+        echo "NOTE: copy the hex value printed above in the line prefixed with 'Responder public key:', and use it as the first argument in the \`telegraf-ockamd\` component command."
+        ;;
+
+    telegraf-ockamd)
+        # start the initiator (source) end, containing `telegraf` and `ockamd`, with configuration
+        # to start `telegraf` to use `ockamd` as an "execd" output plugin:
+        if [[ -z "$2" ]]; then
+            echo "ERROR: You must provide the responder public key returned from the previous script."
+            exit 1
+        fi
+
+        docker run -d --network="host" --name="telegraf-ockamd" \
+            --env OCKAMD_RESPONDER_PUBLIC_KEY=$2 \
+            --env OCKAMD_LOCAL_SOCKET=127.0.0.1:52441 \
+            --env OCKAMD_ROUTE=udp://127.0.0.1:52440 \
+            ockam/telegraf-ockamd:0.1.0 > /dev/null
+        ;;
+
+    ockam-router)
+        echo "TODO"
+        ;;
+
+    influxdb-query)
+        # executes a 'SELECT * FROM temperature' query within the 'ockam_demo' database in 
+        # `influxdb`.
+        docker exec influxdb-ockamd influx -database "ockam_demo" -execute "select * from temperature"
+        ;;
+
+    telegraf-write)
+        # sends a random 'temperature' measurement to `telegraf` agent, which is encrypted by 
+        # `ockamd` and written to `influxdb`.
+        TEMP=$(( ( RANDOM % 10 )  + 70 ))
+        docker exec influxdb-ockamd \
+            curl -s -X POST http://0.0.0.0:8080/telegraf \
+            --data-binary "temperature,region=us-west temp=${TEMP}"
+        ;;
+
+    kill-all)
+        # kills and removes all demo containers.
+        docker container rm -f influxdb-ockamd
+        docker container rm -f telegraf-ockamd
+        ;;
+
+esac
+    

--- a/tools/docker/demo/influxdb.sh
+++ b/tools/docker/demo/influxdb.sh
@@ -1,29 +1,31 @@
 #!/usr/bin/env sh
 
 if [[ -z "$1" ]]; then
-    echo "Ockam Demo: InfluxDB Add-on"
-    echo "" 
-    echo "USAGE"
-    echo "" 
-    echo "$ ./tools/docker/demo/influxdb.sh [COMPONENT] [ARGS]"
-    echo "" 
-    echo "COMPONENTS"
-    echo ""
-    echo "  influxdb-ockamd"
-    echo "      starts the responder (sink) end, containing \`influxdb\` and \`ockamd\`, with configuration to send \`influxdb\` measurement data via \`ockamd\` over HTTP."
-    echo "" 
-    echo "  telegraf-ockamd [RESPONDER-PUBLIC-KEY]"
-    echo "      starts the initiator (source) end, containing \`telegraf\` and \`ockamd\`, with configuration to start \`telegraf\` to use \`ockamd\` as an \"execd\" output plugin."
-    echo ""
-    echo "  telegraf-write"
-    echo "      sends a random 'temperature' measurement to \`telegraf\` agent, which is encrypted by \`ockamd\` and written to \`influxdb\`."
-    echo ""
-    echo "  influxdb-query"
-    echo "      executes a 'SELECT * FROM temperature' query within the 'ockam_demo' database in \`influxdb\`."
-    echo ""
-    echo "  kill-all"
-    echo "      kills and removes all demo containers."
-    echo ""
+    echo "\
+Ockam Demo: InfluxDB Add-on
+
+USAGE
+    
+$ ./tools/docker/demo/influxdb.sh [COMMAND] [ARGS]
+
+COMMANDS
+
+    influxdb-ockamd
+        starts the responder (sink) end, containing \`influxdb\` and \`ockamd\`, with configuration to send \`influxdb\` measurement data via \`ockamd\` over HTTP.
+    
+    telegraf-ockamd [RESPONDER-PUBLIC-KEY]
+        starts the initiator (source) end, containing \`telegraf\` and \`ockamd\`, with configuration to start \`telegraf\` to use \`ockamd\` as an \"execd\" output plugin.
+
+    telegraf-write
+        sends a random 'temperature' measurement to \`telegraf\` agent, which is encrypted by \`ockamd\` and written to \`influxdb\`.
+
+    influxdb-query
+        executes a 'SELECT * FROM temperature' query within the 'ockam_demo' database in \`influxdb\`.
+
+    kill-all
+        kills and removes all demo containers.
+"
+    exit 0
 fi
 
 case $1 in 
@@ -70,9 +72,12 @@ case $1 in
         # sends a random 'temperature' measurement to `telegraf` agent, which is encrypted by 
         # `ockamd` and written to `influxdb`.
         TEMP=$(( ( RANDOM % 10 )  + 70 ))
+        DATA="temperature,region=us-west temp=${TEMP}"
         docker exec influxdb-ockamd \
             curl -s -X POST http://0.0.0.0:8080/telegraf \
-            --data-binary "temperature,region=us-west temp=${TEMP}"
+            --data-binary "${DATA}"
+        
+        echo "sent measurement: ${DATA}"
         ;;
 
     kill-all)

--- a/tools/docker/influxdb/Dockerfile.influxdb-ockamd
+++ b/tools/docker/influxdb/Dockerfile.influxdb-ockamd
@@ -1,3 +1,4 @@
-FROM influxdb:latest
-COPY --from=ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
-ENTRYPOINT ["ockamd"]
+FROM influxdb:1.8
+COPY --from=ockam/ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
+COPY ./tools/docker/influxdb/entrypoint.sh .
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tools/docker/influxdb/Dockerfile.influxdb-ockamd
+++ b/tools/docker/influxdb/Dockerfile.influxdb-ockamd
@@ -1,0 +1,3 @@
+FROM influxdb:latest
+COPY --from=ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
+ENTRYPOINT ["ockamd"]

--- a/tools/docker/influxdb/entrypoint.sh
+++ b/tools/docker/influxdb/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+nohup influxd >/dev/null 2>&1 &
+exec ockamd "$@"

--- a/tools/docker/rust/Dockerfile.ockamd
+++ b/tools/docker/rust/Dockerfile.ockamd
@@ -1,4 +1,4 @@
-FROM ockam-dev as builder
+FROM ockam/ockam-dev as builder
 RUN apt update && apt install -y pkg-config libssl-dev
 COPY . . 
 WORKDIR implementations/rust

--- a/tools/docker/rust/Dockerfile.ockamd
+++ b/tools/docker/rust/Dockerfile.ockamd
@@ -1,11 +1,10 @@
-# stage: test & build
 FROM ockam-dev as builder
+RUN apt update && apt install -y pkg-config libssl-dev
 COPY . . 
 WORKDIR implementations/rust
 RUN cargo test
 RUN cargo build --bin ockamd
 
-# stage: final
 FROM ubuntu:20.04
 COPY --from=builder implementations/rust/target/debug/ockamd /usr/local/bin/ockamd
 ENTRYPOINT ["ockamd"]

--- a/tools/docker/rust/Dockerfile.router
+++ b/tools/docker/rust/Dockerfile.router
@@ -1,0 +1,3 @@
+FROM ubuntu:20.04
+COPY --from=builder implementations/rust/target/debug/ockamd /usr/local/bin/ockamd
+CMD ["ockamd", "--role", "responder", "--local-socket"]

--- a/tools/docker/telegraf/Dockerfile.telegraf-ockamd
+++ b/tools/docker/telegraf/Dockerfile.telegraf-ockamd
@@ -1,3 +1,3 @@
-FROM telegraf:latest
-COPY --from=ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
+FROM telegraf:1.16
+COPY --from=ockam/ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
 COPY ./tools/docker/telegraf/telegraf.conf /etc/telegraf/telegraf.conf

--- a/tools/docker/telegraf/Dockerfile.telegraf-ockamd
+++ b/tools/docker/telegraf/Dockerfile.telegraf-ockamd
@@ -1,0 +1,3 @@
+FROM telegraf:latest
+COPY --from=ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
+COPY ./tools/docker/telegraf/telegraf.conf /etc/telegraf/telegraf.conf

--- a/tools/docker/telegraf/telegraf.conf
+++ b/tools/docker/telegraf/telegraf.conf
@@ -1,10 +1,10 @@
 [agent]
-    interval = "10s"
+    interval = "3s"
     round_interval = true
     metric_batch_size = 1000
     metric_buffer_limit = 10000
     collection_jitter = "0s"
-    flush_interval = "10s"
+    flush_interval = "3s"
     flush_jitter = "0s"
     precision = ""
 

--- a/tools/docker/telegraf/telegraf.conf
+++ b/tools/docker/telegraf/telegraf.conf
@@ -1,0 +1,29 @@
+[agent]
+    interval = "10s"
+    round_interval = true
+    metric_batch_size = 1000
+    metric_buffer_limit = 10000
+    collection_jitter = "0s"
+    flush_interval = "10s"
+    flush_jitter = "0s"
+    precision = ""
+
+[[outputs.execd]]
+    command = ["ockamd", 
+        "--role", "initiator", 
+        "--route", "${OCKAMD_ROUTE}",
+        "--local-socket", "${OCKAMD_LOCAL_SOCKET}",
+        "--service-public-key", "${OCKAMD_RESPONDER_PUBLIC_KEY}", 
+        "--service-address", "01242020"
+    ] 
+    restart_delay = "5s"   
+    data_format = "influx"
+
+[[inputs.http_listener_v2]]
+    service_address = "0.0.0.0:8080"
+    path = "/telegraf"
+    methods = ["POST"]
+    read_timeout = "3s"
+    write_timeout = "3s"
+    max_body_size = "16KB"
+    data_format = "influx"


### PR DESCRIPTION
1. build the local docker files to get the demo images:
```sh
docker build -t ockam/ockam-dev -f tools/docker/ockam-dev/Dockerfile . # base builder image
docker build -t ockam/ockamd:0.1.0 -f tools/docker/rust/Dockerfile.ockamd . # builds v0.1.0 of `ockamd`
docker build -t ockam/telegraf-ockamd:0.1.0 -f tools/docker/telegraf/Dockerfile.telegraf-ockamd . # builds  v0.1.0 of `telegraf-ockamd`
docker build -t ockam/influxdb-ockamd:0.1.0 -f tools/docker/influxdb/Dockerfile.influxdb-ockamd . # builds v0.1.0 of `influxdb-ockamd`
```

2. run `InfluxDB` and `ockamd` as the responder end:
```sh
./tools/docker/demo/influxdb.sh influxdb-ockamd
```

3. run the `Telegraf` agent and `ockamd` as the initiator end:
```sh
./tools/docker/demo/influxdb.sh telegraf-ockamd $COPIED_RESPONDER_PUBLIC_KEY
```

4. send `Telegraf` some input via HTTP:
```sh
./tools/docker/demo/influxdb.sh telegraf-write
```

5. observe the line format data written to `InfluxDB` in the responder end by running some `influxql`:
```sh
./tools/docker/demo/influxdb.sh influxdb-query
```

6. stop & clean-up the docker containers:
```sh
./tools/docker/demo/influxdb.sh kill-all
```