### PR TITLE
feat(rust): implement the influxdb addon configuration, write message over http

### DIFF
--- a/implementations/rust/Cargo.lock
+++ b/implementations/rust/Cargo.lock
@@ -101,6 +101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "attohttpc"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1082810677916862c7704351dfe4696a837aaf34da0dd6431abc60783e71ee8f"
+dependencies = [
+ "flate2",
+ "http",
+ "log",
+ "native-tls",
+ "openssl",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -139,7 +154,7 @@ checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if",
+ "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -188,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
 name = "c_bindings"
 version = "0.9.0"
 dependencies = [
@@ -223,6 +244,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
@@ -305,6 +332,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -446,6 +482,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
+dependencies = [
+ "cfg-if 0.1.10",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "funty"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +640,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -662,6 +731,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +760,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "keychain-services"
@@ -716,7 +802,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2443d8f0478b16759158b2f66d525991a05491138bc05814ef52a250148ef4f9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "winapi",
 ]
 
@@ -726,7 +812,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -749,6 +835,24 @@ checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 0.4.4",
+ "security-framework-sys 0.4.3",
+ "tempfile",
 ]
 
 [[package]]
@@ -874,7 +978,7 @@ dependencies = [
  "ockam-common",
  "p256",
  "rand",
- "security-framework",
+ "security-framework 2.0.0",
  "sha2",
  "subtle",
  "x25519-dalek",
@@ -898,6 +1002,7 @@ dependencies = [
 name = "ockamd"
 version = "0.1.0"
 dependencies = [
+ "attohttpc",
  "hex",
  "ockam-channel",
  "ockam-common",
@@ -923,6 +1028,39 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+dependencies = [
+ "bitflags",
+ "cfg-if 0.1.10",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "p256"
@@ -972,12 +1110,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
 name = "polyval"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "universal-hash",
 ]
 
@@ -1095,6 +1239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1284,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "security-framework"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "libc",
+ "security-framework-sys 0.4.3",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,7 +1316,17 @@ dependencies = [
  "core-foundation 0.9.1",
  "core-foundation-sys 0.8.1",
  "libc",
- "security-framework-sys",
+ "security-framework-sys 2.0.0",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
 ]
 
 [[package]]
@@ -1149,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 
 [[package]]
 name = "sha2"
@@ -1160,7 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest",
  "opaque-debug",
@@ -1241,6 +1433,20 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1360,6 +1566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1607,12 @@ dependencies = [
  "libc",
  "thiserror",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79346daa5ca66c72db46ee4dac6e605811478ae0807b385d18328be3f5c0eb74"
 
 [[package]]
 name = "winapi"

--- a/implementations/rust/daemon/Cargo.toml
+++ b/implementations/rust/daemon/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+attohttpc = "0.16.0"
 hex = "0.4.2"
 structopt = { version = "0.3.20", default-features = false }
 url = "2.1.1"
@@ -18,5 +19,4 @@ ockam-kex = { path = "../kex", version = "0.1.0" }
 ockam-transport = { path = "../transport", version = "0.1.0" }
 ockam-router = { path = "../router", version = "0.1.0" }
 ockam-system = { version = "0.1", path = "../system" }
-
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/implementations/rust/daemon/src/cli.rs
+++ b/implementations/rust/daemon/src/cli.rs
@@ -204,7 +204,7 @@ impl FromStr for Addon {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.split(',').collect::<Vec<&str>>().as_slice() {
-            ["influx", dbname_url @ ..] => {
+            ["influxdb", dbname_url @ ..] => {
                 if dbname_url.len() != 2 {
                     return Err("bad configuration: influx addon needs db and url".into());
                 }
@@ -215,7 +215,7 @@ impl FromStr for Addon {
                     Err("expected valid URL".into())
                 }
             }
-            _ => Err(format!("couldn't parse: {}", s)),
+            _ => Err(format!("unknown configuration: {}", s)),
         }
     }
 }

--- a/implementations/rust/daemon/src/config.rs
+++ b/implementations/rust/daemon/src/config.rs
@@ -17,6 +17,11 @@ pub enum Input {
 }
 
 #[derive(Debug, Clone)]
+pub enum AddonKind {
+    InfluxDb(url::Url, String),
+}
+
+#[derive(Debug, Clone)]
 pub struct Config {
     onward_route: Option<Route>,
     output_to_stdout: bool,
@@ -27,6 +32,13 @@ pub struct Config {
     remote_public_key: Option<String>,
     service_address: Option<String>,
     identity_name: String,
+    addon: Option<AddonKind>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        cli::Args::default().into()
+    }
 }
 
 impl Config {
@@ -61,6 +73,10 @@ impl Config {
     pub fn identity_name(&self) -> String {
         self.identity_name.clone()
     }
+
+    pub fn addon(&self) -> Option<AddonKind> {
+        self.addon.clone()
+    }
 }
 
 impl From<cli::Args> for Config {
@@ -75,6 +91,13 @@ impl From<cli::Args> for Config {
             remote_public_key: args.service_public_key(),
             service_address: args.service_address(),
             identity_name: args.identity_name(),
+            addon: if let Some(a) = args.addon() {
+                match a {
+                    cli::Addon::InfluxDb(u, db) => Some(AddonKind::InfluxDb(u, db)),
+                }
+            } else {
+                None
+            },
         };
 
         match args.output_kind() {

--- a/implementations/rust/daemon/src/responder.rs
+++ b/implementations/rust/daemon/src/responder.rs
@@ -1,24 +1,45 @@
 use std::io::Write;
 
-use crate::config::Config;
+use crate::config::{AddonKind, Config};
 use crate::node::Node;
 use crate::worker::Worker;
 
 use ockam_message::message::RouterAddress;
 
-pub fn run(config: Config) {
-    // 1. generate key pair
-    // 2. print the public key
-    // 3.
+use attohttpc::post;
 
+pub fn run(config: Config) {
     let (mut node, router_tx) = Node::new(&config);
 
     let worker_addr = RouterAddress::worker_router_address_from_str("01242020").unwrap();
-    let worker = Worker::new(worker_addr, router_tx, |_self, msg| {
-        let mut out = std::io::stdout();
-        out.write_all(msg.message_body.as_ref())
-            .expect("failed to write message to stdout");
-        out.flush().expect("failed to flush stdout");
+    let worker = Worker::new(worker_addr, router_tx, config.clone(), |w, msg| {
+        match w.config().addon() {
+            Some(AddonKind::InfluxDb(url, db)) => {
+                let payload = String::from_utf8(msg.message_body);
+                if payload.is_err() {
+                    eprintln!("invalid message body for influx");
+                    return;
+                }
+
+                match post(format!("{}write?db={}", url.into_string(), db))
+                    .text(payload.unwrap())
+                    .send()
+                {
+                    Ok(resp) => {
+                        if let Err(e) = resp.error_for_status() {
+                            eprintln!("bad influx HTTP response: {}", e);
+                        }
+                    }
+                    Err(e) => println!("failed to send to influxdb: {}", e),
+                }
+            }
+            None => {
+                let mut out = std::io::stdout();
+                out.write_all(msg.message_body.as_ref())
+                    .expect("failed to write message to stdout");
+                out.flush().expect("failed to flush stdout");
+            }
+        }
     });
     // add the worker and run the node to poll its various internal components
     node.add_worker(worker);


### PR DESCRIPTION
implement the full data path: 
`telegraf -> ockamd --(secure channel)--> ockamd -> influxdb`

introduces an "addon" CLI paramater, which is meant to simplify the usage of various integrations. to use the InfluxDB addon, you run the responder as such:

`ockamd --role=responder --local-socket=127.0.0.1:52440 --addon=influxdb,$DB_NAME,http://127.0.0.1:8086`

This will configure `ockamd` to send encrypted messages received by responder to InfluxDB over HTTP using the database name and URL provided.
