### PR TITLE
Working on resilient message delivery.

### DIFF
--- a/implementations/elixir/ockam/_ockam/lib/ockam/stream.ex
+++ b/implementations/elixir/ockam/_ockam/lib/ockam/stream.ex
@@ -1,0 +1,328 @@
+defmodule Ockam.Topics.Stream.Storage do
+  @type message() :: %{message: term(), index: integer()}
+  @type topic() :: atom()
+
+  @callback create_topic(topic()) :: {:ok, atom()} | {:error, term()}
+  @callback destroy_topic(topic()) :: :ok | {:error, term()}
+
+  @callback push_message(topic(), term()) :: :ok | {:error, term()}
+  @callback get_all_messages(topic()) :: {:ok, [message()]} | {:error, term()}
+  @callback queue_length(topic()) :: {:ok, integer()} | {:error, term()}
+  @callback get_messages(topic(), integer(), integer()) :: {:ok, [message()]} | {:error, term}
+  @callback cleanup(topic(), integer()) :: :ok | {:error, term}
+end
+
+defmodule Ockam.Topics.Stream.ConsumerStorage do
+  @type consumer_id() :: term()
+  @type topic() :: atom()
+  @type mode() :: :earliest | :latest
+
+  @callback subscribe(topic(), consumer_id(), mode()) :: {:ok, integer()} | {:error, term()}
+  @callback get_index(topic(), consumer_id()) :: {:ok, integer()} | {:error, term()}
+  @callback confirm(topic(), consumer_id(), integer()) :: {:ok, integer()} | {:error, term()}
+  @callback unsubscribe(topic(), consumer_id()) :: :ok | {:error, term()}
+end
+
+defmodule Ockam.Topics.Stream.Storage.Memory do
+  @behaviour Ockam.Topics.Stream.Storage
+  @behaviour Ockam.Topics.Stream.ConsumerStorage
+
+  def create_topic(topic_name) do
+    case find_topic(topic_name) do
+      {:ok, server} ->
+        {:error, {:already_started, server}}
+
+      _ ->
+        start_topic(topic_name)
+    end
+  end
+
+  def start_topic(_topic_name) do
+    ## TODO: supervised start
+    # Ockam.Topics.Stream.Storage.Memory.Server.start_link()
+  end
+
+  def destroy_topic(topic_name) do
+    with_topic(topic_name, fn server ->
+      GenServer.stop(server)
+    end)
+  end
+
+  def push_message(topic_name, message) do
+    with_topic(topic_name, fn server ->
+      GenServer.cast(server, {:push_message, message})
+    end)
+  end
+
+  def get_all_messages(topic_name) do
+    remote_rpc(topic_name, :do_get_all_messages, [topic_name])
+  end
+
+  def queue_length(topic_name) do
+    remote_rpc(topic_name, :do_get_queue_length, [topic_name])
+  end
+
+  def get_messages(topic_name, index, limit) do
+    remote_rpc(topic_name, :do_get_messages, [topic_name, index, limit])
+  end
+
+  def cleanup(topic_name, index) do
+    remote_rpc(topic_name, :do_cleanup, [topic_name, index])
+  end
+
+  def with_topic(topic_name, fun) do
+    case find_topic(topic_name) do
+      {:ok, server} -> fun.(server)
+      error -> error
+    end
+  end
+
+  def find_topic(topic_name) do
+    GenServer.whereis(Ockam.Topics.Stream.Storage.Memory.Server.via(topic_name))
+  end
+
+  def remote_rpc(topic_name, fun, args) do
+    with_topic(topic_name, fn server ->
+      case :rpc.call(node(server), __MODULE__, fun, args) do
+        {:badrpc, reason} ->
+          {:error, {:badrpc, reason}}
+
+        value ->
+          {:ok, value}
+      end
+    end)
+  end
+
+  def do_get_all_messages(topic_name) do
+    :ets.tab2list(topic_name)
+    |> Enum.map(&format_message/1)
+  end
+
+  def format_message({index, message}) do
+    %{index: index, message: message}
+  end
+
+  def do_get_queue_length(topic_name) do
+    :ets.info(topic_name, :size)
+  end
+
+  def do_get_messages(topic_name, index, limit) do
+    :lists.seq(index, index + limit - 1)
+    |> Enum.map(fn i -> :ets.lookup(topic_name, i) end)
+    |> List.flatten()
+    |> Enum.map(&format_message/1)
+  end
+
+  def do_cleanup(topic_name, index) do
+    [{:earliest, earliest}] = :ets.lookup(topic_name, :earliest)
+    do_cleanup(topic_name, earliest, index)
+  end
+
+  def do_cleanup(topic_name, from, to) when from < to do
+    :lists.seq(from, to)
+    |> Enum.each(fn i -> :ets.delete(topic_name, i) end)
+
+    update_earliest(topic_name, to)
+  end
+
+  def do_cleanup(_, _, _) do
+    :ok
+  end
+
+  def update_earliest(topic_name, index) do
+    {:ok, server} = find_topic(topic_name)
+    GenServer.cast(server, {:update_earliest, index})
+  end
+
+  def subscribe(topic_name, consumer_id, mode) do
+    with_topic(topic_name, fn server ->
+      GenServer.call(server, {:subscribe, consumer_id, mode})
+    end)
+  end
+
+  def get_index(topic_name, consumer_id) do
+    with_topic(topic_name, fn server ->
+      GenServer.call(server, {:get_index, consumer_id})
+    end)
+  end
+
+  def confirm(topic_name, consumer_id, index) do
+    with_topic(topic_name, fn server ->
+      GenServer.cast(server, {:confirm, consumer_id, index})
+    end)
+  end
+
+  def unsubscribe(topic_name, consumer_id) do
+    with_topic(topic_name, fn server ->
+      GenServer.call(server, {:unsubscribe, consumer_id})
+    end)
+  end
+end
+
+defmodule Ockam.Topics.Stream.Storage.Memory.Server do
+  use GenServer
+
+  def start_link(topic_name) do
+    GenServer.start_link(__MODULE__, topic_name, name: via(topic_name))
+  end
+
+  def via(topic_name) do
+    {:global, topic_name}
+  end
+
+  def init(topic_name) do
+    :ets.new(topic_name, [:named_table, :public])
+    :ets.insert(topic_name, {:earliest, 0})
+    :ets.insert(topic_name, {:latest, 0})
+    consumers = :ets.new(:consumers, [:public])
+    %{consumers: consumers, topic: topic_name}
+  end
+
+  def handle_cast({:push_message, message}, %{topic: topic} = state) do
+    [{:latest, index}] = :ets.lookup(topic, :latest)
+    next = index + 1
+    :ets.insert(topic, {next, message})
+    :ets.insert(topic, {:latest, next})
+    {:noreply, state}
+  end
+
+  def handle_cast({:update_earliest, index}, %{topic: topic} = state) do
+    [{:earliest, old_index}] = :ets.lookup(topic, :earliest)
+    :ets.insert(topic, {:earliest, max(index, old_index)})
+    {:noreply, state}
+  end
+
+  def handle_cast({:confirm, consumer_id, index}, %{consumers: consumers} = state) do
+    [{consumer_id, old_index}] = :ets.lookup(consumers, consumer_id)
+
+    new_index =
+      case old_index do
+        i when is_integer(i) -> max(i, index)
+        ## Earliest or latest
+        _ -> index
+      end
+
+    :ets.insert(consumers, {consumer_id, new_index})
+    {:noreply, state}
+  end
+
+  def handle_call(
+        {:subscribe, consumer_id, mode},
+        _from,
+        %{consumers: consumers, topic: topic} = state
+      ) do
+    result =
+      case :ets.lookup(consumers, consumer_id) do
+        [{_consumer_id, _index}] ->
+          {:error, :consumer_already_exists}
+
+        [] ->
+          :ets.insert(consumers, {consumer_id, mode})
+          do_get_index(topic, mode)
+      end
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:unsubscribe, consumer_id}, _from, %{consumers: consumers} = state) do
+    :ets.delete(consumers, consumer_id)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:get_index, consumer_id}, _from, %{consumers: consumers, topic: topic} = state) do
+    result =
+      case :ets.lookup(consumers, consumer_id) do
+        [{_consumer_id, index}] ->
+          do_get_index(topic, index)
+
+        [] ->
+          {:error, :consumer_does_not_exist}
+      end
+
+    {:reply, result, state}
+  end
+
+  def do_get_index(_topic, index) when is_integer(index) do
+    index
+  end
+
+  def do_get_index(topic, mode) when is_atom(mode) do
+    [{_mode, index}] = :ets.lookup(topic, mode)
+    index
+  end
+end
+
+defmodule Ockam.Topics.Stream.Topic do
+  @default_storage Ockam.Topics.Stream.Storage.Memory
+
+  def create(topic_name, storage \\ @default_storage)
+
+  def create(topic_name, storage) when is_atom(topic_name) do
+    storage.create_topic(topic_name)
+  end
+
+  def destroy(topic_name, storage \\ @default_storage)
+
+  def destroy(topic_name, storage) when is_atom(topic_name) do
+    storage.destroy_topic(topic_name)
+  end
+
+  def publish(topic_name, message, storage \\ @default_storage)
+
+  def publish(topic_name, message, storage) do
+    storage.push_message(topic_name, message, storage)
+  end
+
+  def get_queue(topic_name, storage \\ @default_storage)
+
+  def get_queue(topic_name, storage) do
+    storage.get_all_messages(topic_name)
+  end
+
+  def queue_length(topic_name, storage \\ @default_storage)
+
+  def queue_length(topic_name, storage) do
+    storage.queue_length(topic_name)
+  end
+
+  ## Caveat: if the earliest index is higher than index+limit,
+  ## the limit of messages will be returned starting on the earliest
+  def get_messages(topic_name, index, limit, storage \\ @default_storage)
+
+  def get_messages(topic_name, index, limit, storage) do
+    storage.get_messages(topic_name, index, limit)
+  end
+
+  def cleanup(topic_name, index, storage \\ @default_storage)
+
+  def cleanup(topic_name, index, storage) do
+    storage.cleanup(topic_name, index)
+  end
+
+  ## Consumer management
+
+  @doc "Crate a new consumer. Returns an error if consumer exists"
+  def subscribe(topic_name, consumer_id, mode, consumer_storage \\ @default_storage)
+
+  def subscribe(topic_name, consumer_id, mode, consumer_storage)
+      when mode == :earliest or mode == :latest do
+    consumer_storage.subscribe(topic_name, consumer_id, mode)
+  end
+
+  @doc "Get an existing consumer index. Returns an error if consumer does not exist"
+  def get_index(topic_name, consumer_id, consumer_storage \\ @default_storage)
+
+  def get_index(topic_name, consumer_id, consumer_storage) do
+    consumer_storage.get_index(topic_name, consumer_id)
+  end
+
+  def confirm(topic_name, consumer_id, index, consumer_storage \\ @default_storage)
+
+  def confirm(topic_name, consumer_id, index, consumer_storage) do
+    consumer_storage.confirm(topic_name, consumer_id, index)
+  end
+
+  def unsubscribe(topic_name, consumer_id, consumer_storage \\ @default_storage) do
+    consumer_storage.unsubscribe(topic_name, consumer_id)
+  end
+end

