### PR TITLE
feat(rust): add facade for various std no-std modes

### DIFF
--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -23,5 +23,13 @@ default = ["std"]
 # Requires the Rust Standard Library.
 std = []
 
+# Requires the Rust alloc library
+alloc = []
+
+# No alloc and no standard library
+no_std = ["heapless"]
+
 [dependencies]
 async-trait = "0.1.42"
+hashbrown = "0.9"
+heapless = { version = "0.6", optional = true }

--- a/implementations/rust/ockam/ockam_core/src/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/address.rs
@@ -1,1 +1,3 @@
+use crate::lib::String;
+
 pub type Address = String;

--- a/implementations/rust/ockam/ockam_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_core/src/error.rs
@@ -1,7 +1,6 @@
 //! Error and Result types
 
-#[cfg(feature = "std")]
-use std::fmt::{Display, Formatter};
+use crate::lib::{fmt::Formatter, Display};
 
 /// The type of errors returned by Ockam functions.
 ///
@@ -30,12 +29,7 @@ pub struct Error {
 }
 
 /// The type returned by Ockam functions.
-#[cfg(feature = "std")]
-pub type Result<T> = std::result::Result<T, Error>;
-
-/// The type returned by Ockam functions.
-#[cfg(not(feature = "std"))]
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T> = crate::lib::Result<T, Error>;
 
 impl Error {
     /// Creates a new [`Error`].
@@ -64,19 +58,25 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Error {{ code: {}, domain: \"{}\" }}",
-            self.code, self.domain
-        )
+    fn fmt(&self, f: &mut Formatter<'_>) -> crate::lib::fmt::Result {
+        #[cfg(feature = "std")]
+        {
+            write!(
+                f,
+                "Error {{ code: {}, domain: \"{}\" }}",
+                self.code, self.domain
+            )
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            write!(f, "Error {{ code: {} }}", self.code)
+        }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl crate::lib::error::Error for Error {}
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -5,7 +5,7 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
-
+#![no_std]
 #![deny(
     // missing_docs,
     trivial_casts,
@@ -15,8 +15,15 @@
     unused_qualifications,
     warnings
 )]
-// #![no_std] if the std feature is disabled.
-#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "no_std", feature = "alloc"))]
+compile_error!(r#"Cannot compile both features "alloc" and "no_std""#);
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
 
 mod address;
 mod error;
@@ -25,3 +32,70 @@ mod worker;
 pub use address::*;
 pub use error::*;
 pub use worker::*;
+
+/// A facade around the various collections and primitives needed
+/// when using no alloc, alloc only, or std modes
+pub mod lib {
+    mod core {
+        #[cfg(not(feature = "std"))]
+        pub use core::*;
+        #[cfg(feature = "std")]
+        pub use std::*;
+    }
+
+    pub use self::core::cell::{Cell, RefCell};
+    pub use self::core::clone::{self, Clone};
+    pub use self::core::convert::{self, From, Into};
+    pub use self::core::default::{self, Default};
+    pub use self::core::fmt::{self, Debug, Display};
+    pub use self::core::marker::{self, PhantomData};
+    pub use self::core::num::Wrapping;
+    pub use self::core::ops::Range;
+    pub use self::core::option::{self, Option};
+    pub use self::core::result::{self, Result};
+    pub use self::core::{cmp, iter, mem, num, slice, str};
+    pub use self::core::{f32, f64};
+    pub use self::core::{i16, i32, i64, i8, isize};
+    pub use self::core::{u16, u32, u64, u8, usize};
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::borrow::{Cow, ToOwned};
+    #[cfg(feature = "std")]
+    pub use std::borrow::{Cow, ToOwned};
+
+    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
+    pub use heapless::consts::*;
+
+    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
+    use heapless::String as ByteString;
+    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
+    pub type String = ByteString<U128>;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::string::{String, ToString};
+    #[cfg(feature = "std")]
+    pub use std::string::{String, ToString};
+
+    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
+    use heapless::Vec as InternalVec;
+    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
+    pub type Vec<T> = InternalVec<T, U64>;
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::vec::Vec;
+    #[cfg(feature = "std")]
+    pub use std::vec::Vec;
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::boxed::Box;
+    #[cfg(feature = "std")]
+    pub use std::boxed::Box;
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+    #[cfg(feature = "std")]
+    pub use std::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+
+    #[cfg(feature = "std")]
+    pub use std::{error, net};
+
+    pub use hashbrown::{HashMap, HashSet};
+}


### PR DESCRIPTION
This allows all other crates to no longer have to worry about the various imports for the three different std no-std modes.

Crate consumers just need to add

`use ockam_core::lib::*;`

which figures out the correct structs and traits to import.