### PR TITLE
feat(rust): app and service apps

### DIFF
--- a/implementations/rust/ockam/Cargo.toml
+++ b/implementations/rust/ockam/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 lto = true
 
 [features]
-default = ["ockam-common/default", "ockam-vault-software", "ockam-kex-xx"]
+default = ["ockam-common/default", "ockam-vault-software", "ockam-kex-xx", "ockam-kex-x3dh"]
 ffi = ["ockam-common/default", "ockam-vault-ffi"] #, "ockam-kex-ffi"]
 
 [dependencies]
@@ -17,6 +17,7 @@ hex = "0.4"
 ockam-common = { version = "0.1", path = "../common", default-features = false }
 ockam-kex = { version = "0.1", path = "../kex/traits"}
 ockam-kex-xx = { version = "0.1", path = "../kex/xx", optional = true }
+ockam-kex-x3dh = { version = "0.1", path = "../kex/x3dh", optional = true }
 #ockam-kex-ffi = { version = "0.1", path = "../kex/ffi", optional = true }
 ockam-queue-topic = { version = "0.1", path = "../queue_topic" }
 ockam-vault = { version = "0.1", path = "../vault/traits" }

--- a/implementations/rust/ockam/src/lib.rs
+++ b/implementations/rust/ockam/src/lib.rs
@@ -5,9 +5,12 @@ pub mod system;
 
 pub use ockam_common as common;
 pub use ockam_kex as kex;
-// pub use ockam_message_router as message_router;
-// pub use ockam_no_std_traits as no_std_traits;
-// pub use ockam_node as node;
-// pub use ockam_queue as queue;
-// pub use ockam_queue_topic as queue_topic;
 pub use ockam_vault as vault;
+
+#[cfg(feature = "ockam-vault-software")]
+pub use ockam_vault_software as vault_software;
+
+#[cfg(feature = "ockam-kex-x3dh")]
+pub use ockam_kex_x3dh as kex_x3dh;
+#[cfg(feature = "ockam-kex-xx")]
+pub use ockam_kex_xx as kex_xx;

--- a/implementations/rust/okta/Cargo.toml
+++ b/implementations/rust/okta/Cargo.toml
@@ -4,6 +4,13 @@ name = "okta-plugin"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+name = "oktaplugin"
+
+[[bin]]
+name = "ockam-plugin"
+path = "main.rs"
+
 [profile.release]
 lto = true
 
@@ -11,8 +18,11 @@ lto = true
 base64-url = "1.4"
 colored = "2.0"
 dirs = "3.0"
+generic-array = "0.12"
 isahc = "0.9"
 rpassword = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_bare = "0.3"
+serde-big-array = "0.3"
 structopt = "0.3"

--- a/implementations/rust/okta/management_app/Cargo.toml
+++ b/implementations/rust/okta/management_app/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name = "truck"
+name = "management_app"
 version = "0.1.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 
-[profile.release]
-lto = true
 
 [dependencies]
-arrayref = "0.3"
-colored = "2.0"
-rand = "0.7"
+lazy_static = "1.4"
 ockam = { version = "0.1", path = "../../ockam" }
 okta-plugin = { version = "0.1", path = "../" }
+rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_bare = "0.3"
+serde_json = "1.0"
+structopt = "0.3"

--- a/implementations/rust/okta/management_app/src/config.rs
+++ b/implementations/rust/okta/management_app/src/config.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, Deserialize, Serialize, StructOpt)]
+pub struct Config {
+    #[structopt(short="-a", long)]
+    pub service_address: String,
+    #[structopt(short="-p", long)]
+    pub service_port: u16,
+    #[structopt(short="-t", long)]
+    pub truck_address: String,
+    #[structopt(short="-u", long)]
+    pub truck_port: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { service_address: "127.0.0.1".to_string(), service_port: 0, truck_address: "127.0.0.1".to_string(), truck_port: 0 }
+    }
+}