--- a/implementations/elixir/ockam/_ockam/lib/ockam/topic.ex
+++ b/implementations/elixir/ockam/_ockam/lib/ockam/topic.ex
@@ -40,11 +40,18 @@ defmodule Ockam.Topic do
 
   alias Ockam.Topics
 
-  def init(%{topic_name: _} = state) do
+  require Logger
+
+  @storage_module Ockam.Topics.Log.Map
+  @consumers_module Ockam.Topics.Consumers.Map
+
+  def init(%{topic_name: topic_name} = state) do
     # @TODO use ets for messages
     # @TODO register consumers with their own DynamicSupervisor
     # @TODO queued_messages is unbounded and really ought to be a pluggable backend with an ets table.
-    {:ok, Map.merge(state, %{queued_messages: [], consumers: []})}
+    storage = {@storage_module, @storage_module.init(topic_name)}
+    consumers = {@consumers_module, @consumers_module.init()}
+    {:ok, Map.merge(state, %{storage: storage, consumers: consumers})}
   end
 
   def start_link(topic_name) do
@@ -72,70 +79,227 @@ defmodule Ockam.Topic do
     GenServer.call(topic_name, :queue_length)
   end
 
-  def subscribe(topic_name, pid) do
-    GenServer.call(topic_name, {:subscribe, pid})
-  end
-
-  def process_queued_messages(topic_name) do
-    GenServer.cast(topic_name, :process_queued_messages)
+  def subscribe(topic_name, pid, limit \\ 10) do
+    GenServer.call(topic_name, {:subscribe, pid, limit})
   end
 
   def unsubscribe(topic_name, pid) do
     GenServer.call(topic_name, {:unsubscribe, pid})
   end
 
