### PR TITLE
chore(rust): ockam_node crate v0.1.1

### DIFF
--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.1.1 - 2021-02-04
+### Added
+
+- Added description to Cargo.toml.
+
 ## v0.1.0 - 2021-02-03
 ### Added
 


### PR DESCRIPTION
Fixes typo in Changelog