--- a/implementations/rust/okta/management_app/src/main.rs
+++ b/implementations/rust/okta/management_app/src/main.rs
@@ -1,0 +1,269 @@
+#[macro_use]
+extern crate lazy_static;
+
+mod config;
+
+use ockam::{
+    vault::*,
+    vault::types::*,
+    vault_software::*,
+};
+use oktaplugin::{Messages, OckamMessages, OckamRole, KeyEstablishment, EstablishmentBundle};
+use rand::prelude::*;
+use std::{
+    fs,
+    io::{self, Write},
+    net::TcpStream,
+    path::Path,
+    sync::Mutex,
+};
+use structopt::StructOpt;
+use oktaplugin::Messages::OktaRequest;
+use std::collections::BTreeMap;
+use std::borrow::BorrowMut;
+use std::thread::sleep;
+
+const FILE_NAME: &str = ".env";
+
+lazy_static! {
+    static ref VAULT: Mutex<DefaultVault> = Default::default();
+}
+
+fn main() {
+    let cfg =
+        if Path::new(FILE_NAME).is_file() {
+            let contents = fs::read_to_string(FILE_NAME).unwrap();
+            serde_json::from_str::<config::Config>(&contents).unwrap()
+        } else {
+            config::Config::from_args()
+        };
+
+
+    let res = TcpStream::connect(format!("{}:{}", cfg.service_address, cfg.service_port));
+    if res.is_err() {
+        eprintln!("Unable to connect to service");
+        return;
+    }
+    let mut service_stream = res.unwrap();
+    let login_id = thread_rng().gen::<u64>() as usize;
+    let msg = Messages::OktaLogin(login_id);
+    let res = service_stream.write(&serde_bare::to_vec(&msg).unwrap());
+    if res.is_err() {
+        eprintln!("Unable to send login notice");
+        service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+        return;
+    }
+    let res = service_stream.flush();
+    if res.is_err() {
+        eprintln!("Unable to send login notice");
+        service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+        return;
+    }
+
+    let mut services_data = BTreeMap::new();
+    let mut x3dh_bundles = BTreeMap::new();
+    let mut access_token = String::new();
+    let mut credential_key: Option<Box<dyn Secret>> = None;
+
+    loop {
+        let res = serde_bare::from_reader::<&TcpStream, Messages>(&service_stream);
+        if res.is_err() {
+            match res.unwrap_err() {
+                serde_bare::Error::Io(e) => {
+                    if e.kind() == io::ErrorKind::UnexpectedEof {
+                        eprintln!("Server closed connection");
+                        return;
+                    }
+                    eprintln!("Unknown message type");
+                    continue;
+                }
+                _ => {
+                    eprintln!("Unknown message type");
+                    continue;
+                }
+            }
+        }
+        let msg = res.unwrap();
+        match msg {
+            Messages::OktaLoginUrl{ preamble, url } => {
+                println!("{}", preamble);
+                println!("{}", url);
+            },
+            Messages::OktaGrantToken { token } => {
+
+            },
+            Messages::OktaAccessToken { token } => {
+                access_token = token;
+
+                if credential_key.is_some() {
+                    let msg = OktaRequest { token: access_token.clone(), msg: OckamMessages::ListServicesRequest {
+                        limit: 1000,
+                        offset: 0
+                    }};
+                    serde_bare::to_writer(&mut service_stream, &msg).unwrap();
+                    service_stream.flush().unwrap();
+                    continue;
+                }
+
+                let mut vault = VAULT.lock().unwrap();
+
+                let res = vault.secret_generate(SecretAttributes {
+                    stype: SecretType::Curve25519,
+                    persistence: SecretPersistence::Ephemeral,
+                    length: 0
+                });
+                if res.is_err() {
+                    eprintln!("Couldn't create enroller credential key");
+                    service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                    return;
+                }
+                let secret = res.unwrap();
+                let public = vault.secret_public_key_get(&secret).unwrap();
+                let proof = vault.sign(&secret, public.as_ref()).unwrap();
+
+                let mut public_key = [0u8; 32];
+                public_key.copy_from_slice(public.as_ref());
+
+                let msg = Messages::OktaRequest {
+                    token: access_token.clone(),
+                    msg: OckamMessages::BecomeRequest {
+                        role: OckamRole::Enroller {
+                            public_key,
+                            proof
+                        }
+                    }
+                };
+                serde_bare::to_writer(&mut service_stream, &msg).unwrap();
+                service_stream.flush().unwrap();
+                credential_key = Some(secret);
+            },
+            Messages::OktaResponse { msg } => {
+                match msg {
+                    OckamMessages::AccessDenied => {
+                        let login_id = thread_rng().gen::<u64>() as usize;
+                        let msg = Messages::OktaLogin(login_id);
+                        serde_bare::to_writer(&mut service_stream, &msg).unwrap();
+                        service_stream.flush().unwrap();
+                    },
+                    OckamMessages::BecomeResponse { result, msg } => {
+                        if result {
+                            println!("Became Enroller successfully");
+
+                            let msg = OktaRequest { token: access_token.clone(), msg: OckamMessages::ListServicesRequest {
+                                limit: 1000,
+                                offset: 0
+                            }};
+                            serde_bare::to_writer(&mut service_stream, &msg).unwrap();
+                            service_stream.flush().unwrap();
+                        } else {
+                            println!("Become Enroller failure: {:?}", msg);
+                            service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                            return;
+                        }
+                    },
+                    OckamMessages::ListServicesResponse { services } => {
+                        services_data = services.iter().map(|s| (s.id, s.clone())).collect();
+                        let mut bundles = Vec::new();
+                        for s in &services {
+                            if s.key_establishment.contains(&KeyEstablishment::X3dh) {
+                                bundles.push(s.id);
+                            }
+                        }
+                        println!("Services: {:?}", services_data);
+                        let req = OktaRequest { token: access_token.clone(), msg: OckamMessages::GetEstablishmentBundlesRequest {
+                            services: bundles
+                        }};
+                        serde_bare::to_writer(&mut service_stream, &req).unwrap();
+                        service_stream.flush().unwrap();
+                    },
+                    OckamMessages::GetEstablishmentBundlesResponse { services } => {
+                        println!("Received bundles: {:?}", services);
+
+                        x3dh_bundles = services.iter().map(|s| (s.service_id, s.clone())).collect();
+
+                        println!("Start a truck to begin enrollment");
+                        let res = TcpStream::connect(format!("{}:{}", cfg.truck_address, cfg.truck_port));
+                        while res.is_err() {
+                            sleep(std::time::Duration::from_secs(2));
+                            println!("Waiting for truck at {}:{}", cfg.truck_address, cfg.truck_port);
+                        }
+
+                        let mut truck_stream = res.unwrap();
+
+                        println!("Connected to truck");
+                        print!("Starting enrollment...");
+                        io::stdout().flush().unwrap();
+                        let mut cred_id = [0u8; 16];
+                        rand::thread_rng().fill_bytes(&mut cred_id);
+
+                        serde_bare::to_writer(&truck_stream, &OckamMessages::BeginDeviceEnrollment {
+                            nonce: cred_id
+                        }).unwrap();
+                        let res = serde_bare::from_reader::<&TcpStream, OckamMessages>(&truck_stream);
+                        if res.is_err() {
+                            println!("fail");
+                            println!("{:?}", res.unwrap_err());
+                            truck_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                            service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                            return;
+                        }
+                        match res.unwrap() {
+                            OckamMessages::DeviceEnrollmentRequest { nonce, blind_device_secret, .. } => {
+                                if cred_id != nonce {
+                                    println!("fail");
+                                    println!("Invalid cred id");
+                                    truck_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                                    service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                                    return;
+                                }
+                                println!("pass");
+                                print!("Creating credential...");
+                                io::stdout().flush().unwrap();
+                                let mut vault = VAULT.lock().unwrap();
+                                let attributes = vec![
+                                    cred_id.to_vec(),
+                                    b"Acme Truck".to_vec(),
+                                    b"Site B".to_vec(),
+                                    b"LTE".to_vec()
+                                ];
+                                let mut sig_data = Vec::new();
+                                sig_data.extend_from_slice(&blind_device_secret);
+                                let mut hashed_attributes = Vec::new();
+                                hashed_attributes.push(blind_device_secret.to_vec());
+                                for a in &attributes {
+                                    let hash = vault.sha256(a.as_slice()).unwrap();
+                                    sig_data.extend_from_slice(&hash);
+                                    hashed_attributes.push(hash.to_vec());
+                                }
+                                let sig_data = vault.sha256(&sig_data).unwrap();
+                                let sig_key = credential_key.as_ref().unwrap();
+                                let signature = vault.sign(sig_key, &sig_data).unwrap();
+                                serde_bare::to_writer(&mut truck_stream, &OckamMessages::DeviceEnrollmentResponse {
+                                    schema: services_data[&1].schemas[0].clone(),
+                                    service: x3dh_bundles[&1].clone(),
+                                    attributes,
+                                    attestation: signature.to_vec()
+                                }).unwrap();
+                                println!("done");
+
+                                println!("Closing down");
+                                let _ = truck_stream.shutdown(std::net::Shutdown::Both);
+                                service_stream.shutdown(std::net::Shutdown::Both).unwrap();
+                                break;
+                            },
+                            _ => {
+
+                            }
+                        }
+                    }
+                    _ => {
+
+                    }
+                }
+            },
+            _ => {
+
+            }
+        }
+    }
+}

