### PR TITLE
Release ockam_node crate v0.1.2

### DIFF
--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -9,5 +9,5 @@ version = "0.1.1"
 [dependencies]
 async-trait = "0.1.42"
 hashbrown = "0.9.1"
-ockam_core = {path = "../ockam_core", version = "*"}
+ockam_core = {path = "../ockam_core", version = "0.2.0"}
 tokio = {version = "1.1.0", features = ["full"]}

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -4,7 +4,7 @@ description = "Ockam Node implementation crate"
 edition = "2018"
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 async-trait = "0.1.42"

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.1.1"
+ockam_node = "0.1.2"
 ```
 
 ## License


### PR DESCRIPTION
# ockam_node crate v0.1.2

Releases ockam_node crate with crates.io TOML fixes
