### PR TITLE
feature(rust): use async/await for worker creation

### DIFF
--- a/implementations/rust/examples/workers/Cargo.lock
+++ b/implementations/rust/examples/workers/Cargo.lock
@@ -7,11 +7,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "examples"
 version = "0.1.0"
 dependencies = [
  "executor",
  "ockam",
+ "ockam_node_std",
 ]
 
 [[package]]
@@ -80,6 +87,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_node_std"
+version = "0.0.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +132,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tokio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/implementations/rust/examples/workers/Cargo.toml
+++ b/implementations/rust/examples/workers/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 ockam = {path = "../../ockam/ockam", version = "*"}
+ockam_node_std = {path = "../../ockam/ockam_node_std", version = "*"}
 executor = {version = "*"}

--- a/implementations/rust/examples/workers/examples/worker.rs
+++ b/implementations/rust/examples/workers/examples/worker.rs
@@ -1,34 +1,20 @@
-use ockam::address::Addressable;
 use ockam::node::Node;
-use ockam::worker::{Worker, WorkerContext};
-use ockam::Result;
+use ockam::worker::Worker;
 
 struct MyWorker {}
 
 struct Data {}
 
-impl Worker<Data> for MyWorker {
-    fn starting(&self, context: &WorkerContext<Data>) -> Result<bool> {
-        println!("Started on address {}", context.address());
-        Ok(true)
-    }
-
-    fn stopping(&self, _context: &WorkerContext<Data>) -> Result<bool> {
-        println!("Stopping!");
-        Ok(true)
-    }
-}
+impl Worker<Data> for MyWorker {}
 
 #[ockam::node]
 pub async fn main() {
     let node = Node::new();
 
-    if let Some(address) = ockam::worker::with(node.clone(), MyWorker {}).start() {
-        println!("Worker started at {:?}", address);
+    let mut worker = ockam::worker::with(node.clone(), MyWorker {});
+    let starting = worker.start();
 
-        let n = node.borrow();
-        n.stop(&address);
-    } else {
-        panic!("Couldn't start Worker");
+    if let Some(address) = starting.await {
+        println!("Started Worker at address {}", address)
     }
 }

--- a/implementations/rust/examples/workers/examples/worker_builder.rs
+++ b/implementations/rust/examples/workers/examples/worker_builder.rs
@@ -1,29 +1,20 @@
 use ockam::node::Node;
-use ockam::worker::{Worker, WorkerContext};
-
-use ockam::address::Addressable;
-use ockam::Result;
+use ockam::worker::Worker;
 
 struct BuiltWorker {}
 
 struct Data {}
 
-impl Worker<Data> for BuiltWorker {
-    fn starting(&self, context: &WorkerContext<Data>) -> Result<bool> {
-        println!("Started on address {}", context.address());
-        Ok(true)
-    }
-}
+impl Worker<Data> for BuiltWorker {}
 
 #[ockam::node]
 pub async fn main() {
     let node_handle = Node::new();
 
-    let address = ockam::worker::with(node_handle, BuiltWorker {})
-        .address("worker123")
-        .start();
+    let mut worker = ockam::worker::with(node_handle, BuiltWorker {});
+    let address = worker.address("worker123").start();
 
-    match address {
+    match address.await {
         Some(a) => println!("Node running at address {}", a),
         None => panic!("Failed to start"),
     }

--- a/implementations/rust/examples/workers/examples/worker_send.rs
+++ b/implementations/rust/examples/workers/examples/worker_send.rs
@@ -19,12 +19,13 @@ impl Worker<Data> for PrintWorker {
 #[ockam::node]
 async fn main() {
     let node = Node::new();
-    if let Some(address) = ockam::worker::with(node.clone(), PrintWorker {})
-        .address("printer")
-        .start()
-    {
-        println!("Address: {}", address);
 
-        node.borrow().send(&address, Data { val: 123 })
+    let mut worker = ockam::worker::with(node.clone(), PrintWorker {});
+    let starting = worker.address("printer").start();
+
+    if let Some(address) = starting.await {
+        if let Ok(n) = node.lock() {
+            n.send(&address, Data { val: 123 });
+        }
     }
 }

--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -4,136 +4,36 @@ pub use ockam_node_no_std::block_on;
 #[cfg(feature = "ockam_node_std")]
 pub use ockam_node_std::block_on;
 
-use crate::address::{Address, Addressable};
-use crate::worker::{Worker, WorkerContext, WorkerState};
-use alloc::rc::Rc;
-use core::cell::RefCell;
+use crate::address::Address;
+use crate::worker::{Registry, RegistryHandle, Worker, WorkerRegistry};
 
-use hashbrown::HashMap;
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
 struct Message {}
 
 #[derive(Clone)]
-pub struct WorkerRegistry<T> {
-    workers: HashMap<Address, WorkerContext<T>>,
-}
-
-pub type RegistryHandle<T> = Rc<RefCell<WorkerRegistry<T>>>;
-
-pub trait Registry<T> {
-    fn register(&mut self, element: T);
-
-    fn get(&mut self, key: &Address) -> Option<&mut T>;
-}
-
-impl<T> WorkerRegistry<T> {
-    fn new() -> RegistryHandle<T> {
-        Rc::new(RefCell::new(WorkerRegistry {
-            workers: HashMap::new(),
-        }))
-    }
-}
-
-impl<T> Registry<WorkerContext<T>> for WorkerRegistry<T> {
-    fn register(&mut self, worker: WorkerContext<T>) {
-        let address = worker.address();
-        self.workers.insert(address, worker);
-    }
-
-    fn get(&mut self, key: &Address) -> Option<&mut WorkerContext<T>> {
-        if let Some(worker) = self.workers.get_mut(key) {
-            Some(worker)
-        } else {
-            None
-        }
-    }
-}
-
 pub struct Node<T> {
     pub workers: RegistryHandle<T>,
 }
 
-pub type NodeHandle<T> = Rc<RefCell<Node<T>>>;
+pub type NodeHandle<T> = Arc<Mutex<Node<T>>>;
 
 impl<T> Node<T> {
     pub fn new() -> NodeHandle<T> {
-        Rc::new(RefCell::new(Node {
+        Arc::new(Mutex::new(Node {
             workers: WorkerRegistry::new(),
         }))
     }
 
-    pub fn start(&self, address: &Address) -> WorkerState {
-        {
-            let mut reg = self.workers.borrow_mut();
-            if let Some(worker) = reg.get(address) {
-                match worker.starting(worker) {
+    pub fn send(&self, address: &Address, _data: T) {
+        if let Ok(mut workers) = self.workers.lock() {
+            if let Some(worker) = workers.get(address) {
+                match worker.handle(_data, worker) {
                     Ok(x) => x,
-                    Err(_) => panic!(),
+                    Err(_) => unimplemented!(),
                 };
             }
         }
-
-        WorkerState::Started
-    }
-
-    pub fn stop(&self, address: &Address) -> WorkerState {
-        let mut reg = self.workers.borrow_mut();
-        if let Some(worker) = reg.get(address) {
-            match worker.stopping(worker) {
-                Ok(x) => x,
-                Err(_) => unimplemented!(),
-            };
-        }
-        WorkerState::Started
-    }
-
-    pub fn send(&self, address: &Address, _data: T) {
-        let mut reg = self.workers.borrow_mut();
-        if let Some(worker) = reg.get(address) {
-            match worker.handle(_data, worker) {
-                Ok(x) => x,
-                Err(_) => unimplemented!(),
-            };
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::address::Addressable;
-    use crate::node::{Node, Registry};
-    use crate::worker::{Worker, WorkerContext};
-
-    struct Thing {}
-
-    struct ThingWorker {}
-
-    impl Worker<Thing> for ThingWorker {
-        fn starting(&self, _worker: &WorkerContext<Thing>) -> crate::Result<bool> {
-            Ok(true)
-        }
-
-        fn stopping(&self, _worker: &WorkerContext<Thing>) -> crate::Result<bool> {
-            Ok(true)
-        }
-    }
-
-    #[test]
-    fn test_node() {
-        let node_handle = Node::<Thing>::new();
-
-        let node_clone = node_handle.clone();
-        let node = node_clone.borrow_mut();
-
-        let worker = crate::worker::with(node_handle, ThingWorker {})
-            .build()
-            .unwrap();
-
-        let address = worker.address().clone();
-        node.workers.borrow_mut().register(worker);
-
-        node.start(&address);
-        node.stop(&address);
     }
 }


### PR DESCRIPTION
1. Remove started and stopped handler callbacks
2. Made `WorkerBuilder::start` async
3. Deleted closure related code.
4. Deleted old tests: Rust unit tests can't use async. We will need to rewrite tests using `tokio_test`.
5. All tests now use async