--- a/implementations/rust/okta/management_service/Cargo.toml
+++ b/implementations/rust/okta/management_service/Cargo.toml
@@ -8,13 +8,17 @@ edition = "2018"
 lto = true
 
 [dependencies]
+arrayref = "0.3"
 base64-url = "1.4"
 colored = "2.0"
 isahc = "0.9"
 lazy_static = "1.4"
 percent-encoding = "2.1"
 rand = "0.7"
+ockam = { version = "0.1", path = "../../ockam" }
+okta-plugin = { version = "0.1", path = "../" }
 serde = { version = "1.0", features = ["derive"] }
+serde_bare = "0.3"
 serde_json = "1.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }

--- a/implementations/rust/okta/management_service/src/config.rs
+++ b/implementations/rust/okta/management_service/src/config.rs
@@ -9,14 +9,16 @@ pub struct Config {
     pub client_id: String,
     #[structopt(short="-s", long)]
     pub client_secret: String,
-    #[structopt(short, long)]
-    pub port: u16,
-    #[structopt(short, long)]
+    #[structopt(short="-p", long)]
+    pub channel_port: u16,
+    #[structopt(short="o", long)]
+    pub okta_port: u16,
+    #[structopt(short="-u", long)]
     pub okta_url: String,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self { api_token: String::new(), client_id: String::new(), client_secret: String::new(), port: 0, okta_url: String::new() }
+        Self { api_token: String::new(), client_id: String::new(), client_secret: String::new(), channel_port: 0, okta_port: 0, okta_url: String::new() }
     }
 }

--- a/implementations/rust/okta/management_service/src/main.rs
+++ b/implementations/rust/okta/management_service/src/main.rs
@@ -1,4 +1,6 @@
 #[macro_use]
+extern crate arrayref;
+#[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
@@ -10,18 +12,30 @@ use colored::Colorize;
 use isahc::prelude::*;
 use objects::UsersInGroup;
 use rand::RngCore;
+use ockam::{
+    vault::*,
+    vault_software::*,
+    kex::*,
+    kex_x3dh::*,
+};
+use oktaplugin::{
+    *,
+    Messages::OktaResponse,
+};
 use serde::Deserialize;
 use std::{
     cell::RefCell,
-    collections::BTreeSet,
+    collections::{BTreeSet, BTreeMap},
     fs,
-    io::{stdout, Write},
+    io::{self, stdout, Write},
+    net::{TcpListener, TcpStream},
     path::Path,
-    sync::Mutex,
+    sync::{Arc, Mutex},
     thread,
 };
 use structopt::StructOpt;
 use warp::Filter;
+use std::thread::sleep;
 
 const FILE_NAME: &str = ".env";
 
