### PR TITLE
chore(rust): ockam_node crate v0.1.1

### DIFF
--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -8,4 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.1.0 - 2021-02-03
 ### Added
 
+- Added description to Cargo.toml.
+
+## v0.1.0 - 2021-02-03
+### Added
+
 - This document and other meta-information documents.

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -136,14 +136,14 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
 ]
 
 [[package]]
 name = "ockam_node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -4,7 +4,7 @@ description = "Ockam Node implementation crate"
 edition = "2018"
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 async-trait = "0.1.42"

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.1.0"
+ockam_node = "0.1.1"
 ```
 
 ## License


### PR DESCRIPTION
# ockam_node crate v0.1.1 

Adds a `description` to the Cargo.toml, required by crates.io.
