### PR TITLE
feat(rust): additional worker examples

### DIFF
--- a/implementations/rust/examples/examples/worker_builder.rs
+++ b/implementations/rust/examples/examples/worker_builder.rs
@@ -1,0 +1,26 @@
+use ockam::message::Message;
+use ockam::node::WorkerContext;
+use ockam::worker::Worker;
+
+use ockam::Result;
+
+struct BuiltWorker {}
+
+impl Worker<Message> for BuiltWorker {
+    fn starting(&mut self, context: &mut WorkerContext) -> Result<bool> {
+        println!("Started on address {}", context.address);
+        Ok(true)
+    }
+}
+
+#[ockam::node]
+pub async fn main() {
+    let address = ockam::worker::with(BuiltWorker {})
+        .address("worker123")
+        .start();
+
+    match address {
+        Some(a) => println!("Node running at address {}", a),
+        None => panic!("Failed to start"),
+    }
+}

--- a/implementations/rust/examples/examples/worker_from_closure.rs
+++ b/implementations/rust/examples/examples/worker_from_closure.rs
@@ -1,0 +1,15 @@
+#[ockam::node]
+pub async fn main() {
+    if let Some(address) = ockam::worker::with_closure(move |message, context| {
+        println!("Address: {}\tMessage: {:#?}", context.address(), message)
+    })
+    .start()
+    {
+        ockam::node::send(&address, "hello".into());
+        ockam::node::worker_at(&address, |maybe_worker| {
+            if let Some(worker) = maybe_worker {
+                println!("Worker at {}", worker.address())
+            }
+        })
+    }
+}

--- a/implementations/rust/examples/examples/worker_mailbox.rs
+++ b/implementations/rust/examples/examples/worker_mailbox.rs
@@ -1,0 +1,20 @@
+use ockam::address::Address;
+use ockam::message::Message;
+use ockam::node::WorkerContext;
+
+#[ockam::node]
+pub async fn main() {
+    let message_queue = ockam::message::new_message_queue(Address::from("worker_inbox"));
+
+    let handler = |message: &Message, context: &mut WorkerContext| {
+        println!("Address: {}, Message: {:#?}", context.address, message);
+    };
+
+    if let Some(address) = ockam::worker::with_closure(handler)
+        .mailbox(message_queue)
+        .address("external")
+        .start()
+    {
+        ockam::node::send(&address, "hello".into())
+    }
+}

--- a/implementations/rust/examples/examples/worker_send.rs
+++ b/implementations/rust/examples/examples/worker_send.rs
@@ -1,0 +1,25 @@
+use ockam::message::Message;
+use ockam::node::WorkerContext;
+use ockam::worker::Worker;
+use ockam::Result;
+
+struct PrintWorker {}
+
+impl Worker<Message> for PrintWorker {
+    fn handle(&self, message: Message, _context: &mut WorkerContext) -> Result<bool> {
+        println!("{:#?}", message);
+        Ok(true)
+    }
+}
+
+#[ockam::node]
+async fn main() {
+    if let Some(address) = ockam::worker::with(PrintWorker {})
+        .address("printer")
+        .start()
+    {
+        println!("Address: {}", address);
+
+        ockam::node::send(&address, "hello".into());
+    }
+}


### PR DESCRIPTION
Includes more Worker examples:

1. WorkerBuilder
2. Closure based workers
3. External mailbox
4. Sending a message to a Worker