### PR TITLE
feat(rust): `ockam_node_attribute` validate function arguments (#793)

### DIFF
--- a/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn.rs
@@ -1,0 +1,4 @@
+#[ockam::node]
+async fn foo(c: ockam::Context) {
+    c.stop().unwrap();
+}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn_ockam_use_as_o.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn_ockam_use_as_o.rs
@@ -1,0 +1,7 @@
+// Test case that passes if ockam is used as `o` (or any other id).
+use ockam::{self as o};
+
+#[ockam::node]
+async fn foo(c: o::Context) {
+    c.stop().unwrap();
+}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.rs
@@ -1,0 +1,6 @@
+// Test case to verify that only one argument is passed.
+//
+#[ockam::node]
+async fn foo(c: ockam::Context, _x: u64) {
+    c.stop().unwrap();
+}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.stderr
@@ -1,0 +1,14 @@
+error: a function with '#[ockam::node]' must have exactly one argument
+ --> $DIR/fails_if_more_than_one_arg.rs:4:7
+  |
+4 | async fn foo(c: ockam::Context, _x: u64) {
+  |       ^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/fails_if_more_than_one_arg.rs:3:1
+  |
+3 | / #[ockam::node]
+4 | | async fn foo(c: ockam::Context, _x: u64) {
+5 | |     c.stop().unwrap();
+6 | | }
+  | |_^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_more_than_one_arg.rs`

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_self.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_self.rs
@@ -1,0 +1,6 @@
+// This test checks that #[ockam::node] causes a compile time error
+// if the function is passed a `self` param (thus making it a
+// `Receiver` function.
+
+#[ockam::node]
+async fn main(self) {}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_self.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_self.stderr
@@ -1,0 +1,12 @@
+error: Input argument should be of type `ockam::Context`
+ --> $DIR/fails_if_passed_param_is_self.rs:6:15
+  |
+6 | async fn main(self) {}
+  |               ^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/fails_if_passed_param_is_self.rs:5:1
+  |
+5 | / #[ockam::node]
+6 | | async fn main(self) {}
+  | |______________________^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_passed_param_is_self.rs`

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type.rs
@@ -1,0 +1,5 @@
+// This test checks that #[ockam::node] causes a compile time error
+// if the function is passed a param that is not of type `ockam::Context`
+
+#[ockam::node]
+async fn main(ctx: std::string::String) {}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type.stderr
@@ -1,0 +1,12 @@
+error: Expected `ockam::Context` found `std::string::String`
+ --> $DIR/fails_if_passed_param_is_wrong_type.rs:5:20
+  |
+5 | async fn main(ctx: std::string::String) {}
+  |                    ^^^^^^^^^^^^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/fails_if_passed_param_is_wrong_type.rs:4:1
+  |
+4 | / #[ockam::node]
+5 | | async fn main(ctx: std::string::String) {}
+  | |__________________________________________^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_passed_param_is_wrong_type.rs`

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type_using_use_statement.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type_using_use_statement.rs
@@ -1,0 +1,8 @@
+// This test checks that #[ockam::node] causes a compile time error
+// if the function is passed a param that is not of type `ockam::Context`
+// The param is not fully qualified (ie. using `use` statement).
+
+use std::string::String;
+
+#[ockam::node]
+async fn main(ctx: String) {}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type_using_use_statement.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_passed_param_is_wrong_type_using_use_statement.stderr
@@ -1,0 +1,22 @@
+error: Expected `ockam::Context` found `String`
+ --> $DIR/fails_if_passed_param_is_wrong_type_using_use_statement.rs:8:20
+  |
+8 | async fn main(ctx: String) {}
+  |                    ^^^^^^
+
+warning: unused import: `std::string::String`
+ --> $DIR/fails_if_passed_param_is_wrong_type_using_use_statement.rs:5:5
+  |
+5 | use std::string::String;
+  |     ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/fails_if_passed_param_is_wrong_type_using_use_statement.rs:5:1
+  |
+5 | / use std::string::String;
+6 | |
+7 | | #[ockam::node]
+8 | | async fn main(ctx: String) {}
+  | |_____________________________^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_passed_param_is_wrong_type_using_use_statement.rs`

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context.rs
@@ -1,0 +1,8 @@
+// This test checks that #[ockam::node] causes a compile time error
+// if the function is passed a parameter of type `ockam::Context` but is unused.
+
+#[ockam::node]
+async fn main(_ctx: ockam::Context) {
+    // _ctx.stop().unwrap();
+    let _x = 42 as u8;
+}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context.stderr
@@ -1,0 +1,15 @@
+error: Unused `_ctx`. Passed `ockam::Context` should be used.
+ --> $DIR/fails_if_unused_context.rs:5:15
+  |
+5 | async fn main(_ctx: ockam::Context) {
+  |               ^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/fails_if_unused_context.rs:4:1
+  |
+4 | / #[ockam::node]
+5 | | async fn main(_ctx: ockam::Context) {
+6 | |     // _ctx.stop().unwrap();
+7 | |     let _x = 42 as u8;
+8 | | }
+  | |_^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_unused_context.rs`

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context_empty_fnbody.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context_empty_fnbody.rs
@@ -1,0 +1,5 @@
+// This test checks that #[ockam::node] causes a compile time error
+// if the function is passed a parameter of type `ockam::Context` but is unused.
+
+#[ockam::node]
+async fn main(_ctx: ockam::Context) {}

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context_empty_fnbody.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_unused_context_empty_fnbody.stderr
@@ -1,0 +1,12 @@
+error: Function body Cannot be Empty.
+ --> $DIR/fails_if_unused_context_empty_fnbody.rs:5:10
+  |
+5 | async fn main(_ctx: ockam::Context) {}
+  |          ^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/fails_if_unused_context_empty_fnbody.rs:4:1
+  |
+4 | / #[ockam::node]
+5 | | async fn main(_ctx: ockam::Context) {}
+  | |______________________________________^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_unused_context_empty_fnbody.rs`

--- a/implementations/rust/ockam/ockam/tests/trybuild.rs
+++ b/implementations/rust/ockam/ockam/tests/trybuild.rs
@@ -2,6 +2,16 @@
 fn trybuild() {
     let t = trybuild::TestCases::new();
     t.pass("tests/node_attribute/can_be_used_on_main.rs");
+    t.pass("tests/node_attribute/can_be_used_on_any_fn.rs");
+    t.pass("tests/node_attribute/can_be_used_on_any_fn_ockam_use_as_o.rs");
     t.compile_fail("tests/node_attribute/fails_if_item_is_not_a_function.rs");
     t.compile_fail("tests/node_attribute/fails_if_function_is_not_async.rs");
+    t.compile_fail("tests/node_attribute/fails_if_passed_param_is_self.rs");
+    t.compile_fail("tests/node_attribute/fails_if_passed_param_is_wrong_type.rs");
+    t.compile_fail(
+        "tests/node_attribute/fails_if_passed_param_is_wrong_type_using_use_statement.rs",
+    );
+    t.compile_fail("tests/node_attribute/fails_if_unused_context.rs");
+    t.compile_fail("tests/node_attribute/fails_if_unused_context_empty_fnbody.rs");
+    t.compile_fail("tests/node_attribute/fails_if_more_than_one_arg.rs");
 }

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -20,7 +20,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Error, Ident, ItemFn};
+use syn::{self, parse_macro_input, Error, Ident, ItemFn};
 
 /// Marks an async function to be run in an ockam node.
 #[proc_macro_attribute]
@@ -43,6 +43,89 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
         return Error::new_spanned(token, message).to_compile_error().into();
     }
 
+    // Verify the passed function arguments -
+    // the type should be `Context`
+    // Capture the identifier, that we can use later.
+    let ctx_ident: &Ident;
+    let function_arg = &input_function.sig.inputs.first().unwrap();
+    if let syn::FnArg::Typed(syn::PatType {
+        attrs: _,
+        pat,
+        colon_token: _,
+        ty,
+    }) = function_arg
+    {
+        // Verify that we are passed `(ident: Type)` as a parameter.
+        if let syn::Pat::Ident(syn::PatIdent {
+            attrs: _,
+            by_ref: _,
+            mutability: _,
+            ident,
+            subpat: _,
+        }) = &**pat
+        {
+            ctx_ident = ident;
+        } else {
+            let message = format!(
+                "Expected an identifier, found `{}`",
+                quote! {#pat}.to_string()
+            );
+            return Error::new_spanned(pat, message).to_compile_error().into();
+        };
+
+        // Verify that the type is `ockam::Context` (We only verify that the type is `Context`).
+        // If it is some other context, there might be other compiler error, so that's fine.
+        if let syn::Type::Path(syn::TypePath { qself: _, path }) = &**ty {
+            let ident = path.segments.last();
+            if ident.is_none() {
+                let message = "Input argument should be of type `ockam::Context`";
+                return Error::new_spanned(path, message).to_compile_error().into();
+            } else {
+                let type_ident = quote! {#ident}.to_string();
+                if type_ident != "Context" {
+                    let path_ident = quote! {#path}.to_string().replace(' ', "");
+                    let message = format!("Expected `ockam::Context` found `{}`", path_ident);
+                    return Error::new_spanned(path, message).to_compile_error().into();
+                }
+            }
+        }
+
+        // Function body cannot be empty (Special case of unused `context`).
+        if input_function.block.stmts.is_empty() {
+            let fn_ident = input_function.sig.ident;
+            let message = "Function body Cannot be Empty.";
+            return Error::new_spanned(fn_ident, message)
+                .to_compile_error()
+                .into();
+        }
+
+        // Make Sure that the passed Context is used.
+        let mut ctx_used = false;
+        for st in &input_function.block.stmts {
+            let stmt_str = quote! {#st}.to_string().replace(' ', "");
+            if stmt_str.find(&ctx_ident.to_string()).is_some() {
+                ctx_used = true;
+            }
+        }
+        if !ctx_used {
+            let message = format!(
+                "Unused `{}`. Passed `ockam::Context` should be used.",
+                &ctx_ident.to_string()
+            );
+            return Error::new_spanned(ctx_ident, message)
+                .to_compile_error()
+                .into();
+        }
+
+    // Everything is fine if not returned, let it compile! :-)
+    } else {
+        // Passed parameter is a `self`.
+        let message = "Input argument should be of type `ockam::Context`";
+        return Error::new_spanned(function_arg, message)
+            .to_compile_error()
+            .into();
+    };
+
     // Transform the input_function to the output_function:
     // - Rename the user function
     // - Keep the same attributes, ident, inputs and output
@@ -57,8 +140,8 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
         #input_function
 
         fn main() -> ockam::Result<()> {
-            let (context, mut executor) = ockam::start_node();
-            executor.execute(async move { #output_fn_ident(context).await })
+            let (#ctx_ident, mut executor) = ockam::start_node();
+            executor.execute(async move { #output_fn_ident(#ctx_ident).await })
         }
     };
     // Create a token stream of the transformed output_function and return it.


### PR DESCRIPTION

<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes

Following validations are performed on the passed function arguments to `ockam_node_attribute`  -
1. Number of passed arguments is 1.
2. Passed argument is of `ockam::Context` type.
3. Passed argument is used inside the function.

Related issue #793 

<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
