### PR TITLE
update dockerfiles and scripts to use ockamd version 0.10.0

### DIFF
--- a/tools/docker/demo/influxdb.sh
+++ b/tools/docker/demo/influxdb.sh
@@ -32,7 +32,7 @@ case $1 in
     influxdb-ockamd)
         # start the responder (sink) end, containing `influxdb` and `ockamd`, with configuration to 
         # send `influxdb` measurement data via `ockamd` over HTTP.
-        docker run -d --network="host" --name="influxdb-ockamd" ockam/influxdb-ockamd:0.1.0 \
+        docker run -d --network="host" --name="influxdb-ockamd" ockam/influxdb-ockamd:0.10.0 \
             --role=responder \
             --local-socket=127.0.0.1:52440 \
             --addon=influxdb,ockam_demo,http://localhost:8086 > /dev/null
@@ -55,7 +55,7 @@ case $1 in
             --env OCKAMD_RESPONDER_PUBLIC_KEY=$2 \
             --env OCKAMD_LOCAL_SOCKET=127.0.0.1:52441 \
             --env OCKAMD_ROUTE=udp://127.0.0.1:52440 \
-            ockam/telegraf-ockamd:0.1.0 > /dev/null
+            ockam/telegraf-ockamd:0.10.0 > /dev/null
         ;;
 
     ockam-router)

--- a/tools/docker/influxdb/Dockerfile.influxdb-ockamd
+++ b/tools/docker/influxdb/Dockerfile.influxdb-ockamd
@@ -1,4 +1,4 @@
 FROM influxdb:1.8
-COPY --from=ockam/ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
+COPY --from=ockam/ockamd:0.10.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
 COPY ./tools/docker/influxdb/entrypoint.sh .
 ENTRYPOINT ["./entrypoint.sh"]

--- a/tools/docker/rust/Dockerfile.ockamd
+++ b/tools/docker/rust/Dockerfile.ockamd
@@ -3,7 +3,7 @@ RUN apt update && apt install -y pkg-config libssl-dev
 COPY . . 
 WORKDIR implementations/rust
 RUN cargo test
-RUN cargo build --bin ockamd
+RUN cargo build --bin ockamd --release
 
 FROM ubuntu:20.04
 COPY --from=builder implementations/rust/target/debug/ockamd /usr/local/bin/ockamd

--- a/tools/docker/rust/Dockerfile.router
+++ b/tools/docker/rust/Dockerfile.router
@@ -1,3 +1,0 @@
-FROM ubuntu:20.04
-COPY --from=builder implementations/rust/target/debug/ockamd /usr/local/bin/ockamd
-CMD ["ockamd", "--role", "responder", "--local-socket"]

--- a/tools/docker/telegraf/Dockerfile.telegraf-ockamd
+++ b/tools/docker/telegraf/Dockerfile.telegraf-ockamd
@@ -1,3 +1,3 @@
 FROM telegraf:1.16
-COPY --from=ockam/ockamd:0.1.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
+COPY --from=ockam/ockamd:0.10.0 /usr/local/bin/ockamd /usr/local/bin/ockamd
 COPY ./tools/docker/telegraf/telegraf.conf /etc/telegraf/telegraf.conf


### PR DESCRIPTION
feat: update dockerfiles and scripts to use ockamd version 0.10.0
feat: build ockamd in release mode in dockerfile