### PR TITLE
feat(rust): migrate to use ockam_core facade for structs

### DIFF
--- a/implementations/rust/ockam/ockam_credential/Cargo.lock
+++ b/implementations/rust/ockam/ockam_credential/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,16 @@ dependencies = [
  "rayon",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
 ]
 
 [[package]]
@@ -299,6 +315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heapless"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +458,10 @@ name = "ockam_core"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "bincode",
+ "hashbrown",
+ "heapless",
+ "serde",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_credential/Cargo.toml
+++ b/implementations/rust/ockam/ockam_credential/Cargo.toml
@@ -20,8 +20,8 @@ exclude = [
 [features]
 default = ["std"]
 std = ["ockam_core/std", "alloc", "bbs", "ff", "pairing-plus"]
-alloc = ["serde/alloc"]
-no_std = ["heapless"]
+alloc = ["ockam_core/alloc", "serde/alloc"]
+no_std = ["ockam_core/no_std"]
 
 [dependencies]
 bbs = { version = "0.4", optional = true }

--- a/implementations/rust/ockam/ockam_credential/src/credential.rs
+++ b/implementations/rust/ockam/ockam_credential/src/credential.rs
@@ -1,6 +1,6 @@
-use super::structs::*;
 use crate::{credential_attribute::CredentialAttribute, credential_schema::CredentialSchema};
 use bbs::prelude::*;
+use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 /// A credential offer is how an issuer informs a potential holder that
@@ -17,7 +17,7 @@ pub struct CredentialOffer {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Credential {
     /// The signed attributes in the credential
-    pub attributes: Buffer<CredentialAttribute>,
+    pub attributes: Vec<CredentialAttribute>,
     /// The cryptographic signature
     pub signature: Signature,
 }
@@ -26,7 +26,7 @@ pub struct Credential {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlindCredential {
     /// The signed attributes in the credential
-    pub attributes: Buffer<CredentialAttribute>,
+    pub attributes: Vec<CredentialAttribute>,
     /// The cryptographic signature
     pub signature: BlindSignature,
 }

--- a/implementations/rust/ockam/ockam_credential/src/credential_attribute.rs
+++ b/implementations/rust/ockam/ockam_credential/src/credential_attribute.rs
@@ -1,5 +1,5 @@
-use crate::structs::*;
 use crate::CredentialAttributeType;
+use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -17,7 +17,7 @@ pub enum CredentialAttribute {
     /// The attribute value is specified as empty
     Empty,
     /// The attribute is a UTF-8 String
-    String(ByteString),
+    String(String),
     /// The attribute is numeric
     Numeric(i64),
     /// The attribute is a sequence of bytes

--- a/implementations/rust/ockam/ockam_credential/src/credential_attribute_schema.rs
+++ b/implementations/rust/ockam/ockam_credential/src/credential_attribute_schema.rs
@@ -1,5 +1,5 @@
-use super::structs::*;
 use crate::{credential_attribute_type::CredentialAttributeType, serde::*};
+use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 /// An attribute describes a statement that the issuer of a credential is
@@ -11,14 +11,14 @@ pub struct CredentialAttributeSchema {
         serialize_with = "write_byte_string",
         deserialize_with = "read_byte_string"
     )]
-    pub label: ByteString,
+    pub label: String,
 
     /// A longer description of the meaning of the attribute.
     #[serde(
         serialize_with = "write_byte_string",
         deserialize_with = "read_byte_string"
     )]
-    pub description: ByteString,
+    pub description: String,
 
     /// The data type of the attribute value.
     pub attribute_type: CredentialAttributeType,

--- a/implementations/rust/ockam/ockam_credential/src/credential_schema.rs
+++ b/implementations/rust/ockam/ockam_credential/src/credential_schema.rs
@@ -1,5 +1,5 @@
-use super::structs::*;
 use crate::{credential_attribute_schema::CredentialAttributeSchema, serde::*};
+use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 /// A schema describes the data format of a credential.
@@ -10,21 +10,21 @@ pub struct CredentialSchema {
         serialize_with = "write_byte_string",
         deserialize_with = "read_byte_string"
     )]
-    pub id: ByteString,
+    pub id: String,
 
     /// A user friendly name for this schema
     #[serde(
         serialize_with = "write_byte_string",
         deserialize_with = "read_byte_string"
     )]
-    pub label: ByteString,
+    pub label: String,
 
     /// A longer description about this schema
     #[serde(
         serialize_with = "write_byte_string",
         deserialize_with = "read_byte_string"
     )]
-    pub description: ByteString,
+    pub description: String,
 
     /// A list of attributes that are contained in credentials that
     /// have this schema.
@@ -32,5 +32,5 @@ pub struct CredentialSchema {
         serialize_with = "write_attributes",
         deserialize_with = "read_attributes"
     )]
-    pub attributes: Buffer<CredentialAttributeSchema>,
+    pub attributes: Vec<CredentialAttributeSchema>,
 }

--- a/implementations/rust/ockam/ockam_credential/src/lib.rs
+++ b/implementations/rust/ockam/ockam_credential/src/lib.rs
@@ -27,28 +27,6 @@
     warnings
 )]
 