+  def confirm(topic_name, pid, index) do
+    GenServer.cast(topic_name, {:confirm, pid, index})
+  end
+
   # @TODO add a timer for processing the queued messages.
 
-  def handle_cast({:publish, message}, %{queued_messages: messages, consumers: []} = state) do
-    # ++ performance does not suck anymore
-    {:noreply, %{state | queued_messages: [message | messages]}}
+  def handle_cast({:publish, message}, state) do
+    new_state =
+      state
+      |> enqueue(message)
+      |> bump_consumers()
+
+    ## TODO: when using distributed storage it might be a challenge
+    ## to bump consumers
+
+    ## In that case consumers checking storage periodically would be better
+
+    {:noreply, new_state}
   end
 
-  def handle_cast({:publish, message}, %{consumers: consumers} = state) do
-    Enum.each(consumers, fn consumer ->
-      # @TODO this should be a protocol probably.
-      GenServer.cast(consumer, {:consume, message})
-    end)
-
-    {:noreply, state}
+  def handle_cast({:confirm, pid, index}, state) do
+    new_state =
+      state
+      |> confirm_consumer_index(pid, index)
+      |> consume_messages(pid)
+      |> cleanup_log()
+    {:noreply, new_state}
   end
 
-  def handle_cast(
-        :process_queued_messages,
-        %{queued_messages: messages, topic_name: topic_name} = state
-      ) do
-    messages
-    |> Enum.reverse()
-    |> Enum.each(fn message ->
-      publish(topic_name, message)
-    end)
-
-    {:noreply, %{state | queued_messages: []}}
+  def handle_call(:get_queue, _from, state) do
+    {storage_module, storage} = state.storage
+    {:reply, storage_module.get_all_messages(storage), state}
   end
 
