### PR TITLE
chore(rust): remove wildcard dep from node crate

### DIFF
--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -9,5 +9,5 @@ version = "0.1.1"
 [dependencies]
 async-trait = "0.1.42"
 hashbrown = "0.9.1"
-ockam_core = {path = "../ockam_core", version = "*"}
+ockam_core = {path = "../ockam_core", version = "0.2.0"}
 tokio = {version = "1.1.0", features = ["full"]}


### PR DESCRIPTION
Removing wildcard dependency which is disallowed on crates.io