### PR TITLE
feat(elixir): MVP of a Message Queue Implementation

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/topic.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/topic.ex
@@ -16,10 +16,126 @@ defmodule Ockam.Topics do
   def init(_init_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
+
+  @spec start_child(atom, atom) :: :ignore | {:error, any} | {:ok, pid} | {:ok, pid, any}
+  def start_child(module, topic_name) when is_atom(topic_name) do
+    DynamicSupervisor.start_child(__MODULE__, %{
+      id: topic_name,
+      start: {module, :start_link, [topic_name]}
+    })
+  end
+
+  @spec terminate_child(atom) :: :ok | {:error, :not_found}
+  def terminate_child(topic_name) do
+    pid = Process.whereis(topic_name)
+    DynamicSupervisor.terminate_child(__MODULE__, pid)
+  end
 end
 
 defmodule Ockam.Topic do
   @moduledoc """
   Implements the publish and subscribe semantics.
   """
+  use GenServer
+
+  alias Ockam.Topics
+
+  def init(%{topic_name: _} = state) do
+    # @TODO use ets for messages
+    # @TODO register consumers with their own DynamicSupervisor
+    # @TODO queued_messages is unbounded and really ought to be a pluggable backend with an ets table.
+    {:ok, Map.merge(state, %{queued_messages: [], consumers: []})}
+  end
+
+  def start_link(topic_name) do
+    GenServer.start_link(__MODULE__, %{topic_name: topic_name}, name: topic_name)
+  end
+
+  def create(topic_name) when is_atom(topic_name) do
+    # @TODO check for existing topic
+    Topics.start_child(__MODULE__, topic_name)
+  end
+
+  def destroy(topic_name) when is_atom(topic_name) do
+    Topics.terminate_child(topic_name)
+  end
+
+  def publish(topic_name, message) do
+    GenServer.cast(topic_name, {:publish, message})
+  end
+
+  def get_queue(topic_name) do
+    GenServer.call(topic_name, :get_queue)
+  end
+
+  def queue_length(topic_name) do
+    GenServer.call(topic_name, :queue_length)
+  end
+
+  def subscribe(topic_name, pid) do
+    GenServer.call(topic_name, {:subscribe, pid})
+  end
+
+  def process_queued_messages(topic_name) do
+    GenServer.cast(topic_name, :process_queued_messages)
+  end
+
+  def unsubscribe(topic_name, pid) do
+    GenServer.call(topic_name, {:unsubscribe, pid})
+  end
+
+  # @TODO add a timer for processing the queued messages.
+
+  def handle_cast({:publish, message}, %{queued_messages: messages, consumers: []} = state) do
+    # ++ performance does not suck anymore
+    {:noreply, %{state | queued_messages: [message | messages]}}
+  end
+
+  def handle_cast({:publish, message}, %{consumers: consumers} = state) do
+    Enum.each(consumers, fn consumer ->
+      # @TODO this should be a protocol probably.
+      GenServer.cast(consumer, {:consume, message})
+    end)
+
+    {:noreply, state}
+  end
+
+  def handle_cast(
+        :process_queued_messages,
+        %{queued_messages: messages, topic_name: topic_name} = state
+      ) do
+    messages
+    |> Enum.reverse()
+    |> Enum.each(fn message ->
+      publish(topic_name, message)
+    end)
+
+    {:noreply, %{state | queued_messages: []}}
+  end
+
+  def handle_call(:get_queue, _from, %{queued_messages: messages} = state) do
+    {:reply, messages, state}
+  end
+
+  def handle_call(:queue_length, _from, %{queued_messages: messages} = state) do
+    {:reply, length(messages), state}
+  end
+
+  def handle_call(
+        {:subscribe, pid},
+        _from,
+        %{topic_name: topic_name, consumers: consumers} = state
+      ) do
+    process_queued_messages(topic_name)
+    {:reply, :ok, %{state | consumers: [pid | consumers]}}
+  end
+
+  def handle_call({:unsubscribe, pid}, _from, %{consumers: consumers} = state) do
+    consumers =
+      Enum.reject(consumers, fn consumer ->
+        consumer == pid
+      end)
+
+    {:reply, :ok, %{state | consumers: consumers}}
+  end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/topic_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/topic_test.exs
@@ -1,0 +1,147 @@
+defmodule Ockam.Topic.Tests do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  doctest Ockam.Topic
+  alias Ockam.Topic
+
+  @topic_name :test_topic
+  @other_topic_name :test_topic_2
+
+  defmodule Consumer do
+    @moduledoc """
+    Example consumer for Ockam.Topic
+    """
+    use GenServer
+    require Logger
+
+    def init(_state) do
+      {:ok, %{}}
+    end
+
+    def start_link(default) when is_list(default) do
+      GenServer.start_link(__MODULE__, default)
+    end
+
+    def destroy(name \\ __MODULE__) do
+      GenServer.stop(name)
+    end
+
+    def handle_cast({:consume, message}, state) do
+      Logger.debug("Should process message: #{message}")
+      {:noreply, state}
+    end
+  end
+
+  setup_all do
+    Ockam.Topics.start_link([])
+    :ok
+  end
+
+  describe "topic" do
+    test "create/1" do
+      assert {:ok, pid} = Topic.create(@topic_name)
+      assert is_pid(pid)
+      assert Process.whereis(@topic_name) == pid
+      assert Topic.destroy(@topic_name)
+    end
+
+    test "can create two topics" do
+      assert {:ok, pid} = Topic.create(@topic_name)
+      assert is_pid(pid)
+      assert Process.whereis(@topic_name) == pid
+      assert {:ok, pid} = Topic.create(@other_topic_name)
+      assert is_pid(pid)
+      assert Process.whereis(@other_topic_name) == pid
+      assert Topic.destroy(@topic_name)
+      assert Topic.destroy(@other_topic_name)
+    end
+
+    test "cannot create twice" do
+      {:ok, pid} = Topic.create(@topic_name)
+      assert Topic.create(@topic_name) == {:error, {:already_started, pid}}
+      assert Topic.destroy(@topic_name) == :ok
+    end
+
+    test "destroy/1" do
+      Topic.create(@topic_name)
+      assert Topic.destroy(@topic_name) == :ok
+      assert Process.whereis(@topic_name) == nil
+    end
+
+    test "publish/2 with no consumer" do
+      Topic.create(@topic_name)
+      message = "no consumers"
+      assert Topic.publish(@topic_name, message) == :ok
+      assert Topic.get_queue(@topic_name) == [message]
+      assert Topic.queue_length(@topic_name) == 1
+      assert Topic.destroy(@topic_name) == :ok
+    end
+
+    test "publish/2 with a consumer" do
+      Topic.create(@topic_name)
+      message = "1 consumer"
+      {:ok, pid} = Consumer.start_link([])
+      assert Topic.subscribe(@topic_name, pid) == :ok
+      assert Topic.publish(@topic_name, message) == :ok
+      # if there is at least one consumer it won't save in the queue
+      assert Topic.get_queue(@topic_name) == []
+      assert Topic.queue_length(@topic_name) == 0
+      assert Topic.destroy(@topic_name) == :ok
+    end
+
+    test "subscribe/2" do
+      Topic.create(@topic_name)
+      {:ok, consumer_pid} = Consumer.start_link([])
+
+      assert Topic.subscribe(@topic_name, consumer_pid) == :ok
+      assert Topic.destroy(@topic_name) == :ok
+    end
+
+    test "unsubscribe/2" do
+      Topic.create(@topic_name)
+      {:ok, consumer_pid} = Consumer.start_link([])
+
+      assert Topic.unsubscribe(@topic_name, consumer_pid) == :ok
+      assert Topic.destroy(@topic_name) == :ok
+    end
+
+    test "process_queued_messages/1" do
+      Topic.create(@topic_name)
+      {:ok, consumer_pid} = Consumer.start_link([])
+      message = "queued message"
+
+      assert Topic.publish(@topic_name, message) == :ok
+      assert Topic.get_queue(@topic_name) == [message]
+      assert Topic.queue_length(@topic_name) == 1
+
+      # now subscribe a consumer and check that the message is gone
+      assert Topic.subscribe(@topic_name, consumer_pid) == :ok
+      assert Topic.process_queued_messages(@topic_name) == :ok
+      assert Topic.get_queue(@topic_name) == []
+      assert Topic.queue_length(@topic_name) == 0
+
+      assert Topic.process_queued_messages(@topic_name) == :ok
+      assert Topic.destroy(@topic_name) == :ok
+    end
+  end
+
+  describe "consumer" do
+    test "start_link/1" do
+      assert {:ok, pid} = Consumer.start_link([])
+      assert Consumer.destroy(pid) == :ok
+    end
+
+    test "destroy/1" do
+      assert {:ok, pid} = Consumer.start_link([])
+      assert Consumer.destroy(pid) == :ok
+    end
+
+    test "consume a message" do
+      message = "definitely consuming"
+
+      assert capture_log(fn ->
+               assert Consumer.handle_cast({:consume, message}, %{}) == {:noreply, %{}}
+             end) =~ "Should process message: definitely consuming"
+    end
+  end
+end


### PR DESCRIPTION
### Proposed Changes
Adds a basic GenServer-based message queue.

Consumer GenServers must accept handle_call({:consume, message}).

The queue is unbounded when there are no consumers.
Due to time constraints an ets table was considered but not used.

I'll be adding some more documentation and attaching a design document for next steps tomorrow.