### PR TITLE
chore(rust): change ockam_core error domain to non-static string

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_core/src/error.rs
@@ -1,6 +1,6 @@
 //! Error and Result types
 
-use crate::lib::{fmt::Formatter, Display};
+use crate::lib::{fmt::Formatter, Display, String};
 
 /// The type of errors returned by Ockam functions.
 ///
@@ -25,7 +25,7 @@ pub struct Error {
     code: u32,
 
     #[cfg(feature = "std")]
-    domain: &'static str,
+    domain: String,
 }
 
 /// The type returned by Ockam functions.
@@ -40,14 +40,17 @@ impl Error {
 
     /// Creates a new [`Error`].
     #[cfg(feature = "std")]
-    pub fn new(code: u32, domain: &'static str) -> Self {
-        Self { code, domain }
+    pub fn new<S: Into<String>>(code: u32, domain: S) -> Self {
+        Self {
+            code,
+            domain: domain.into(),
+        }
     }
 
     /// Returns an error's domain.
     #[cfg(feature = "std")]
     #[inline]
-    pub fn domain(&self) -> &'static str {
+    pub fn domain(&self) -> &String {
         &self.domain
     }
 


### PR DESCRIPTION
When sending Error types over the network, `'static` lifetime strings can't be deserialised.  This change is required for the current ockam worker supervisor design.

## Change impact

This change has some obvious implications for `ockam_ffi`, and maybe others.

In `ockam_ffi` the error representation can still hold a `*const c_char`, but it needs to be contstructed differently.  This is done via `std::ffi::Cstring`, which allocates the string in a way that C will understand. Then calling `into_raw()` returns a pointer to the location.

This will leak memory if the C-calling code doesn't `free()` the string!

In `no_std` settings we will need to find a way to do the equivalent thing without the standard allocator.

## Alternatives

I opted to use the `ockam_node::Error` type for the supervisor system because it is immediately available to users, and adds a good mechanism for namespaced error codes.  There are however other approaches that we can take with this design:

### Separate, concrete error type

There can be a special type exposed by `ockam_core` which allows users to fill in their own error data without having to move this requirement to the `ockam_core::Error`.

The main downside to this approach is code duplication. Based on the requirements, this type may end up being a near-identical copy of the `ockam_core::Error` type.


### Associative type

There can be another associated type on the `Worker` trait, meaning that users can make the supervisor error type custom to their workers.

**Cons:**

* Requires _another_ `type Foo = ...` line in the worker definition, which increases general boilerplate, even if they don't use the supervisor feature
* All workers in a system may have to share the same type anyway, because otherwise incompatible error types may be dropped by the supervisors

For `no_std` settings we will have to find a way to do this without relying on the libstd CString type. But I the `heapless` crate we're using probably has some way of handling this too.

---

Anyway, this change doesn't urgently need to land, but it may be worth some thoughts with regards to how to achieve the most flexible design in this domain.