### PR TITLE
Don't Merge refactor(rust): example of discrete worker lifecycle traits

### DIFF
--- a/implementations/rust/examples/workers/Cargo.lock
+++ b/implementations/rust/examples/workers/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,9 +73,15 @@ name = "ockam"
 version = "0.0.0"
 dependencies = [
  "hashbrown",
+ "hex",
+ "ockam_error",
  "ockam_node_attribute",
  "ockam_node_no_std",
 ]
+
+[[package]]
+name = "ockam_error"
+version = "0.0.0"
 
 [[package]]
 name = "ockam_node_attribute"

--- a/implementations/rust/examples/workers/examples/worker.rs
+++ b/implementations/rust/examples/workers/examples/worker.rs
@@ -1,9 +1,13 @@
 use ockam::node::Node;
-use ockam::worker::Worker;
+use ockam::worker::{Handler, Starting, Stopping, Worker};
 
 struct MyWorker {}
 
 struct Data {}
+
+impl Starting<Data> for MyWorker {}
+impl Stopping<Data> for MyWorker {}
+impl Handler<Data> for MyWorker {}
 
 impl Worker<Data> for MyWorker {}
 

--- a/implementations/rust/examples/workers/examples/worker_builder.rs
+++ b/implementations/rust/examples/workers/examples/worker_builder.rs
@@ -1,9 +1,13 @@
 use ockam::node::Node;
-use ockam::worker::Worker;
+use ockam::worker::{Handler, Starting, Stopping, Worker};
 
 struct BuiltWorker {}
 
 struct Data {}
+
+impl Starting<Data> for BuiltWorker {}
+impl Stopping<Data> for BuiltWorker {}
+impl Handler<Data> for BuiltWorker {}
 
 impl Worker<Data> for BuiltWorker {}
 

--- a/implementations/rust/examples/workers/examples/worker_send.rs
+++ b/implementations/rust/examples/workers/examples/worker_send.rs
@@ -1,5 +1,5 @@
 use ockam::node::Node;
-use ockam::worker::{Worker, WorkerContext};
+use ockam::worker::{Handler, Starting, Stopping, Worker, WorkerContext};
 use ockam::OckamResult;
 
 struct PrintWorker {}
@@ -9,12 +9,27 @@ struct Data {
     val: usize,
 }
 
-impl Worker<Data> for PrintWorker {
+// Not called by anything, just example.
+impl Starting<Data> for PrintWorker {
+    fn starting(&self, _worker: &WorkerContext<Data>) -> OckamResult<bool> {
+        unimplemented!()
+    }
+}
+
+impl Stopping<Data> for PrintWorker {
+    fn stopping(&self, _worker: &WorkerContext<Data>) -> OckamResult<bool> {
+        unimplemented!()
+    }
+}
+
+impl Handler<Data> for PrintWorker {
     fn handle(&self, data: Data, _context: &WorkerContext<Data>) -> OckamResult<bool> {
         println!("{:#?}", data);
         Ok(true)
     }
 }
+
+impl Worker<Data> for PrintWorker {}
 
 #[ockam::node]
 async fn main() {

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -83,11 +83,16 @@ version = "0.0.0"
 dependencies = [
  "hashbrown",
  "hex",
+ "ockam_error",
  "ockam_node_attribute",
  "ockam_node_no_std",
  "ockam_node_std",
  "trybuild",
 ]
+
+[[package]]
+name = "ockam_error"
+version = "0.0.0"
 
 [[package]]
 name = "ockam_node_attribute"

--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -5,7 +5,7 @@ pub use ockam_node_no_std::block_on;
 pub use ockam_node_std::block_on;
 
 use crate::address::Address;
-use crate::worker::{Registry, RegistryHandle, Worker, WorkerRegistry};
+use crate::worker::{Handler, Registry, RegistryHandle, WorkerRegistry};
 
 use std::sync::{Arc, Mutex};
 

--- a/implementations/rust/ockam/ockam/src/worker.rs
+++ b/implementations/rust/ockam/ockam/src/worker.rs
@@ -12,12 +12,27 @@ pub enum WorkerState {
     Failed,
 }
 
-/// Worker callbacks.
-pub trait Worker<T> {
-    fn handle(&self, _message: T, _worker: &WorkerContext<T>) -> OckamResult<bool> {
-        unimplemented!()
+// Starting and stopping callbacks.
+pub trait Starting<T> {
+    fn starting(&self, _worker: &WorkerContext<T>) -> OckamResult<bool> {
+        Ok(true)
     }
 }
+
+pub trait Stopping<T> {
+    fn stopping(&self, _worker: &WorkerContext<T>) -> OckamResult<bool> {
+        Ok(true)
+    }
+}
+
+/// Data handler callback.
+pub trait Handler<T> {
+    fn handle(&self, _message: T, _worker: &WorkerContext<T>) -> OckamResult<bool> {
+        Ok(true)
+    }
+}
+
+pub trait Worker<T>: Starting<T> + Stopping<T> + Handler<T> {}
 
 pub type WorkerHandler<T> = Arc<Mutex<dyn Worker<T> + Send>>;
 
@@ -36,7 +51,11 @@ impl<T> Addressable for WorkerContext<T> {
     }
 }
 
-impl<T> Worker<T> for WorkerContext<T> {
+impl<T> Starting<T> for WorkerContext<T> {}
+
+impl<T> Stopping<T> for WorkerContext<T> {}
+
+impl<T> Handler<T> for WorkerContext<T> {
     fn handle(&self, message: T, context: &WorkerContext<T>) -> OckamResult<bool> {
         if let Ok(worker) = self.worker.lock() {
             worker.handle(message, context)


### PR DESCRIPTION
This is what it would look like if we brought Starting, Stopping and Handler traits out and made the Worker trait a super-type comprised of all of them.

In the other branch, these are collapsed into the Worker trait itself as we previously had done.