@@ -32,19 +46,28 @@ lazy_static! {
     static ref CFG: Mutex<RefCell<config::Config>> = Default::default();
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct OktaData {
-    state: [u8; 16],
+    state: BTreeMap<[u8; 16], StateData>,
+    ids: BTreeMap<usize, [u8; 16]>,
     redirect_uri: String
 }
 
 impl Default for OktaData {
     fn default() -> Self {
         Self {
-            state: [0u8; 16],
+            state: BTreeMap::new(),
+            ids : BTreeMap::new(),
             redirect_uri: String::new()
         }
     }
+}
+
+#[derive(Debug)]
+struct StateData {
+    id: usize,
+    state: [u8; 16],
+    stream: TcpStream,
 }
 
 /// Groups to check against
@@ -106,15 +129,17 @@ impl OktaIntrospectResponse {
 }
 
 async fn parse_query_params(query: OktaOpenIdResponse) -> WarpResult<impl warp::Reply> {
-    thread::spawn(move || {
-        let cfg = CFG.lock().unwrap().borrow().clone();
-        let state = STATE.lock().unwrap().borrow().clone();
-        start(cfg, &state, query);
+    thread::spawn(|| {
+        let lock = STATE.lock().unwrap();
+        let state = lock.borrow();
+        let lock = CFG.lock().unwrap();
+        let cfg = lock.borrow();
+        start( &cfg, &state, query);
     });
     Ok("Success. You may close this tab and return to the shell.")
 }
 
-fn start(cfg: config::Config, data: &OktaData, query: OktaOpenIdResponse) {
+fn start(cfg: &config::Config, data: &OktaData, query: OktaOpenIdResponse) {
     let mut stdout = stdout();
     println!("Received authorization code");
     print!("Decoding...");
@@ -129,12 +154,13 @@ fn start(cfg: config::Config, data: &OktaData, query: OktaOpenIdResponse) {
     print!("Verifying expected state...");
     stdout.flush().unwrap();
     let rx_state = res.unwrap();
-    if rx_state != data.state {
+    if !data.state.contains_key(rx_state.as_slice()) {
         fail("fail");
         eprintln!("Expected state does not match the request");
         return;
     }
     pass("match");
+
     print!("Obtaining access token...");
     stdout.flush().unwrap();
     let res = exchange_code_for_access_token(&cfg, &data, &query.code);
@@ -147,7 +173,7 @@ fn start(cfg: config::Config, data: &OktaData, query: OktaOpenIdResponse) {
     print!("Inspecting user information...");
     stdout.flush().unwrap();
     let creds = res.unwrap();
-    let res = introspect(&cfg, &creds);
+    let res = introspect(&cfg, &creds.access_token);
     if res.is_err() {
         fail("fail");
         eprintln!("Unable to introspect access token from okta: {:?}", res);
@@ -156,14 +182,27 @@ fn start(cfg: config::Config, data: &OktaData, query: OktaOpenIdResponse) {
     pass("success");
     let intro = res.unwrap();
     println!("Logged in as {}", intro.username());
-    print!("Checking user roles...");
+    // print!("Checking user roles...");
+    // stdout.flush().unwrap();
+    // if !is_user_in_group(&cfg, &intro.id(), &OKTA_GROUPS) {
+    //     fail("fail");
+    //     eprintln!("{} is not in the correct group", intro.username());
+    //     return;
+    // }
+    // pass("success");
+
+    print!("Sending code back to client...");
     stdout.flush().unwrap();
-    if !is_user_in_group(&cfg, &intro, &OKTA_GROUPS) {
+    let mut stream = &data.state[rx_state.as_slice()].stream;
+    let msg = Messages::OktaAccessToken { token: creds.access_token };
+    let res = serde_bare::to_writer(stream, &msg);
+    if res.is_err() {
         fail("fail");
-        eprintln!("{} is not in the correct group", intro.username());
+        eprintln!("Unable to send code back to client");
         return;
     }
-    pass("success");
+    stream.flush().unwrap();
+    pass("done");
 }
 
 fn exchange_code_for_access_token(cfg: &config::Config, data: &OktaData, code: &str) -> Result<OktaTokenResponse, String> {
@@ -176,17 +215,17 @@ fn exchange_code_for_access_token(cfg: &config::Config, data: &OktaData, code: &
     serde_json::from_str(&text).map_err(|e| format!("{:?}", e))
 }
 
-fn introspect(cfg: &config::Config, creds: &OktaTokenResponse) -> Result<OktaIntrospectResponse, String> {
+fn introspect(cfg: &config::Config, access_token: &str) -> Result<OktaIntrospectResponse, String> {
     let mut response = Request::post(format!("{}/oauth2/default/v1/introspect", cfg.okta_url))
         .header("accept", "application/json")
         .header("content-type", "application/x-www-form-urlencoded")
-        .body(format!("client_id={}&client_secret={}&token_type_hint=access_token&token={}", cfg.client_id, cfg.client_secret, creds.access_token)).unwrap()
+        .body(format!("client_id={}&client_secret={}&token_type_hint=access_token&token={}", cfg.client_id, cfg.client_secret, access_token)).unwrap()
         .send().unwrap();
     let text = response.text().unwrap();
     serde_json::from_str(&text).map_err(|e| format!("{:?}", e))
 }
 
-fn is_user_in_group(cfg: &config::Config, creds: &OktaIntrospectResponse, groups: &[&str]) -> bool {
+fn is_user_in_group(cfg: &config::Config, id: &str, groups: &[&str]) -> bool {
     let mut response = Request::get(format!("{}/api/v1/groups/{}/users", cfg.okta_url, groups[0]))
         .header("Accept", "application/json")
         .header("Content-type", "application/json")
@@ -200,7 +239,6 @@ fn is_user_in_group(cfg: &config::Config, creds: &OktaIntrospectResponse, groups
     }
     let text = response.text().unwrap();
     let response: Vec<UsersInGroup> = serde_json::from_str(&text).unwrap();
-    let id = creds.id();
     response.iter().any(|u| u.id == id)
 }
 
@@ -211,6 +249,15 @@ fn pass(s: &str) {
 #[cfg(not(target_os = "windows"))]
 fn pass(s: &str) {
     println!("{}", s.green());
+}
+
+#[cfg(target_os = "windows")]
+fn highlight(s: &str) {
+    println!("{}", s);
+}
+#[cfg(not(target_os = "windows"))]
+fn highlight(s: &str) {
+    println!("{}", s.yellow());
 }
 
 #[cfg(target_os = "windows")]
@@ -233,24 +280,25 @@ async fn main() {
         };
 
     let mut okta_data = OktaData::default();
-    let mut nonce = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut okta_data.state);
-    rand::thread_rng().fill_bytes(&mut nonce);
 
-    okta_data.redirect_uri = format!("http://localhost:{}/authorization-code/callback", cfg.port);
+    okta_data.redirect_uri = format!("http://localhost:{}/authorization-code/callback", cfg.okta_port);
 
-    println!("Open the following URL in a browser to continue");
-    println!("{}/oauth2/default/v1/authorize?response_type=code&client_id={}&redirect_uri={}&state={}&nonce={}&scope=openid",
-             cfg.okta_url,
-             percent_encoding::utf8_percent_encode(&cfg.client_id, percent_encoding::NON_ALPHANUMERIC),
-             percent_encoding::utf8_percent_encode(&okta_data.redirect_uri, percent_encoding::NON_ALPHANUMERIC),
-             base64_url::encode(&okta_data.state),
-             base64_url::encode(&nonce));
+    // println!("Open the following URL in a browser to continue");
+    // println!("{}/oauth2/default/v1/authorize?response_type=code&client_id={}&redirect_uri={}&state={}&nonce={}&scope=openid",
+    //          cfg.okta_url,
+    //          percent_encoding::utf8_percent_encode(&cfg.client_id, percent_encoding::NON_ALPHANUMERIC),
+    //          percent_encoding::utf8_percent_encode(&okta_data.redirect_uri, percent_encoding::NON_ALPHANUMERIC),
+    //          base64_url::encode(&okta_data.state),
+    //          base64_url::encode(&nonce));
 
     *STATE.lock().unwrap().borrow_mut() = okta_data;
 
-    let port = cfg.port;
+    let port = cfg.okta_port;
     *CFG.lock().unwrap().borrow_mut() = cfg;
+
+    thread::spawn(|| {
+       channel_listener();
+    });
 
     let callback = warp::get()
         .and(warp::path("authorization-code"))
@@ -260,4 +308,314 @@ async fn main() {
     warp::serve(callback).run(([127,0,0,1], port)).await;
 }
 
+fn channel_listener() {
+    let mut enrollers: BTreeMap<String, BTreeSet<[u8; 32]>> = BTreeMap::new();
+    let cfg = CFG.lock().unwrap().borrow().clone();
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", cfg.channel_port)).unwrap();
+    let xxvault = Arc::new(Mutex::new(DefaultVault::default()));
+    let x3dh_kex = X3dhNewKeyExchanger::new(xxvault.clone(), xxvault.clone());
+    let mut responder = Some(Box::new(x3dh_kex.responder(None)));
+    let mut nonce = 2u16;
 
+    let mut connections = Vec::new();
+
+    let mut completed_key_exchange = None;
+
+    loop {
+        listener.set_nonblocking(true).unwrap();
+        let res = listener.accept();
+        if res.is_err() {
+            let err = res.unwrap_err();
+            match err.kind() {
+                io::ErrorKind::WouldBlock => {
+                    if connections.is_empty() {
+                        sleep(std::time::Duration::from_millis(50));
+                    }
+                },
+                _ => {
+                    eprintln!("{:?}", err);
+                }
+            }
+        } else {
+            let (stream, addr) = res.unwrap();
+            println!("Connection from {:?}", addr);
+            connections.push(stream);
+        }
+
+        let mut i = 0;
+        while i < connections.len() {
+            let mut stream = connections.get_mut(i).unwrap();
+            stream.set_nonblocking(true).unwrap();
+
+            let res = serde_bare::from_reader::<&TcpStream, Messages>(&stream);
+            if res.is_err() {
+                match res.unwrap_err() {
+                    serde_bare::Error::Io(e) => {
+                        match e.kind() {
+                            io::ErrorKind::WouldBlock => {
+                                sleep(std::time::Duration::from_millis(50));
+                                i += 1;
+                                continue;
+                            },
+                            io::ErrorKind::UnexpectedEof => {
+                                eprintln!("Client closed connection");
+                                connections.remove(i);
+                                continue;
+                            }
+                            _ => {
+                                i += 1;
+                                eprintln!("Unknown message type");
+                                continue;
+                            }
+                        }
+                    }
+                    _ => {
+
+                        i += 1;
+                        eprintln!("Unknown message type");
+                        continue;
+                    }
+                }
+            }
+
+            let m = res.unwrap();
+            i += 1;
+
+            match m {
+                Messages::OktaLogin(id) => {
+                    let cfg = CFG.lock().unwrap().borrow().clone();
+                    let lock = STATE.lock().unwrap();
+                    let mut okta_data = lock.borrow_mut();
+
+                    let mut nonce = [0u8; 16];
+                    rand::thread_rng().fill_bytes(&mut nonce);
+                    let mut state = [0u8; 16];
+
+                    if let Some(s) = okta_data.ids.get(&id) {
+                        state.copy_from_slice(s);
+                    } else {
+                        rand::thread_rng().fill_bytes(&mut state);
+                        okta_data.ids.insert(id, state);
+                        okta_data.state.insert(state, StateData {
+                            state,
+                            id,
+                            stream: stream.try_clone().unwrap()
+                        });
+                    }
+
+                    let msg = Messages::OktaLoginUrl {
+                        preamble: "Open the following URL in a browser to continue".to_string(),
+                        url: format!("{}/oauth2/default/v1/authorize?response_type=code&client_id={}&redirect_uri={}&state={}&nonce={}&scope=openid",
+                                     cfg.okta_url,
+                                     percent_encoding::utf8_percent_encode(&cfg.client_id, percent_encoding::NON_ALPHANUMERIC),
+                                     percent_encoding::utf8_percent_encode(&okta_data.redirect_uri, percent_encoding::NON_ALPHANUMERIC),
+                                     base64_url::encode(&state),
+                                     base64_url::encode(&nonce))
+                    };
+                    stream.write(&serde_bare::to_vec(&msg).unwrap()).unwrap();
+                    stream.flush().unwrap();
+                },
+                Messages::OktaRequest { token, msg } => {
+                    println!("Received token = {}\n msg = {:?}", token, msg);
+                    // Verify Okta token
+                    let lock = CFG.lock().unwrap();
+                    let cfg = lock.borrow();
+                    let res = introspect(&cfg, &token);
+                    if res.is_err() {
+                        println!("Invalid access token: {:?}", res);
+                        continue;
+                    }
+                    let introspect_res = res.unwrap();
+                    if !introspect_res.active {
+                        println!("Access token is not active");
+                        continue;
+                    }
+
+                    match msg {
+                        OckamMessages::BecomeRequest {role} => {
+                            match role {
+                                OckamRole::Enroller {public_key, proof} => {
+                                    if !is_user_in_group(&cfg, &introspect_res.id(), &OKTA_GROUPS) {
+                                        println!("Access Denied, no Enroller group associated with user");
+                                        let msg = OktaResponse {msg : OckamMessages::BecomeResponse { result: false, msg: "Access Denied, no Enroller group associated with user".to_string() } };
+                                        stream.write(&serde_bare::to_vec(&msg).unwrap()).unwrap();
+                                        stream.flush().unwrap();
+                                        continue;
+                                    }
+                                    let mut vault = DefaultVault::default();
+                                    if vault.verify(&proof, &public_key, &public_key).is_err() {
+                                        println!("Invalid enroller key");
+                                        let msg = OktaResponse {msg : OckamMessages::BecomeResponse { result: false, msg: "Invalid enroller key".to_string() } };
+                                        stream.write(&serde_bare::to_vec(&msg).unwrap()).unwrap();
+                                        stream.flush().unwrap();
+                                        continue;
+                                    }
+                                    let msg = OktaResponse {msg : OckamMessages::BecomeResponse { result: true, msg: String::new() } };
+                                    stream.write(&serde_bare::to_vec(&msg).unwrap()).unwrap();
+                                    stream.flush().unwrap();
+                                    let uid = introspect_res.uid.clone().unwrap();
+                                    if let Some(keys) = enrollers.get_mut(&uid) {
+                                        keys.insert(public_key);
+                                    } else {
+                                        let mut keys = BTreeSet::new();
+                                        keys.insert(public_key);
+                                        enrollers.insert(uid, keys);
+                                    }
+                                }
+                            }
+                        },
+                        OckamMessages::ListServicesRequest { limit, offset  } => {
+                            println!("List no more than {} services starting at {}", limit, offset);
+
+                            // Ignore limit and offset since its hardcoded
+                            let services = vec![OckamService {
+                                id: 1,
+                                key_establishment: vec![KeyEstablishment::Xx, KeyEstablishment::X3dh],
+                                schemas: vec![CredentialSchema {
+                                    id: "TruckManagement0001".to_string(),
+                                    attributes: vec![
+                                        "device_id".to_string(),
+                                        "credential_id".to_string(),
+                                        "device_name".to_string(),
+                                        "location".to_string(),
+                                        "interface".to_string()
+                                    ]
+                                }]
+                            }];
+
+                            let msg = OktaResponse { msg: OckamMessages::ListServicesResponse { services }};
+                            serde_bare::to_writer(&mut stream, &msg).unwrap();
+                            stream.flush().unwrap();
+                        },
+                        OckamMessages::GetEstablishmentBundlesRequest { services } => {
+                            println!("GetEstablishmentBundlesRequest: {:?}", services);
+                            loop {
+                                if let Some(ref mut resp) = responder {
+                                    let res = resp.process(b"").unwrap();
+                                    let msg = OktaResponse {
+                                        msg: OckamMessages::GetEstablishmentBundlesResponse {
+                                            services: vec![EstablishmentBundle {
+                                                service_id: 1,
+                                                address: format!("127.0.0.1:{}", cfg.channel_port),
+                                                key_establishment: KeyEstablishment::X3dh,
+                                                key_establishment_data: res
+                                            }]
+                                        }
+                                    };
+                                    serde_bare::to_writer(&mut stream, &msg).unwrap();
+                                    stream.flush().unwrap();
+                                    break;
+                                } else {
+                                    println!("Enrollment bundle already used. Creating new bundle");
+                                    responder = Some(Box::from(x3dh_kex.responder(None)));
+                                }
+                            }
+                        },
+                        _ => {
+
+                        }
+                    };
+                },
+                Messages::NonOktaRequest(m) => {
+                    match m {
+                        OckamMessages::ServiceEnrollmentMessage1(data) => {
+                            if let Some(ref mut resp) = responder {
+                                match resp.process(&data) {
+                                    Err(e) => eprintln!("{}", e.to_string()),
+                                    Ok(d) => {
+                                        serde_bare::to_writer(&mut stream, &OckamMessages::ServiceEnrollmentResponse(d)).unwrap();
+                                    }
+                                }
+                            } else {
+                                eprintln!("Enrollment bundle already used.");
+                                serde_bare::to_writer(&mut stream, &OckamMessages::ServiceEnrollmentResponse(vec![])).unwrap();
+                            }
+                        },
+                        OckamMessages::ServiceEnrollmentMessage2(data) => {
+                            if responder.is_some() {
+                                let mut resp = responder.unwrap();
+                                responder = None;
+                                let res = resp.process(&data);
+                                match res {
+                                    Err(e) => {
+                                        eprintln!("{}", e.to_string());
+                                        serde_bare::to_writer(&mut stream, &OckamMessages::ServiceEnrollmentResponse(vec![0])).unwrap();
+                                    },
+                                    Ok(_) => {
+                                        let kex = resp.finalize().unwrap();
+                                        let mut v = xxvault.lock().unwrap();
+                                        let ctt = v.aead_aes_gcm_encrypt(&kex.encrypt_key, &[1], &[0u8; 12], &kex.h).unwrap();
+                                        completed_key_exchange = Some(kex);
+                                        serde_bare::to_writer(&mut stream, &OckamMessages::ServiceEnrollmentResponse(ctt)).unwrap();
+                                        responder = None;
+                                    }
+                                }
+                            }
+                        },
+                        OckamMessages::ServiceEnrollmentMessage3(data) => {
+                            let mut v = xxvault.lock().unwrap();
+                            let kex = completed_key_exchange.as_ref().unwrap();
+                            let mut n= [0u8; 12];
+                            n[11] = 1;
+                            let res = v.aead_aes_gcm_decrypt(&kex.decrypt_key, data.as_slice(), &n, &kex.h);
+                            match res {
+                                Err(e) => eprintln!("{}", e.to_string()),
+                                Ok(plaintext) => {
+                                    match serde_bare::from_slice::<Attestation>(plaintext.as_slice()) {
+                                        Err(e) => eprintln!("{:?}", e),
+                                        Ok(attestation) => {
+                                            let mut sig_data = Vec::new();
+                                            for a in &attestation.attributes {
+                                                let hash = v.sha256(a).unwrap();
+                                                sig_data.extend_from_slice(&hash);
+                                            }
+                                            let sig_data = v.sha256(&sig_data).unwrap();
+                                            let signature = *array_ref![attestation.signature, 0, 64];
+                                            let mut verified = false;
+                                            for (_, keys) in &enrollers {
+                                                for key in keys {
+                                                    if v.verify(&signature, &key[..], &sig_data).is_ok() {
+                                                        verified = true;
+                                                        break;
+                                                    }
+                                                }
+                                                if verified {
+                                                    break;
+                                                }
+                                            }
+                                            n[11] = 2;
+                                            let ctt = v.aead_aes_gcm_encrypt(&kex.encrypt_key, &[verified as u8], &n, &kex.h).unwrap();
+
+                                            serde_bare::to_writer(&mut stream, &OckamMessages::ServiceEnrollmentResponse(ctt)).unwrap();
+                                            stream.flush().unwrap();
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        OckamMessages::GeneralMessage(data) => {
+                            nonce = nonce.wrapping_add(1);
+                            let mut n = [0u8; 12];
+                            n[10..].copy_from_slice(&nonce.to_be_bytes());
+                            let mut v = xxvault.lock().unwrap();
+                            let kex = completed_key_exchange.as_ref().unwrap();
+                            match v.aead_aes_gcm_decrypt(&kex.decrypt_key, data.as_slice(), &n, &kex.h) {
+                                Err(e) => eprintln!("An error occurred while decrypting: {}", e.to_string()),
+                                Ok(s) => {
+                                    print!("Received: ");
+                                    highlight(std::str::from_utf8(&s).unwrap());
+                                },
+                            }
+                        },
+                        _ => {
+
+                        }
+                    }
+                },
+                _ => {
+
+                }
+            }
+        }
+    }
+}

--- a/implementations/rust/okta/src/lib.rs
+++ b/implementations/rust/okta/src/lib.rs
@@ -1,0 +1,79 @@
+#[macro_use]
+extern crate serde_big_array;
+
+big_array! { BigArray; }
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum Messages {
+    OktaLogin(usize),
+    OktaLoginUrl { preamble: String, url: String },
+    OktaGrantToken { token: String },
+    OktaAccessToken { token: String },
+    OktaRequest { token: String, msg: OckamMessages },
+    OktaResponse { msg: OckamMessages },
+    NonOktaRequest(OckamMessages),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum OckamMessages {
+    AccessDenied,
+    BecomeRequest { role: OckamRole },
+    BecomeResponse { result: bool, msg: String },
+    ListServicesRequest { limit: u32, offset: u32 },
+    ListServicesResponse { services: Vec<OckamService> },
+    GetEstablishmentBundlesRequest { services: Vec<u32> },
+    GetEstablishmentBundlesResponse { services: Vec<EstablishmentBundle> },
+    BeginDeviceEnrollment { nonce: [u8; 16] },
+    DeviceEnrollmentRequest { nonce: [u8; 16], blind_device_secret: [u8; 32], proof_of_secret: [u8; 32] },
+    DeviceEnrollmentResponse { schema: CredentialSchema, service: EstablishmentBundle, attributes: Vec<Vec<u8>>, attestation: Vec<u8> },
+    ServiceEnrollmentMessage1(Vec<u8>),
+    ServiceEnrollmentMessage2(Vec<u8>),
+    ServiceEnrollmentMessage3(Vec<u8>),
+    ServiceEnrollmentResponse(Vec<u8>),
+    GeneralMessage(Vec<u8>)
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum OckamRole {
+    Enroller {
+        public_key: [u8; 32],
+        #[serde(with = "BigArray")]
+        proof: [u8; 64],
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum KeyEstablishment {
+    Xx,
+    X3dh,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct OckamService {
+    pub id: u32,
+    pub key_establishment: Vec<KeyEstablishment>,
+    pub schemas: Vec<CredentialSchema>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct CredentialSchema {
+    pub id: String,
+    pub attributes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct EstablishmentBundle {
+    pub service_id: u32,
+    pub address: String,
+    pub key_establishment: KeyEstablishment,
+    pub key_establishment_data: Vec<u8>
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Attestation {
+    pub attributes: Vec<Vec<u8>>,
+    pub signature: Vec<u8>
+}

--- a/implementations/rust/okta/src/objects.rs
+++ b/implementations/rust/okta/src/objects.rs
@@ -134,7 +134,6 @@ api_obj_impl!(GroupLogo,
               "type" => xtype: String
 );
 
-
 api_obj_impl!(Link,
               "href" => href: String,
               "method" => method: Option<String>,

--- a/implementations/rust/okta/truck/src/main.rs
+++ b/implementations/rust/okta/truck/src/main.rs
@@ -1,3 +1,262 @@
+#[macro_use]
+extern crate arrayref;
+
+use ockam::{
+    vault::*,
+    vault_software::*,
+    kex::*,
+    kex_x3dh::*,
+};
+use oktaplugin::*;
+use rand::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{self, Write},
+    net::{TcpListener, TcpStream},
+    sync::{Arc, Mutex}
+};
+use colored::Colorize;
+use oktaplugin::Messages::NonOktaRequest;
+
+
+#[cfg(target_os = "windows")]
+fn pass(s: &str) {
+    println!("{}", s);
+}
+#[cfg(not(target_os = "windows"))]
+fn pass(s: &str) {
+    println!("{}", s.green());
+}
+
+#[cfg(target_os = "windows")]
+fn fail(s: &str) {
+    println!("{}", s);
+}
+#[cfg(not(target_os = "windows"))]
+fn fail(s: &str) {
+    println!("{}", s.red());
+}
+
+#[derive(Debug, Clone)]
+struct Service {
+    schema: CredentialSchema,
+    bundle: EstablishmentBundle,
+}
+
 fn main() {
-    println!("Hello, world!");
+    let mut id = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut id);
+
+    let mut service_info = None;
+    let mut attestation_info = None;
+
+    let listener = TcpListener::bind("127.0.0.1:8081").unwrap();
+    let vault = Arc::new(Mutex::new(DefaultVault::default()));
+
+    let res = listener.accept();
+    if res.is_err() {
+        eprintln!("Unable to connect");
+        return;
+    }
+    let (mut stream, addr) = res.unwrap();
+    println!("Connection from {:?}", addr);
+    loop {
+        match serde_bare::from_reader::<&TcpStream, OckamMessages>(&stream) {
+            Err(e) => match e {
+                serde_bare::Error::Io(err) => match err.kind() {
+                    std::io::ErrorKind::UnexpectedEof => {
+                        eprintln!("Client closed connection");
+                        return;
+                    },
+                    _ => {
+                        eprintln!("Unknown message type");
+                        stream.shutdown(std::net::Shutdown::Both).unwrap();
+                        return;
+                    }
+                },
+                _ => {
+                    eprintln!("Unknown message type");
+                    stream.shutdown(std::net::Shutdown::Both).unwrap();
+                    return;
+                }
+            },
+            Ok(m) => {
+                match m {
+                    OckamMessages::BeginDeviceEnrollment { nonce } => {
+                        //Just demo signing, nonce is the credential id
+                        let v = vault.lock().unwrap();
+                        let device_id = v.sha256(&id).unwrap();
+                        let msg = OckamMessages::DeviceEnrollmentRequest {
+                            nonce,
+                            blind_device_secret: device_id,
+                            proof_of_secret: [0u8; 32]
+                        };
+                        serde_bare::to_writer(&mut stream, &msg).unwrap();
+                        stream.flush().unwrap();
+                    },
+                    OckamMessages::DeviceEnrollmentResponse {schema, service, attributes, attestation} => {
+                        service_info = Some(Service {
+                            schema,
+                            bundle: service
+                        });
+                        attestation_info = Some(Attestation {
+                            attributes,
+                            signature: attestation
+                        });
+                        println!("Received enrollment bundle");
+                        println!("Closing connection to enroller");
+                        let _  = stream.shutdown(std::net::Shutdown::Both);
+                        break;
+                    }
+                    mm => {
+                        eprintln!("Unhandled message type: {:?}", mm);
+                    }
+                }
+            }
+        }
+    }
+
+    let service = service_info.unwrap();
+
+    print!("Connecting to service...");
+    io::stdout().flush().unwrap();
+    let res = TcpStream::connect(&service.bundle.address);
+    if res.is_err() {
+        fail("fail");
+        return;
+    }
+    pass("success");
+    let mut stream = res.unwrap();
+    let x3dh_kex = X3dhNewKeyExchanger::new(vault.clone(), vault.clone());
+    let mut initiator = Box::new(x3dh_kex.initiator(None));
+    let prekey = initiator.process(b"").unwrap();
+
+    print!("Sending service enrollment message 1...");
+    io::stdout().flush().unwrap();
+    let enroll_msg = Messages::NonOktaRequest(OckamMessages::ServiceEnrollmentMessage1(prekey));
+    serde_bare::to_writer(&mut stream, &enroll_msg).unwrap();
+    stream.flush().unwrap();
+
+    let res = serde_bare::from_reader::<&TcpStream, OckamMessages>(&stream);
+    if res.is_err() {
+        fail("fail");
+        fail(&format!("{:?}", res.unwrap_err()));
+        stream.shutdown(std::net::Shutdown::Both).unwrap();
+        return;
+    }
+    pass("success");
+
+    let ciphertext_and_tag = initiator.process(service.bundle.key_establishment_data.as_slice()).unwrap();
+    let enroll_msg = Messages::NonOktaRequest(OckamMessages::ServiceEnrollmentMessage2(ciphertext_and_tag));
+
+    print!("Sending service enrollment message 2...");
+    io::stdout().flush().unwrap();
+    serde_bare::to_writer(&mut stream, &enroll_msg).unwrap();
+
+    let res = serde_bare::from_reader::<&TcpStream, OckamMessages>(&stream);
+    if res.is_err() {
+        fail("fail");
+        fail(&format!("{:?}", res.unwrap_err()));
+        stream.shutdown(std::net::Shutdown::Both).unwrap();
+        return;
+    }
+    let completed_key_exchange = initiator.finalize().unwrap();
+    let mut vv = vault.lock().unwrap();
+    match res.unwrap() {
+        OckamMessages::ServiceEnrollmentResponse(data) => {
+            match vv.aead_aes_gcm_decrypt(&completed_key_exchange.decrypt_key, data.as_slice(), &[0u8; 12], &completed_key_exchange.h) {
+                Err(e) => {
+                    fail("fail");
+                    println!("Unable to decrypt message: {}", e.to_string());
+                    stream.shutdown(std::net::Shutdown::Both).unwrap();
+                    return;
+                },
+                Ok(plaintext) => {
+                    if plaintext.len() == 1 && plaintext[0] == 1u8 {
+                        pass("success");
+                    } else {
+                        fail("fail");
+                        println!("Unable to enroll");
+                        stream.shutdown(std::net::Shutdown::Both).unwrap();
+                        return;
+                    }
+                }
+            }
+        },
+        _ => {
+            fail("fail");
+            println!("Unexpected response");
+            stream.shutdown(std::net::Shutdown::Both).unwrap();
+            return;
+        }
+    }
+
+    print!("Sending credential proof to match schema {:?}...", service.schema);
+    io::stdout().flush().unwrap();
+    let mut attestation = attestation_info.unwrap();
+    attestation.attributes.insert(0, id.to_vec());
+    let plaintext = serde_bare::to_vec(&attestation).unwrap();
+    let mut nonce = [0u8; 12];
+    nonce[11] = 1;
+    let ciphertext_and_tag = vv.aead_aes_gcm_encrypt(
+        &completed_key_exchange.encrypt_key, plaintext.as_slice(), &nonce, &completed_key_exchange.h).unwrap();
+    serde_bare::to_writer(&mut stream, &Messages::NonOktaRequest(OckamMessages::ServiceEnrollmentMessage3(ciphertext_and_tag))).unwrap();
+    stream.flush().unwrap();
+
+    let res = serde_bare::from_reader::<&TcpStream, OckamMessages>(&stream);
+
+    if res.is_err() {
+        fail("fail");
+        eprintln!("{:?}", res.unwrap_err());
+        stream.shutdown(std::net::Shutdown::Both).unwrap();
+        return;
+    }
+
+    nonce[11] = 2;
+    match res.unwrap() {
+        OckamMessages::ServiceEnrollmentResponse(data) => {
+            match vv.aead_aes_gcm_decrypt(&completed_key_exchange.decrypt_key, data.as_slice(), &nonce, &completed_key_exchange.h) {
+                Err(e) => {
+                    fail("fail");
+                    println!("Unable to decrypt message: {}", e.to_string());
+                    stream.shutdown(std::net::Shutdown::Both).unwrap();
+                    return;
+                },
+                Ok(plaintext) => {
+                    if plaintext.len() == 1 && plaintext[0] == 1u8 {
+                        pass("success");
+                    } else {
+                        fail("fail");
+                        println!("Proof validation failed");
+                        stream.shutdown(std::net::Shutdown::Both).unwrap();
+                        return;
+                    }
+                }
+            }
+        },
+        _ => {
+            fail("fail");
+            println!("Unexpected response");
+            stream.shutdown(std::net::Shutdown::Both).unwrap();
+            return;
+        }
+    }
+
+    println!("Successfully enrolled to service. Type data to send to the service");
+    let mut buffer = String::new();
+    let mut nonce = 2u16;
+    loop {
+        io::stdin().read_line(&mut buffer).unwrap();
+        let text = buffer.trim();
+        if !text.is_empty() {
+            nonce = nonce.wrapping_add(1);
+            let mut n = [0u8; 12];
+            n[10..].copy_from_slice(&nonce.to_be_bytes());
+
+            let ctt = vv.aead_aes_gcm_encrypt(&completed_key_exchange.encrypt_key, text.as_bytes(), &n, &completed_key_exchange.h).unwrap();
+            serde_bare::to_writer(&mut stream, &Messages::NonOktaRequest(OckamMessages::GeneralMessage(ctt))).unwrap();
+            stream.flush().unwrap();
+            buffer = String::new();
+        }
+    }
 }


### PR DESCRIPTION
Updates the okta example to use two different processes: the service and the enroller.