-  def handle_call(:get_queue, _from, %{queued_messages: messages} = state) do
-    {:reply, messages, state}
-  end
-
-  def handle_call(:queue_length, _from, %{queued_messages: messages} = state) do
-    {:reply, length(messages), state}
+  def handle_call(:queue_length, _from, state) do
+    {storage_module, storage} = state.storage
+    {:reply, storage_module.get_queue_length(storage), state}
   end
 
   def handle_call(
-        {:subscribe, pid},
+        {:subscribe, pid, limit},
         _from,
-        %{topic_name: topic_name, consumers: consumers} = state
+        state
       ) do
-    process_queued_messages(topic_name)
-    {:reply, :ok, %{state | consumers: [pid | consumers]}}
+    {s_mod, storage} = state.storage
+    earliest = s_mod.get_earliest(storage)
+    new_state =
+      state
+      |> Map.update!(:consumers, fn({mod, mod_state}) -> {mod, mod.add_consumer(mod_state, pid, earliest, limit)} end)
+      |> consume_messages(pid)
+    {:reply, :ok, new_state}
   end
 
-  def handle_call({:unsubscribe, pid}, _from, %{consumers: consumers} = state) do
-    consumers =
-      Enum.reject(consumers, fn consumer ->
-        consumer == pid
-      end)
+  def handle_call({:unsubscribe, pid}, _from, state) do
+    new_state = state |> Map.update!(:consumers, fn({mod, mod_state}) -> {mod, mod.remove_consumer(mod_state, pid)} end)
+    ## TODO: cleanup log
+    {:reply, :ok, new_state}
+  end
 
