### PR TITLE
feat(rust): address structure and traits

### DIFF
--- a/implementations/rust/ockam/src/address.rs
+++ b/implementations/rust/ockam/src/address.rs
@@ -1,0 +1,86 @@
+use alloc::fmt;
+use alloc::string::{String, ToString};
+use core::fmt::{Display, Formatter};
+use core::hash::{Hash, Hasher};
+
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub struct Address {
+    inner: String,
+}
+
+impl Address {
+    pub fn new<T: ToString>(s: T) -> Address {
+        Address {
+            inner: s.to_string(),
+        }
+    }
+}
+
+impl Display for Address {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl From<String> for Address {
+    fn from(s: String) -> Self {
+        Address::new(s.clone())
+    }
+}
+
+impl From<&str> for Address {
+    fn from(s: &str) -> Self {
+        Address::from(String::from(s))
+    }
+}
+
+impl Into<String> for Address {
+    fn into(self) -> String {
+        self.inner.clone()
+    }
+}
+
+impl Hash for Address {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash(state)
+    }
+}
+
+pub trait Addressable {
+    fn address(&self) -> Address;
+}
+
+#[cfg(test)]
+mod test {
+    use crate::address::{Address, Addressable};
+    use alloc::string::{String, ToString};
+
+    #[test]
+    pub fn test_addressable() {
+        struct Thing {
+            address: String,
+        }
+        impl Addressable for Thing {
+            fn address(&self) -> Address {
+                return self.address.clone().into();
+            }
+        }
+
+        let test = "test".to_string();
+
+        let thing = Thing {
+            address: test.clone(),
+        };
+        assert_eq!(Address::from("test"), thing.address());
+
+        let addr: String = thing.address().into();
+        assert_eq!(test, addr);
+
+        let mut map = hashbrown::HashMap::new();
+        map.insert(thing.address(), true);
+
+        assert!(map.get(&thing.address()).unwrap());
+
+        assert_eq!("test", format!("{}", thing.address()))
+    }
+}

--- a/implementations/rust/ockam/src/lib.rs
+++ b/implementations/rust/ockam/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+
+#[macro_use]
 extern crate alloc;
 
 pub use ockam_macros::*;
@@ -10,4 +12,5 @@ pub enum Error {
 
 pub type Result<T> = core::result::Result<T, Error>;
 
+pub mod address;
 pub mod worker;


### PR DESCRIPTION
Implements a basic, typeless Address with String internal storage. Several convenience traits are implemented.

1. Address internal storage is a String, for convenience and easy cloning.
2. Implements various traits for conversion to and from Address and String
3. Implements Hash so that it can be used in hash tables.

We should decide whether or not we want to introduce the notion of `Address Type`.