### PR TITLE
feat(rust): ockam_core crate v0.3.0

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -20,7 +20,7 @@ default = ["std"]
 std = ["ockam_node"]
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.2.0"}
+ockam_core = {path = "../ockam_core", version = "0.3.0"}
 ockam_node = {path = "../ockam_node", version = "0.1.2", optional = true}
 ockam_node_attribute = {path = "../ockam_node_attribute", version = "0.1.3"}
 ockam_vault_core = {path = "../ockam_vault_core", version = "*"}

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.1.0 - 2021-01-30
+## v0.3.0 - 2021-02-16
 ### Added
 
-- `Error` - an error type that can be returned is both `std` and `no_std` modes.
-- `Result` - a result type that can be returned is both `std` and `no_std` modes.
+- Explicit `alloc`, `no_std`, and `std` features.
+- Generalized `Address` implementation.
+- Global crate lib facade wrapper around `std` and `core` re-exports, for cross-feature compatibility.
+- Message trait base implementation.
+
+### Modified
+
+- Updated dependencies.
+- Improved documentation.
+
+
 
 ## v0.2.0 - 2021-02-04
 ### Added
@@ -25,3 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -  Moved Worker and Address types to this crate.
 -  Renamed executor commands to messages
+
+## v0.1.0 - 2021-01-30
+### Added
+
+- `Error` - an error type that can be returned is both `std` and `no_std` modes.
+- `Result` - a result type that can be returned is both `std` and `no_std` modes.
+

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -137,6 +137,20 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.2.0"
+ockam_core = "0.3.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.2.0", default-features = false }
+ockam_core = { version = "0.3.0", default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_credential/Cargo.lock
+++ b/implementations/rust/ockam/ockam_credential/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/implementations/rust/ockam/ockam_credential/Cargo.toml
+++ b/implementations/rust/ockam/ockam_credential/Cargo.toml
@@ -24,11 +24,11 @@ alloc = ["ockam_core/alloc", "serde/alloc"]
 no_std = ["ockam_core/no_std"]
 
 [dependencies]
+ockam_core = { version = "0.3.0", default-features = false, path = "../ockam_core" }
 bbs = { version = "0.4", optional = true }
 digest = { version = "0.8", optional = true }
 ff = { version = "0.6", package = "ff-zeroize", optional = true }
 heapless = { version = "0.6", optional = true }
-ockam_core = { version = "0.2.0", default-features = false, path = "../ockam_core" }
 pairing-plus = { version = "0.19", optional = true }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -406,6 +406,20 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha2"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 lto = true
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.2.0" }
+ockam_core = { path = "../ockam_core", version = "0.3.0" }
 ockam_vault_core = {path = "../ockam_vault_core", version = "0.1.0" }
 ockam_vault = { path = "../ockam_vault", version = "0.1" }
 lazy_static = { version = "1.4" }

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -152,10 +152,11 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",
+ "hashbrown",
  "serde",
 ]
 
@@ -241,6 +242,20 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -9,5 +9,5 @@ version = "0.1.2"
 [dependencies]
 async-trait = "0.1.42"
 hashbrown = "0.9.1"
-ockam_core = {path = "../ockam_core", version = "0.2.0"}
+ockam_core = {path = "../ockam_core", version = "0.3.0"}
 tokio = {version = "1.1.0", features = ["full"]}

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -442,6 +442,20 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha2"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -21,7 +21,7 @@ std = ["ockam_core/std", "hex/std"]
 no_std = ["ockam_vault_core/heapless"]
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.2.0"}
+ockam_core = {path = "../ockam_core", version = "0.3.0"}
 ockam_vault_core = {path = "../ockam_vault_core", version = "0.1.0"}
 arrayref = "0.3"
 aes-gcm = "0.8"

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -152,6 +152,20 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -18,7 +18,7 @@ std = ["ockam_core/std"]
 no_std = ["heapless"]
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.2.0"}
+ockam_core = {path = "../ockam_core", version = "0.3.0"}
 heapless = { version = "0.6", optional = true }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 cfg-if = "1.0"


### PR DESCRIPTION
## v0.3.0 - 2021-02-16
### Added

- Explicit `alloc`, `no_std`, and `std` features.
- Generalized `Address` implementation.
- Global crate lib facade wrapper around `std` and `core` re-exports, for cross-feature compatibility.
- Message trait base implementation.

### Modified

- Updated dependencies.
- Improved documentation.