-    {:reply, :ok, %{state | consumers: consumers}}
+  def enqueue(state, message) do
+    {storage_module, storage} = state.storage
+    storage = storage_module.store(storage, message)
+    %{state | storage: {storage_module, storage}}
+  end
+
+  def cleanup_log(state) do
+    {s_mod, storage} = state.storage
+    {c_mod, consumers} = state.consumers
+
+    min = c_mod.min_confirmed_index(consumers)
+    new_storage = s_mod.cleanup(storage, min)
+    %{state | storage: {s_mod, new_storage}}
+  end
+
+  def bump_consumers(state) do
+    {mod, consumers} = state.consumers
+    mod.get_consumer_ids(consumers)
+    |> Enum.reduce(state, fn(pid, state_acc) -> consume_messages(state_acc, pid) end)
+  end
+
+  def consume_messages(state, consumer_pid) do
+    {c_mod, consumers} = state.consumers
+    {s_mod, storage} = state.storage
+
+    consumer_data = c_mod.get_consumer(consumers, consumer_pid)
+    latest = s_mod.get_latest(storage)
+
+    case consumer_data.sent < latest do
+      true ->
+        limit = consumer_data.limit
+        from = consumer_data.sent + 1
+        to = min(latest, consumer_data.confirmed + limit)
+        s_mod.get_messages(storage, from, to)
+        |> Enum.each(fn(message) -> send_message(message, consumer_pid) end)
+        update_sent(state, consumer_pid, to)
+      false ->
+        state
+    end
+  end
+
+  def send_message({index, message}, consumer_pid) do
+    GenServer.cast(consumer_pid, {:consume, message, index})
+  end
+
+  def update_sent(state, consumer_pid, index) do
+    {mod, consumers} = state.consumers
+
+    consumers = mod.update_consumer(consumers, consumer_pid, :sent, index)
+    %{state | consumers: {mod, consumers}}
+  end
+
+  def confirm_consumer_index(state, consumer_pid, index) do
+    {mod, consumers} = state.consumers
+
+    consumers = mod.update_consumer(consumers, consumer_pid, :confirmed, index)
+    %{state | consumers: {mod, consumers}}
   end
 end
+
+defmodule Ockam.Topics.Consumers.Map do
+  def init() do
+    %{}
+  end
+
+  def update_consumer(consumers, consumer_pid, key, index) do
+    case get_consumer(consumers, consumer_pid) do
+      nil -> consumers
+      consumer ->
+        Map.put(consumers, consumer_pid, Map.put(consumer, key, index))
+    end
+  end
+
+  def add_consumer(consumers, consumer_pid, init, limit) do
+    case Map.get(consumers, consumer_pid) do
+      nil ->
+        consumers |> Map.put(consumer_pid, %{confirmed: init, sent: init, limit: limit})
+      _ ->
+        consumers
+    end
+  end
+
+  def remove_consumer(consumers, consumer_pid) do
+    Map.delete(consumers, consumer_pid)
+  end
+
+  def get_consumer(consumers, consumer_pid) do
+    Map.get(consumers, consumer_pid)
+  end
+
+  def min_confirmed_index(consumers) do
+    consumers
+    |> Map.values
+    |> Enum.min_by(fn(%{confirmed: confirmed}) -> confirmed end)
+    |> Map.get(:confirmed)
+  end
+
+  def get_consumer_ids(consumers) do
+    Map.keys(consumers)
+  end
+end
+
+
+defmodule Ockam.Topics.Log.Map do
+  def init(_topic_name) do
+    %{earliest: 0, latest: 0}
+  end
+
+  def cleanup(storage, index) do
+    earliest = get_earliest(storage)
+    to_cleanup = case earliest <= index do
+      true -> :lists.seq(earliest, index)
+      false -> []
+    end
+
+    to_cleanup
+    |> Enum.reduce(storage, fn(index, acc) -> Map.delete(acc, index) end)
+    |> Map.put(:earliest, index + 1)
+  end
+
+  def get_messages(storage, from, to) do
+    :lists.seq(from, to)
+    |> Enum.map(fn(index) ->
+      {index, Map.get(storage, index)}
+    end)
+    |> Enum.filter(fn({_, nil}) -> false; (_) -> true end)
+  end
+
+  def get_earliest(storage) do
+    Map.get(storage, :earliest)
+  end
+
+  def get_latest(storage) do
+    Map.get(storage, :latest)
+  end
+
+  def get_queue_length(storage) do
+    map_size(storage) - 2
+  end
+
+  def get_all_messages(storage) do
+    storage
+    |> Map.delete(:latest)
+    |> Map.delete(:earliest)
+    |> Enum.sort_by(fn({i, _m}) -> i end)
+    |> Enum.map(fn({_i, m}) -> m end)
+  end
+
+  def store(storage, message) do
+    latest = Map.get(storage, :latest)
+    next = latest + 1
+    storage
+    |> Map.put(next, message)
+    |> Map.put(:latest, next)
+  end
+end
+

