### PR TITLE
feat(rust): address type enum and address member

### DIFF
--- a/implementations/rust/ockam/Cargo.toml
+++ b/implementations/rust/ockam/Cargo.toml
@@ -13,4 +13,4 @@ executor_async = ["ockam_macros/executor_async"]
 
 [dependencies]
 ockam_macros = {path = "../ockam_macros", version = "*"}
-hashbrown = "*"
+hashbrown = "0.9.1"

--- a/implementations/rust/ockam/src/address.rs
+++ b/implementations/rust/ockam/src/address.rs
@@ -4,15 +4,31 @@ use core::fmt::{Display, Formatter};
 use core::hash::{Hash, Hasher};
 
 #[derive(Eq, PartialEq, Clone, Debug)]
+pub enum AddressType {
+    Worker = 0,
+    Undefined = 255,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Address {
+    address_type: AddressType,
     inner: String,
 }
 
 impl Address {
     pub fn new<T: ToString>(s: T) -> Address {
+        Address::for_type(AddressType::Undefined, s)
+    }
+
+    pub fn for_type<T: ToString>(address_type: AddressType, s: T) -> Address {
         Address {
+            address_type,
             inner: s.to_string(),
         }
+    }
+
+    pub fn for_worker<T: ToString>(s: T) -> Address {
+        Address::for_type(AddressType::Worker, s)
     }
 }
 
@@ -58,20 +74,21 @@ mod test {
     #[test]
     pub fn test_addressable() {
         struct Thing {
-            address: String,
+            address: Address,
         }
+
         impl Addressable for Thing {
             fn address(&self) -> Address {
-                return self.address.clone().into();
+                return self.address.clone();
             }
         }
 
         let test = "test".to_string();
 
         let thing = Thing {
-            address: test.clone(),
+            address: Address::for_worker(test.clone()),
         };
-        assert_eq!(Address::from("test"), thing.address());
+        assert_eq!(Address::for_worker("test"), thing.address());
 
         let addr: String = thing.address().into();
         assert_eq!(test, addr);

--- a/implementations/rust/ockam/src/address.rs
+++ b/implementations/rust/ockam/src/address.rs
@@ -3,11 +3,7 @@ use alloc::string::{String, ToString};
 use core::fmt::{Display, Formatter};
 use core::hash::{Hash, Hasher};
 
-#[derive(Eq, PartialEq, Clone, Debug)]
-pub enum AddressType {
-    Worker = 0,
-    Undefined = 255,
-}
+pub type AddressType = u8;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Address {
@@ -17,7 +13,7 @@ pub struct Address {
 
 impl Address {
     pub fn new<T: ToString>(s: T) -> Address {
-        Address::for_type(AddressType::Undefined, s)
+        Address::for_type(0, s)
     }
 
     pub fn for_type<T: ToString>(address_type: AddressType, s: T) -> Address {
@@ -25,10 +21,6 @@ impl Address {
             address_type,
             inner: s.to_string(),
         }
-    }
-
-    pub fn for_worker<T: ToString>(s: T) -> Address {
-        Address::for_type(AddressType::Worker, s)
     }
 }
 
@@ -86,9 +78,9 @@ mod test {
         let test = "test".to_string();
 
         let thing = Thing {
-            address: Address::for_worker(test.clone()),
+            address: Address::for_type(1, test.clone()),
         };
-        assert_eq!(Address::for_worker("test"), thing.address());
+        assert_eq!(Address::for_type(1, "test"), thing.address());
 
         let addr: String = thing.address().into();
         assert_eq!(test, addr);


### PR DESCRIPTION
This provides a minimal AddressType enum definition: Worker and Undefined. I held off including the transport specific address types in case we discover they should be modeled differently.