### PR TITLE
feat(elixir): Minimal qeue implementation

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/queue.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/queue.ex
@@ -1,3 +1,56 @@
 defmodule Ockam.Queue do
   @moduledoc false
+
+  use GenServer
+
+  def create(queue_id) do
+    GenServer.start_link(__MODULE__, [], name: name(queue_id))
+  end
+
+  def enqueue(queue_id, element) do
+    GenServer.call(name(queue_id), {:enqueue, element})
+  end
+
+  def dequeue(queue_id, count) do
+    GenServer.call(name(queue_id), {:dequeue, count})
+  end
+
+  def read(queue_id, starting_index, count) do
+    GenServer.call(name(queue_id), {:read, starting_index, count})
+  end
+
+  def get_length(queue_id) do
+    GenServer.call(name(queue_id), :length)
+  end
+
+  def init([]) do
+    {:ok, %{elements: []}}
+  end
+
+  def handle_call({:enqueue, element}, _, state) do
+    {:reply, :ok, %{state | elements: state.elements ++ [element]}}
+  end
+
+  def handle_call({:read, starting_index, count}, _, state) do
+    elements =
+      state.elements
+      |> Enum.drop(starting_index)
+      |> Enum.take(count)
+
+    {:reply, elements, state}
+  end
+
+  def handle_call({:dequeue, count}, _, state) do
+    {return, rest} = Enum.split(state.elements, count)
+
+    {:reply, return, %{state | elements: rest}}
+  end
+
+  def handle_call(:length, _, state) do
+    {:reply, length(state.elements), state}
+  end
+
+  def name(queue_id) do
+    {:via, Registry, {:queue_registry, queue_id}}
+  end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/queue_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/queue_test.exs
@@ -1,0 +1,64 @@
+defmodule Ockam.QueueTest do
+  use ExUnit.Case
+
+  alias Ockam.Queue
+
+  setup do
+    {:ok, _} = Registry.start_link(keys: :unique, name: :queue_registry)
+
+    :ok
+  end
+
+  test "items can be added and read from the queue" do
+    queue_id = random_id()
+    {:ok, _pid} = Queue.create(queue_id)
+
+    :ok = Queue.enqueue(queue_id, 10)
+    :ok = Queue.enqueue(queue_id, 11)
+    :ok = Queue.enqueue(queue_id, 12)
+
+    assert Queue.read(queue_id, 0, 1) == [10]
+    assert Queue.read(queue_id, 1, 2) == [11, 12]
+    assert Queue.read(queue_id, 2, 5) == [12]
+  end
+
+  test "you can fetch the length of the queue" do
+    queue_id = random_id()
+    {:ok, _pid} = Queue.create(queue_id)
+
+    :ok = Queue.enqueue(queue_id, 10)
+    :ok = Queue.enqueue(queue_id, 11)
+    :ok = Queue.enqueue(queue_id, 12)
+
+    assert Queue.get_length(queue_id) == 3
+  end
+
+  test "elements can be dequeued from the top" do
+    queue_id = random_id()
+    {:ok, _pid} = Queue.create(queue_id)
+
+    :ok = Queue.enqueue(queue_id, 10)
+    :ok = Queue.enqueue(queue_id, 11)
+    :ok = Queue.enqueue(queue_id, 12)
+
+    assert [10, 11] = Queue.dequeue(queue_id, 2)
+    assert Queue.get_length(queue_id) == 1
+  end
+
+  test "queues can be created dynamically" do
+    queue1 = random_id()
+    queue2 = random_id()
+    {:ok, _pid} = Queue.create(queue1)
+    {:ok, _pid} = Queue.create(queue2)
+
+    :ok = Queue.enqueue(queue1, 10)
+    :ok = Queue.enqueue(queue2, 20)
+
+    assert Queue.read(queue1, 0, 1) == [10]
+    assert Queue.read(queue2, 0, 1) == [20]
+  end
+
+  defp random_id do
+    "queue-#{:random.uniform(1_000_000)}"
+  end
+end


### PR DESCRIPTION
A minimal PoC of a simple queue. Still a WIP, since it lacks few things,
mostly:

- integrating it with the rest of the architecture
- topics implementation
- making sure that Registry is always started
- running each queue under a dynamic supervisor
- migrating to a ETS with concurrent reads if the queue should be read
by multiple client processes


Thank you for sending a pull request :heart:

### Proposed Changes
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
