### PR TITLE
Ockam worker relay mailbox

### DIFF
--- a/implementations/rust/examples/node/examples/create_node_with_macro.rs
+++ b/implementations/rust/examples/node/examples/create_node_with_macro.rs
@@ -1,4 +1,4 @@
 #[ockam::node]
 async fn main(context: ockam::Context) {
-    context.node().stop().unwrap();
+    context.stop().unwrap();
 }

--- a/implementations/rust/examples/node/examples/create_node_without_macro.rs
+++ b/implementations/rust/examples/node/examples/create_node_without_macro.rs
@@ -2,7 +2,7 @@ fn main() {
     let (context, mut executor) = ockam::node();
     executor
         .execute(async move {
-            context.node().stop().unwrap();
+            context.stop().unwrap();
         })
         .unwrap();
 }

--- a/implementations/rust/examples/node/examples/create_ping_pong_node.rs
+++ b/implementations/rust/examples/node/examples/create_ping_pong_node.rs
@@ -1,6 +1,6 @@
 //! Spawn to workers that play some ping-pong
 
-use ockam::{Address, Context, Message, Result, Worker};
+use ockam::{Address, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 struct Player {
@@ -70,7 +70,7 @@ impl Worker for Player {
 }
 
 fn main() {
-    let (ctx, mut exe) = ockam::node();
+    let (ctx, mut exe) = ockam::start_node();
 
     exe.execute(async move {
         let a1: Address = "player1".into();

--- a/implementations/rust/examples/node/examples/create_ping_pong_node.rs
+++ b/implementations/rust/examples/node/examples/create_ping_pong_node.rs
@@ -28,8 +28,6 @@ enum Action {
     Pong,
 }
 
-impl Message for Action {}
-
 impl Worker for Player {
     type Message = Action;
     type Context = Context;

--- a/implementations/rust/examples/node/examples/create_ping_pong_node.rs
+++ b/implementations/rust/examples/node/examples/create_ping_pong_node.rs
@@ -42,35 +42,27 @@ impl Worker for Player {
         match msg {
             Action::Intro(addr) if self.friend.is_none() => {
                 self.friend = Some(addr);
-                ctx.node()
-                    .send_message(self.friend(), Action::Intro(ctx.address()))
+                ctx.send_message(self.friend(), Action::Intro(ctx.address()))
                     .unwrap();
             }
 
             // Redundant intro -> start the game
-            Action::Intro(_) => ctx
-                .node()
-                .send_message(self.friend(), Action::Ping)
-                .unwrap(),
+            Action::Intro(_) => ctx.send_message(self.friend(), Action::Ping).unwrap(),
 
             // Ping -> Pong
             Action::Ping if self.count < 5 => {
-                ctx.node()
-                    .send_message(self.friend(), Action::Pong)
-                    .unwrap();
+                ctx.send_message(self.friend(), Action::Pong).unwrap();
                 self.count += 1;
             }
 
             // Pong -> Ping
             Action::Pong if self.count < 5 => {
-                ctx.node()
-                    .send_message(self.friend(), Action::Ping)
-                    .unwrap();
+                ctx.send_message(self.friend(), Action::Ping).unwrap();
                 self.count += 1;
             }
 
             // When the count >= 5
-            _ => ctx.node().stop().unwrap(),
+            _ => ctx.stop().unwrap(),
         }
 
         Ok(())
@@ -84,14 +76,12 @@ fn main() {
         let a1: Address = "player1".into();
         let a2: Address = "player2".into();
 
-        let node = ctx.node();
-
         // Create two players
-        node.start_worker(a1.clone(), Player::new()).unwrap();
-        node.start_worker(a2.clone(), Player::new()).unwrap();
+        ctx.start_worker(a1.clone(), Player::new()).unwrap();
+        ctx.start_worker(a2.clone(), Player::new()).unwrap();
 
         // Tell player1 to start the match with player2
-        node.send_message(a1, Action::Intro(a2)).unwrap();
+        ctx.send_message(a1, Action::Intro(a2)).unwrap();
 
         // Block until all workers are done
     })

--- a/implementations/rust/examples/worker/examples/worker_cancel_reply.rs
+++ b/implementations/rust/examples/worker/examples/worker_cancel_reply.rs
@@ -1,0 +1,68 @@
+use ockam::{Context, Result, Worker};
+use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
+enum Message {
+    Good,
+    Bad,
+}
+
+/// This worker requests more data and is very picky about what data it accepts.
+struct Picky;
+
+impl Worker for Picky {
+    type Message = Message;
+    type Context = Context;
+
+    fn handle_message(&mut self, ctx: &mut Context, msg: Message) -> Result<()> {
+        match msg {
+            Message::Good => {
+                println!("[PICKY]: I got a good message!  I want another one");
+                ctx.send_message("io.ockam.echo", Message::Good).unwrap();
+
+                loop {
+                    let msg = ctx.receive::<Message>().unwrap();
+                    if msg == Message::Bad {
+                        println!("[PICKY]: Ignoring bad message");
+                        msg.cancel();
+                    } else {
+                        println!("[PICKY]: Yay, another good message!");
+                        break;
+                    }
+                }
+            }
+            Message::Bad => {
+                println!("[PICKY]: Oh, a bad message...");
+                ctx.stop().unwrap();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct Echo;
+
+impl Worker for Echo {
+    type Message = Message;
+    type Context = Context;
+
+    fn handle_message(&mut self, ctx: &mut Context, _: Message) -> Result<()> {
+        println!("[ECHO]: Received message: sending one Bad, then one Good");
+        ctx.send_message("io.ockam.picky", Message::Bad).unwrap();
+        ctx.send_message("io.ockam.picky", Message::Good).unwrap();
+        Ok(())
+    }
+}
+
+fn main() {
+    let (app, mut exe) = ockam::start_node();
+
+    exe.execute(async move {
+        app.start_worker("io.ockam.picky", Picky).unwrap();
+        app.start_worker("io.ockam.echo", Echo).unwrap();
+
+        app.send_message("io.ockam.picky", Message::Good).unwrap();
+    })
+    .unwrap();
+}

--- a/implementations/rust/examples/worker/examples/worker_get_reply.rs
+++ b/implementations/rust/examples/worker/examples/worker_get_reply.rs
@@ -1,0 +1,35 @@
+use ockam::{Context, Result, Worker};
+use serde::{Deserialize, Serialize};
+
+struct Square;
+
+#[derive(Serialize, Deserialize)]
+struct Num(usize);
+
+impl Worker for Square {
+    type Message = Num;
+    type Context = Context;
+
+    fn handle_message(&mut self, ctx: &mut Context, msg: Num) -> Result<()> {
+        println!("Getting square request for number {}", msg.0);
+        ctx.send_message("app", Num(msg.0 * msg.0))
+    }
+}
+
+fn main() {
+    let (mut app, mut exe) = ockam::start_node();
+
+    exe.execute(async move {
+        app.start_worker("io.ockam.square", Square).unwrap();
+
+        let num = 3;
+        app.send_message("io.ockam.square", Num(num)).unwrap();
+
+        // block until it receives a message
+        let square = app.receive::<Num>().unwrap();
+        println!("App: {} ^ 2 = {}", num, square.0);
+
+        app.stop().unwrap();
+    })
+    .unwrap();
+}

--- a/implementations/rust/examples/worker/examples/worker_initialize.rs
+++ b/implementations/rust/examples/worker/examples/worker_initialize.rs
@@ -13,7 +13,7 @@ impl Worker for Nothing {
 }
 
 fn main() {
-    let (app, mut exe) = ockam::node();
+    let (app, mut exe) = ockam::start_node();
 
     exe.execute(async move {
         app.start_worker("io.ockam.nothing", Nothing).unwrap();

--- a/implementations/rust/examples/worker/examples/worker_initialize.rs
+++ b/implementations/rust/examples/worker/examples/worker_initialize.rs
@@ -1,0 +1,23 @@
+use ockam::{Context, Result, Worker};
+
+struct Nothing;
+
+impl Worker for Nothing {
+    type Message = ();
+    type Context = Context;
+
+    fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
+        println!("Worker that does nothing is starting");
+        Ok(())
+    }
+}
+
+fn main() {
+    let (app, mut exe) = ockam::node();
+
+    exe.execute(async move {
+        app.start_worker("io.ockam.nothing", Nothing).unwrap();
+        app.stop().unwrap();
+    })
+    .unwrap();
+}

--- a/implementations/rust/examples/worker/examples/worker_send_message.rs
+++ b/implementations/rust/examples/worker/examples/worker_send_message.rs
@@ -23,7 +23,7 @@ impl Worker for Printer {
 }
 
 fn main() {
-    let (app, mut exe) = ockam::node();
+    let (app, mut exe) = ockam::start_node();
 
     exe.execute(async move {
         app.start_worker("io.ockam.printer", Printer {}).unwrap();

--- a/implementations/rust/examples/worker/examples/worker_send_message.rs
+++ b/implementations/rust/examples/worker/examples/worker_send_message.rs
@@ -1,43 +1,35 @@
-use ockam::{Context, Message, Result, Worker};
+use ockam::{Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 struct Printer;
 
+// Types that are Serialize + Deserialize are automatically Message
 #[derive(Debug, Serialize, Deserialize)]
 struct PrintMessage(String);
-
-impl Message for PrintMessage {}
 
 impl Worker for Printer {
     type Message = PrintMessage;
     type Context = Context;
 
     fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
-        println!("Printer starting");
+        println!("[PRINTER]: starting");
         Ok(())
     }
 
     fn handle_message(&mut self, _context: &mut Context, msg: PrintMessage) -> Result<()> {
-        println!("{}", msg.0);
+        println!("[PRINTER]: {}", msg.0);
         Ok(())
     }
 }
 
 fn main() {
-    let (ctx, mut exe) = ockam::node();
+    let (app, mut exe) = ockam::node();
 
     exe.execute(async move {
-        let node = ctx.node();
-
-        node.start_worker("printer", Printer {}).unwrap();
-        node.send_message(
-            "printer",
-            PrintMessage {
-                0: "hi".to_string(),
-            },
-        )
-        .unwrap();
-        node.stop().unwrap();
+        app.start_worker("io.ockam.printer", Printer {}).unwrap();
+        app.send_message("io.ockam.printer", PrintMessage("Hello, ockam!".into()))
+            .unwrap();
+        app.stop().unwrap();
     })
     .unwrap();
 }

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -17,6 +17,9 @@ pub trait Message: Serialize + DeserializeOwned + Send + 'static {
     }
 }
 
+// Auto-implement message trait for types that _can_ be messages
+impl<T> Message for T where T: Serialize + DeserializeOwned + Send + 'static {}
+
 // TODO: see comment in Cargo.toml about this dependency
 impl From<bincode::Error> for crate::Error {
     fn from(_: bincode::Error) -> Self {

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,22 +1,133 @@
-use crate::node::Node;
-use ockam_core::Address;
+use crate::{error::Error, relay, NodeMessage, NodeReply};
+use ockam_core::{Address, Message, Result, Worker};
+use std::{future::Future, sync::Arc};
+use tokio::{
+    runtime::Runtime,
+    sync::mpsc::{channel, Sender},
+    task::{self, LocalSet},
+};
 
-#[derive(Clone)]
+/// Execute a future without blocking the executor
+fn block_future<'r, F>(rt: &'r Runtime, f: F) -> <F as Future>::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    task::block_in_place(move || {
+        let local = LocalSet::new();
+        local.block_on(&rt, f)
+    })
+}
+
 pub struct Context {
     address: Address,
-    node: Node,
+    sender: Sender<NodeMessage>,
+    rt: Arc<Runtime>,
 }
 
 impl Context {
-    pub fn new(node: Node, address: Address) -> Self {
-        Self { node, address }
+    pub(crate) fn new(rt: Arc<Runtime>, sender: Sender<NodeMessage>, address: Address) -> Self {
+        Self {
+            rt,
+            sender,
+            address,
+        }
     }
 
     pub fn address(&self) -> Address {
         self.address.clone()
     }
 
-    pub fn node(&self) -> Node {
-        self.node.clone()
+    /// Start a new worker handle at [`Address`](ockam_core::Address)
+    pub fn start_worker<NM, NW, S>(&self, address: S, worker: NW) -> Result<()>
+    where
+        S: Into<Address>,
+        NM: Message + Send + 'static,
+        NW: Worker<Context = Context, Message = NM>,
+    {
+        let tx = self.sender.clone();
+        let rt = self.rt.clone();
+        let address = address.into();
+
+        // Wait for a worker to have started to avoid data races when
+        // sending messages to it in subsequent api calls
+        block_future(&self.rt, async move {
+            let ctx = Context::new(rt.clone(), tx.clone(), address.clone());
+            let sender = relay::build::<NW, NM>(rt.as_ref(), worker, ctx);
+
+            let msg = NodeMessage::start_worker(address, sender);
+            let _result: Result<()> = match tx.send(msg).await {
+                Ok(()) => Ok(()),
+                Err(_e) => Err(Error::FailedStartWorker.into()),
+            };
+        });
+
+        Ok(())
+    }
+
+    /// Signal to the local application runner to shut down
+    pub fn stop(&self) -> Result<()> {
+        let tx = self.sender.clone();
+        tokio::spawn(async move {
+            println!("App: shutting down all workers");
+            let _result: Result<()> = match tx.send(NodeMessage::StopNode).await {
+                Ok(()) => Ok(()),
+                Err(_e) => Err(Error::FailedStopNode.into()),
+            };
+        });
+
+        Ok(())
+    }
+
+    /// Send a message to a particular worker
+    pub fn send_message<S, M>(&self, address: S, msg: M) -> Result<()>
+    where
+        S: Into<Address>,
+        M: Message + Send + 'static,
+    {
+        let address = address.into();
+        let tx = self.sender.clone();
+        tokio::spawn(async move {
+            let (reply_tx, mut reply_rx) = channel(1);
+            let req = NodeMessage::SenderReq(address, reply_tx);
+
+            // FIXME/ DESIGN: error communication concept
+            let _result: Result<()> = match tx.send(req).await {
+                Ok(()) => {
+                    if let Some(NodeReply::Sender(_, s)) = reply_rx.recv().await {
+                        let msg = msg.encode().unwrap();
+                        match s.send(msg).await {
+                            Ok(()) => Ok(()),
+                            Err(_e) => Err(Error::FailedSendMessage.into()),
+                        }
+                    } else {
+                        Err(Error::FailedSendMessage.into())
+                    }
+                }
+                Err(_e) => Err(Error::FailedSendMessage.into()),
+            };
+        });
+
+        Ok(())
+    }
+
+    /// Return a list of all available worker addresses on a node
+    pub fn list_workers(&self) -> Result<Vec<Address>> {
+        let tx = self.sender.clone();
+
+        block_future(&self.rt, async move {
+            let (msg, mut reply_rx) = NodeMessage::list_workers();
+
+            match tx.send(msg).await {
+                Ok(()) => {
+                    if let Some(NodeReply::Workers(list)) = reply_rx.recv().await {
+                        Ok(list)
+                    } else {
+                        Ok(vec![])
+                    }
+                }
+                Err(_e) => Err(Error::FailedListWorker.into()),
+            }
+        })
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -1,6 +1,6 @@
 // use crate::message::BaseMessage;
 
-use crate::{relay::RelayMessage, Context, NodeMessage, NodeReply};
+use crate::{relay::RelayMessage, Context, Mailbox, NodeMessage, NodeReply};
 use ockam_core::{Address, Result};
 
 use std::{collections::BTreeMap, future::Future, sync::Arc};
@@ -45,7 +45,7 @@ impl Executor {
     /// Create a new [`Context`] at the given address.
     pub fn new_context<S: Into<Address>>(&self, address: S) -> Context {
         let sender = self.sender.clone();
-        Context::new(self.rt.clone(), sender, address.into())
+        Context::new(self.rt.clone(), sender, address.into(), Mailbox::fake())
     }
 
     pub fn execute<F>(&mut self, future: F) -> Result<()>

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -12,11 +12,13 @@
 mod context;
 mod error;
 mod executor;
+mod mailbox;
 mod messages;
 mod relay;
 
 pub use context::*;
 pub use executor::*;
+pub use mailbox::*;
 pub use messages::*;
 
 pub fn node() -> (Context, Executor) {

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -23,3 +23,22 @@ pub use mailbox::*;
 pub use messages::*;
 
 pub use node::start_node;
+
+use std::future::Future;
+use tokio::{runtime::Runtime, task};
+
+/// Execute a future without blocking the executor
+///
+/// This is a wrapper around two simple tokio functions to allow
+/// ockam_node to wait for a task to be completed in a non-async
+/// environment.
+pub(crate) fn block_future<'r, F>(rt: &'r Runtime, f: F) -> <F as Future>::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    task::block_in_place(move || {
+        let local = task::LocalSet::new();
+        local.block_on(&rt, f)
+    })
+}

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -13,13 +13,11 @@ mod context;
 mod error;
 mod executor;
 mod messages;
-mod node;
 mod relay;
 
 pub use context::*;
 pub use executor::*;
 pub use messages::*;
-pub use node::*;
 
 pub fn node() -> (Context, Executor) {
     let executor = Executor::new();

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -14,6 +14,7 @@ mod error;
 mod executor;
 mod mailbox;
 mod messages;
+mod node;
 mod relay;
 
 pub use context::*;
@@ -21,8 +22,4 @@ pub use executor::*;
 pub use mailbox::*;
 pub use messages::*;
 
-pub fn node() -> (Context, Executor) {
-    let executor = Executor::new();
-    let context = executor.new_context("app");
-    (context, executor)
-}
+pub use node::start_node;

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -1,0 +1,39 @@
+use ockam_core::Encoded;
+
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+
+/// A mailbox for encoded messages
+///
+/// Message type information can't be exposed at this stage because
+/// they need to either be typed in the [`Relay`](crate::Relay) or in
+/// the worker's [`Context`](crate::Context).
+#[derive(Debug)]
+pub struct Mailbox {
+    rx: Receiver<Encoded>,
+    tx: Sender<Encoded>,
+}
+
+impl Mailbox {
+    pub fn new(rx: Receiver<Encoded>, tx: Sender<Encoded>) -> Self {
+        Self { rx, tx }
+    }
+
+    pub(crate) fn fake() -> Self {
+        let (tx, rx) = channel(1);
+        Self { tx, rx }
+    }
+    
+    pub fn sender(&self) -> Sender<Encoded> {
+        self.tx.clone()
+    }
+
+    /// Get the next message from the mailbox
+    pub async fn next(&mut self) -> Option<Encoded> {
+        self.rx.recv().await
+    }
+
+    /// If a message wasn't expected, requeue it
+    pub async fn requeue(&self, msg: Encoded) {
+        self.tx.send(msg).await.unwrap();
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -1,6 +1,6 @@
 use ockam_core::Encoded;
 
-use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::sync::mpsc::{Receiver, Sender};
 
 /// A mailbox for encoded messages
 ///
@@ -18,11 +18,6 @@ impl Mailbox {
         Self { rx, tx }
     }
 
-    pub(crate) fn fake() -> Self {
-        let (tx, rx) = channel(1);
-        Self { tx, rx }
-    }
-    
     pub fn sender(&self) -> Sender<Encoded> {
         self.tx.clone()
     }

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -1,161 +1,36 @@
-use crate::{error::Error, relay, Context, NodeMessage, NodeReply};
-use ockam_core::{Address, Message, Result, Worker};
+use crate::{relay, Context, Executor, Mailbox, NodeMessage};
+use ockam_core::Address;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::{channel, Sender};
 
-use std::{future::Future, sync::Arc};
-use tokio::{
-    runtime::Runtime,
-    sync::mpsc::{channel, Sender},
-    task::{self, LocalSet},
-};
+pub struct App;
 
-#[derive(Clone)]
-pub struct Node {
-    sender: Sender<NodeMessage>,
-    rt: Arc<Runtime>,
+impl ockam_core::Worker for App {
+    type Context = Context<App>;
+    type Message = (); // This message type is never used
 }
 
-/// Execute a future without blocking the executor
-fn block_future<F>(rt: &Runtime, f: F) -> <F as Future>::Output
-where
-    F: Future + Send + 'static,
-    F::Output: Send + 'static,
-{
-    task::block_in_place(move || {
-        let local = LocalSet::new();
-        local.block_on(&rt, f)
-    })
+pub fn start_node() -> (Context<App>, Executor) {
+    let mut exe = Executor::new();
+    let addr = "app".into();
+
+    // The root application worker needs a mailbox and relay to accept
+    // messages from workers, and to buffer incoming transcoded data.
+    let ctx = root_app_context(exe.runtime(), &addr, exe.sender());
+
+    // Build a mailbox worker to buffer messages
+    let sender = relay::build_root::<App, _>(exe.runtime(), &ctx.mailbox);
+
+    // Register this mailbox handle with the executor
+    exe.initialize_system("app", sender);
+
+    (ctx, exe)
 }
 
-impl Node {
-    pub fn new(sender: Sender<NodeMessage>, rt: Arc<Runtime>) -> Self {
-        Self { sender, rt }
-    }
-
-    /// Shut down a worker with a specific address
-    pub fn stop_worker<S: Into<Address>>(self: &Arc<Self>, address: S) -> Result<()> {
-        let this = Arc::clone(self);
-        let address = address.into();
-
-        tokio::spawn(async move {
-            let (reply_tx, mut reply_rx) = channel(1);
-            let msg = NodeMessage::StopWorker(address, reply_tx);
-
-            let _result: Result<()> = match this.sender.send(msg).await {
-                Ok(()) => {
-                    if let Some(NodeReply::Ok) = reply_rx.recv().await {
-                        Ok(())
-                    } else {
-                        Err(Error::FailedStopWorker.into())
-                    }
-                }
-                Err(_e) => Err(Error::FailedStopWorker.into()),
-            };
-        });
-
-        Ok(())
-    }
-
-    /// Send messages to all workers to shut them down
-    pub fn stop(&self) -> Result<()> {
-        println!("Node: shutting down all workers");
-
-        let this = self.clone();
-        tokio::spawn(async move {
-            let _result: Result<()> = match this.sender.send(NodeMessage::StopNode).await {
-                Ok(()) => Ok(()),
-                Err(_e) => Err(Error::FailedStopNode.into()),
-            };
-        });
-
-        Ok(())
-    }
-
-    /// Create and start the handler at [`Address`](ockam_core::Address).
-    pub fn start_worker<S, W, M>(&self, address: S, worker: W) -> Result<()>
-    where
-        S: Into<Address>,
-        W: Worker<Context = Context, Message = M>,
-        M: Message + Send + 'static,
-    {
-        let this = self.clone();
-        let address = address.into();
-
-        // Wait for a worker to have started to avoid data races when
-        // sending messages to it in subsequent api calls
-        block_future(&self.rt, async move {
-            let ctx = Context::new(this.clone(), address.clone());
-            let sender = relay::build(this.rt.as_ref(), worker, ctx);
-
-            let msg = NodeMessage::start_worker(address, sender);
-            let _result: Result<()> = match this.sender.send(msg).await {
-                Ok(()) => Ok(()),
-                Err(_e) => Err(Error::FailedStartWorker.into()),
-            };
-        });
-
-        Ok(())
-    }
-
-    /// Return a list of all available worker addresses on a node
-    pub fn list_workers(&self) -> Result<Vec<Address>> {
-        let this = self.clone();
-
-        block_future(&self.rt, async move {
-            let (msg, mut reply_rx) = NodeMessage::list_workers();
-
-            match this.sender.send(msg).await {
-                Ok(()) => {
-                    if let Some(NodeReply::Workers(list)) = reply_rx.recv().await {
-                        Ok(list)
-                    } else {
-                        Ok(vec![])
-                    }
-                }
-                Err(_e) => Err(Error::FailedListWorker.into()),
-            }
-        })
-    }
-
-    /// Send a message to a particular worker
-    pub fn send_message<S, M>(&self, address: S, msg: M) -> Result<()>
-    where
-        S: Into<Address>,
-        M: Message + Send + 'static,
-    {
-        let address = address.into();
-        let this = self.clone();
-        tokio::spawn(async move {
-            let (reply_tx, mut reply_rx) = channel(1);
-            let req = NodeMessage::SenderReq(address, reply_tx);
-
-            // FIXME/ DESIGN: error communication concept
-            let _result: Result<()> = match this.sender.send(req).await {
-                Ok(()) => {
-                    if let Some(NodeReply::Sender(_, s)) = reply_rx.recv().await {
-                        let msg = msg.encode().unwrap();
-                        match s.send(msg).await {
-                            Ok(()) => Ok(()),
-                            Err(_e) => Err(Error::FailedSendMessage.into()),
-                        }
-                    } else {
-                        Err(Error::FailedSendMessage.into())
-                    }
-                }
-                Err(_e) => Err(Error::FailedSendMessage.into()),
-            };
-        });
-
-        Ok(())
-    }
-
-    /// Block to receive a message for the current worker
-    pub fn receive<M>(&self, ctx: &Context) -> Result<M>
-    where
-        M: Message + Send + 'static,
-    {
-        self.rt.block_on(async move {
-            let _addr = ctx.address();
-            todo!()
-        })
-    }
+fn root_app_context(rt: Arc<Runtime>, addr: &Address, tx: Sender<NodeMessage>) -> Context<App> {
+    let (mb_tx, mb_rx) = channel(32);
+    let mb = Mailbox::new(mb_rx, mb_tx.clone());
+    let ctx = Context::new(rt, tx, addr.clone(), mb);
+    ctx
 }

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -7,11 +7,11 @@ use tokio::sync::mpsc::{channel, Sender};
 pub struct App;
 
 impl ockam_core::Worker for App {
-    type Context = Context<App>;
+    type Context = Context;
     type Message = (); // This message type is never used
 }
 
-pub fn start_node() -> (Context<App>, Executor) {
+pub fn start_node() -> (Context, Executor) {
     let mut exe = Executor::new();
     let addr = "app".into();
 
@@ -28,7 +28,7 @@ pub fn start_node() -> (Context<App>, Executor) {
     (ctx, exe)
 }
 
-fn root_app_context(rt: Arc<Runtime>, addr: &Address, tx: Sender<NodeMessage>) -> Context<App> {
+fn root_app_context(rt: Arc<Runtime>, addr: &Address, tx: Sender<NodeMessage>) -> Context {
     let (mb_tx, mb_rx) = channel(32);
     let mb = Mailbox::new(mb_rx, mb_tx.clone());
     let ctx = Context::new(rt, tx, addr.clone(), mb);

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -55,7 +55,7 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
     let output_function = quote! {
         #(#input_function_attrs)*
         fn #input_function_ident() {
-            let (context, mut executor) = ockam::node();
+            let (context, mut executor) = ockam::start_node();
             executor.execute(async move { #input_function_block }).unwrap()
         }
     };


### PR DESCRIPTION
This PR implements a few new concepts, while also refactoring the API.

* Move API endpoints to `Context`
  * Remove `Node` concept entirely
* Implement a worker mailbox to buffer messages
* Allow workers to block for incoming messages
  * Messages that don't belong into that 'state' provide `.cancel()` and will be re-queued
* Move ockam worker core (previously node) to be a minimal ockam worker itself