### PR TITLE
fix(docs): correct broken links to ockam.io site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@ Thank you for your interest in contributing to the Ockam open source projects.
 We have several documents on [Ockam.io](https://www.ockam.io/) that will help to guide you.
 
 You can find Ockam's library of contributing guides here:
-[ockam.io/learn/guides/contributions/CONTRIBUTING](https://www.ockam.io/learn/guides/contributions/CONTRIBUTING)
+[ockam.io/learn/how-to-guides/contributing/CONTRIBUTING](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING)

--- a/implementations/rust/daemon/README.md
+++ b/implementations/rust/daemon/README.md
@@ -6,7 +6,7 @@
   src="https://dev.azure.com/ockam-network/ockam/_apis/build/status/ockam-network.ockam?branchName=develop">
 </a>
 
-<a href="https://www.ockam.io/learn/guides/team/conduct/">
+<a href="https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/">
 <img alt="Contributor Covenant"
   src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg">
 </a>


### PR DESCRIPTION
There are a couple of broken links from the docs to the web site. Until the [404 issue on the site](https://github.com/ockam-network/website/issues/317) is fixed, the links should be fixed.
