### PR TITLE
ockam_credential crate v0.2.0

### DIFF
--- a/implementations/rust/ockam/ockam_credential/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_credential/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.1 - 2021-02-10
+## 0.2.0 - 2021-02-16
 ## Added
 
 - Only available in std mode

--- a/implementations/rust/ockam/ockam_credential/Cargo.lock
+++ b/implementations/rust/ockam/ockam_credential/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_credential"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bbs",
  "digest",

--- a/implementations/rust/ockam/ockam_credential/Cargo.toml
+++ b/implementations/rust/ockam/ockam_credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_credential"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
## 0.2.0 - 2021-02-16
## Added

- Only available in std mode
- `Claim` - information that has been signed in a credential
- `ClaimType` - the data encoding for a claim
- `CredentialOffer` - information from an issuer that will be in a credential
- `Credential` - a cryptographic signature with claims
- `BlindCredential` - a cryptographic blinded signature with claims
- `CredentialError::MismatchedAttributesAndClaims` - schema attributes and claims do not match
- `CredentialError::MismatchedAttributeClaimType` - attribute type and claim type do not match
- `CredentialError::InvalidClaim` - claim data cannot be mapped to a valid cryptographic value
- `Issuer` - methods for issuing credentials and blinded credentials