--- a/implementations/elixir/ockam/_ockam/test/ockam/topic_test.exs
+++ b/implementations/elixir/ockam/_ockam/test/ockam/topic_test.exs
@@ -14,12 +14,12 @@ defmodule Ockam.Topic.Tests do
     use GenServer
     require Logger
 
-    def init(_state) do
-      {:ok, %{}}
+    def init(topic_name) do
+      {:ok, %{last_index: 0, topic_name: topic_name}}
     end
 
-    def start_link(default) when is_list(default) do
-      GenServer.start_link(__MODULE__, default)
+    def start_link(topic_name) do
+      GenServer.start_link(__MODULE__, topic_name)
     end
 
     def destroy(name \\ __MODULE__) do
@@ -28,7 +28,26 @@ defmodule Ockam.Topic.Tests do
 
     def handle_cast({:consume, message}, state) do
       Logger.debug("Should process message: #{message}")
+
       {:noreply, state}
+    end
+
+    def handle_cast({:consume, message, index}, state) do
+      Logger.debug("Should process message: #{message} with index #{index}")
+      {:noreply, %{state | last_index: index}}
+    end
+
+    def handle_call({:confirm, index}, _from, %{last_index: last_index, topic_name: topic_name} = state) do
+      if index <= last_index do
+        Topic.confirm(topic_name, self(), index)
+        {:reply, {:ok, index}, state}
+      else
+        {:reply, {:last_index, last_index}, state}
+      end
+    end
+
+    def handle_call(:last_index, _from, %{last_index: last_index} = state) do
+      {:reply, last_index, state}
     end
   end
 
@@ -80,10 +99,45 @@ defmodule Ockam.Topic.Tests do
     test "publish/2 with a consumer" do
       Topic.create(@topic_name)
       message = "1 consumer"
-      {:ok, pid} = Consumer.start_link([])
+      {:ok, pid} = Consumer.start_link(@topic_name)
       assert Topic.subscribe(@topic_name, pid) == :ok
       assert Topic.publish(@topic_name, message) == :ok
-      # if there is at least one consumer it won't save in the queue
+
+      wait_for_received(pid, 1)
+      GenServer.call(pid, {:confirm, 1})
+
+      assert Topic.get_queue(@topic_name) == []
+      assert Topic.queue_length(@topic_name) == 0
+      assert Topic.destroy(@topic_name) == :ok
+    end
+
+    test "publish/2 with a consumer limit" do
+      Topic.create(@topic_name)
+      message = "1 consumer"
+      {:ok, pid} = Consumer.start_link(@topic_name)
+      assert Topic.subscribe(@topic_name, pid) == :ok
+
+      :lists.seq(1, 20)
+      |> Enum.each(fn(i) -> Topic.publish(@topic_name, "#{i} message") end)
+
+      assert {:ok, 10} == wait_for_received(pid, 10)
+
+      ## Don't receive more
+      Topic.publish(@topic_name, "21 message")
+
+      assert {:error, {:low_index, 10}} == wait_for_received(pid, 11, 1000)
+
+      assert Topic.queue_length(@topic_name) == 21
+
+      GenServer.call(pid, {:confirm, 10})
+
+      assert {:ok, 20} == wait_for_received(pid, 20)
+
+      assert Topic.queue_length(@topic_name) == 11
+
+      GenServer.call(pid, {:confirm, 20})
+      GenServer.call(pid, {:confirm, 21})
+
       assert Topic.get_queue(@topic_name) == []
       assert Topic.queue_length(@topic_name) == 0
       assert Topic.destroy(@topic_name) == :ok
