### PR TITLE
prototype of profile verification policies and purpose

### DIFF
--- a/implementations/rust/ockam/ockam/src/entity/profile.rs
+++ b/implementations/rust/ockam/ockam/src/entity/profile.rs
@@ -4,10 +4,14 @@ pub use identifier::*;
 mod change;
 pub use change::*;
 
+mod verification;
+pub use verification::*;
+
 #[derive(Clone, Debug)]
 pub struct Profile {
     pub identifier: ProfileIdentifier,
     pub change_history: ProfileChangeHistory,
+    pub verification_policies: Vec<ProfileVerificationPolicy>,
 }
 
 impl Profile {
@@ -15,6 +19,7 @@ impl Profile {
         Profile {
             identifier: ProfileIdentifier::new(),
             change_history: ProfileChangeHistory::new(),
+            verification_policies: vec![],
         }
     }
 

--- a/implementations/rust/ockam/ockam/src/entity/profile/verification.rs
+++ b/implementations/rust/ockam/ockam/src/entity/profile/verification.rs
@@ -1,0 +1,27 @@
+#[derive(Clone, Debug)]
+pub struct Ed25519ProfileVerificationMethod {
+    public_key: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EcdsaP256ProfileVerificationMethod {
+    public_key: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ProfileVerificationMethod {
+    Ed25519(Ed25519ProfileVerificationMethod),
+    EcdsaP256(EcdsaP256ProfileVerificationMethod),
+}
+
+#[derive(Clone, Debug)]
+pub enum ProfileVerificationPurpose {
+    // To present a ProfileChangeProof
+    ProfileUpdate,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProfileVerificationPolicy {
+    verification_method: ProfileVerificationMethod,
+    can_be_used_for: Vec<ProfileVerificationPurpose>,
+}


### PR DESCRIPTION
This starts with the key signature verification method and tries to structure it as a collection of verification policies.
Along the lines of https://w3c.github.io/did-spec-registries/#ed25519verificationkey2018