### PR TITLE
chore(rust): context receive returns result

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     FailedListWorker,
     /// Unable to send a message to a worker
     FailedSendMessage,
+    /// Unable to receive the desired piece of data
+    FailedLoadData,
 }
 
 impl Error {


### PR DESCRIPTION
This change improves the context API so that all calls can be used with a `?`, instead of having to unwrap or map errors manually.