@@ -91,7 +145,7 @@ defmodule Ockam.Topic.Tests do
 
     test "subscribe/2" do
       Topic.create(@topic_name)
-      {:ok, consumer_pid} = Consumer.start_link([])
+      {:ok, consumer_pid} = Consumer.start_link(@topic_name)
 
       assert Topic.subscribe(@topic_name, consumer_pid) == :ok
       assert Topic.destroy(@topic_name) == :ok
@@ -99,40 +153,44 @@ defmodule Ockam.Topic.Tests do
 
     test "unsubscribe/2" do
       Topic.create(@topic_name)
-      {:ok, consumer_pid} = Consumer.start_link([])
+      {:ok, consumer_pid} = Consumer.start_link(@topic_name)
 
       assert Topic.unsubscribe(@topic_name, consumer_pid) == :ok
       assert Topic.destroy(@topic_name) == :ok
     end
+  end
 
-    test "process_queued_messages/1" do
-      Topic.create(@topic_name)
-      {:ok, consumer_pid} = Consumer.start_link([])
-      message = "queued message"
+  def wait_for_received(pid, index, timeout \\ 5000)
+  def wait_for_received(pid, index, timeout) do
+    wait_for(fn() ->
+      case GenServer.call(pid, :last_index) do
+        i when i >= index -> {:ok, i}
+        i -> {:error, {:low_index, i}}
+      end
+    end, timeout)
+  end
 
-      assert Topic.publish(@topic_name, message) == :ok
-      assert Topic.get_queue(@topic_name) == [message]
-      assert Topic.queue_length(@topic_name) == 1
-
-      # now subscribe a consumer and check that the message is gone
-      assert Topic.subscribe(@topic_name, consumer_pid) == :ok
-      assert Topic.process_queued_messages(@topic_name) == :ok
-      assert Topic.get_queue(@topic_name) == []
-      assert Topic.queue_length(@topic_name) == 0
-
-      assert Topic.process_queued_messages(@topic_name) == :ok
-      assert Topic.destroy(@topic_name) == :ok
+  def wait_for(fun, timeout, error \\ nil)
+  def wait_for(fun, timeout, error) when timeout <= 0 do
+    error
+  end
+  def wait_for(fun, timeout, error) do
+    case fun.() do
+      {:ok, result} -> {:ok, result}
+      {:error, _} = error ->
+        :timer.sleep(100)
+        wait_for(fun, timeout - 100, error)
     end
   end
 
   describe "consumer" do
     test "start_link/1" do
-      assert {:ok, pid} = Consumer.start_link([])
+      assert {:ok, pid} = Consumer.start_link(@topic_name)
       assert Consumer.destroy(pid) == :ok
     end
 
     test "destroy/1" do
-      assert {:ok, pid} = Consumer.start_link([])
+      assert {:ok, pid} = Consumer.start_link(@topic_name)
       assert Consumer.destroy(pid) == :ok
     end
 


### PR DESCRIPTION
### Rationale

In order to provide reliable "at least once" delivery there should be a confirmation mechanism for consumers to inform the topic that the message was processed.
This PR concentrates on implementing the protocol for that and splitting out the storage API from consumer management.

### Proposed Changes

Change the API for message consumption and protocol requirements for consumers.

- Add an index to each message.
- Add a `confirm(topic_name, pid, index)` api to confirm received messages
- Allow consumers to set a limit of messages to receive before confirming (effectively messages "in flight")
- Remove the `process_queued_messages` api as it doesn't make much sense.

Change implementation of the topic storage:

- Store all messages to storage regardless of consumers existence
- Add consumer state storage to store current consumers indexes (last sent, last confirmed)

TODO:

- Monitor consumer PID
- Consumer ID is still a pid. If we need to carry over consumer ID to the pid restart it needs to be decoupled
- bump_consumers might need a rework for distributed storage. 

The `Ockam.Topics.Stram` modules are more of a demonstration of the alternative approach which might be taken here: consumers in that case are using `pull` model. Doesn't need to go with this PR, but there for demonstration reasons.