-#[cfg_attr(not(feature = "std"), no_std)]
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
-
-#[cfg(all(feature = "no_std", not(feature = "alloc")))]
-mod structs {
-    pub use core::fmt::{self, Debug, Display};
-    use heapless::{consts::*, String, Vec};
-    pub type Buffer<T> = Vec<T, U32>;
-    pub type ByteString = String<U32>;
-}
-
-#[cfg(feature = "alloc")]
-mod structs {
-    pub use alloc::fmt::{self, Debug, Display};
-    use alloc::{string::String, vec::Vec};
-    pub type Buffer<T> = Vec<T>;
-    pub type ByteString = String;
-}
-
 #[cfg(feature = "std")]
 mod credential;
 mod credential_attribute;
@@ -67,20 +45,19 @@ pub use credential_schema::CredentialSchema;
 
 #[cfg(test)]
 mod tests {
-    use crate::{CredentialAttributeSchema, CredentialAttributeType, Schema};
-    use std::string::String;
-    use std::vec;
+    use crate::{CredentialAttributeSchema, CredentialAttributeType, CredentialSchema};
+    use ockam_core::lib::*;
 
-    fn create_test_schema() -> Schema {
+    fn create_test_schema() -> CredentialSchema {
         let attribute = CredentialAttributeSchema {
             label: String::from("test_attr"),
             description: String::from("test attribute"),
             attribute_type: CredentialAttributeType::Utf8String,
         };
 
-        let attributes = vec![attribute];
+        let attributes = [attribute].to_vec();
 
-        Schema {
+        CredentialSchema {
             id: String::from("test_id"),
             label: String::from("test_label"),
             description: String::from("test_desc"),
@@ -104,7 +81,7 @@ mod tests {
             assert!(serialized.contains("test_attr"));
             assert!(serialized.contains("test attribute"));
 
-            if let Ok(mut rehydrated) = serde_json::from_str::<Schema>(&serialized) {
+            if let Ok(mut rehydrated) = serde_json::from_str::<CredentialSchema>(&serialized) {
                 assert_eq!(rehydrated.id, schema.id);
                 assert_eq!(rehydrated.label, schema.label);
                 assert_eq!(rehydrated.description, schema.description);

--- a/implementations/rust/ockam/ockam_credential/src/serde.rs
+++ b/implementations/rust/ockam/ockam_credential/src/serde.rs
@@ -1,4 +1,5 @@
-use super::{structs::*, CredentialAttributeSchema};
+use super::CredentialAttributeSchema;
+use ockam_core::lib::*;
 use serde::{
     de::{Error as DError, SeqAccess, Visitor},
     ser::SerializeSeq,
@@ -6,7 +7,7 @@ use serde::{
 };
 
 #[allow(clippy::ptr_arg)]
-pub fn write_attributes<S>(v: &Buffer<CredentialAttributeSchema>, s: S) -> Result<S::Ok, S::Error>
+pub fn write_attributes<S>(v: &Vec<CredentialAttributeSchema>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -19,27 +20,25 @@ where
     iter.end()
 }
 
-pub fn read_attributes<'de, D>(
-    deserializer: D,
-) -> Result<Buffer<CredentialAttributeSchema>, D::Error>
+pub fn read_attributes<'de, D>(deserializer: D) -> Result<Vec<CredentialAttributeSchema>, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct BufferAttributeVisitor;
 
     impl<'de> Visitor<'de> for BufferAttributeVisitor {
-        type Value = Buffer<CredentialAttributeSchema>;
+        type Value = Vec<CredentialAttributeSchema>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("expected array of attributes")
         }
 
-        fn visit_seq<A>(self, mut s: A) -> Result<Buffer<CredentialAttributeSchema>, A::Error>
+        fn visit_seq<A>(self, mut s: A) -> Result<Vec<CredentialAttributeSchema>, A::Error>
         where
             A: SeqAccess<'de>,
         {
             let _l = if let Some(l) = s.size_hint() { l } else { 0 };
-            let mut buf = Buffer::new();
+            let mut buf = Vec::new();
             while let Some(a) = s.next_element()? {
                 #[cfg(all(feature = "no_std", not(feature = "alloc")))]
                 {
@@ -58,31 +57,31 @@ where
 }
 
 #[allow(clippy::ptr_arg)]
-pub fn write_byte_string<S>(v: &ByteString, s: S) -> Result<S::Ok, S::Error>
+pub fn write_byte_string<S>(v: &String, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     s.serialize_str(v.as_str())
 }
 
-pub fn read_byte_string<'de, D>(deserializer: D) -> Result<ByteString, D::Error>
+pub fn read_byte_string<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct ByteStringVisitor;
 
     impl<'de> Visitor<'de> for ByteStringVisitor {
-        type Value = ByteString;
+        type Value = String;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("expected array of attributes")
         }
 
-        fn visit_str<E>(self, s: &str) -> Result<ByteString, E>
+        fn visit_str<E>(self, s: &str) -> Result<String, E>
         where
             E: DError,
         {
-            Ok(ByteString::from(s))
+            Ok(String::from(s))
         }
     }
 


### PR DESCRIPTION
This changes all instances where Vec and String are used to call upon the recently added facade in ockam_core.
