### PR TITLE
Remove bashisms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@ Thank you for your interest in contributing to the Ockam open source projects.
 We have several documents on [Ockam.io](https://www.ockam.io/) that will help to guide you.
 
 You can find Ockam's library of contributing guides here:
-[ockam.io/learn/guides/contributions/CONTRIBUTING](https://www.ockam.io/learn/guides/contributions/CONTRIBUTING)
+[ockam.io/learn/how-to-guides/contributing/CONTRIBUTING](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING)

--- a/tools/docker/demo/influxdb.sh
+++ b/tools/docker/demo/influxdb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-if [[ -z "$1" ]]; then
+if [ -z "$1" ]; then
     echo "\
 Ockam Demo: InfluxDB Add-on
 
@@ -57,7 +57,7 @@ case $1 in
     telegraf-ockamd)
         # start the initiator (source) end, containing `telegraf` and `ockamd`, with configuration
         # to start `telegraf` to use `ockamd` as an "execd" output plugin:
-        if [[ -z "$2" ]]; then
+        if [ -z "$2" ]; then
             echo "ERROR: You must provide the responder public key returned from the previous script."
             exit 1
         fi
@@ -95,7 +95,7 @@ case $1 in
     telegraf-ockamd-via-ockam-hub)
         # start the initiator (source) end, containing `telegraf` and `ockamd`, with configuration
         # to start `telegraf` to use `ockamd` as an "execd" output plugin:
-        if [[ -z "$2" ]]; then
+        if [ -z "$2" ]; then
             echo "ERROR: You must provide the responder public key and cleartext channel address returned from the previous script."
             exit 1
         fi


### PR DESCRIPTION
### Proposed Changes
Small fix: demo script shebang only specifies `sh`, but script had some bashisms (`[[ ... ]]` conditionals) and thus failed to run on systems were bash was not the default shell. Changed to simple POSIX (`[ ... ]` conditionals).

(Unrelated) Also fix broken link to contributing guidelines. 