### PR TITLE
chore(rust): change node, context, and worker api to be async again

### DIFF
--- a/implementations/rust/examples/node/Cargo.toml
+++ b/implementations/rust/examples/node/Cargo.toml
@@ -15,4 +15,3 @@ ockam_node = {path = "../../ockam/ockam_node", version = "*"}
 # support re-exporting attributes from crates.  Tracking issue:
 # https://github.com/rust-lang/rust/issues/27812
 serde = { version = "1.0", features = ["derive"] }
-async-trait = "0.1"

--- a/implementations/rust/examples/node/examples/create_node_with_macro.rs
+++ b/implementations/rust/examples/node/examples/create_node_with_macro.rs
@@ -1,4 +1,4 @@
 #[ockam::node]
 async fn main(context: ockam::Context) {
-    context.stop().unwrap();
+    context.stop().await.unwrap();
 }

--- a/implementations/rust/examples/node/examples/create_node_without_macro.rs
+++ b/implementations/rust/examples/node/examples/create_node_without_macro.rs
@@ -2,7 +2,7 @@ fn main() {
     let (context, mut executor) = ockam::start_node();
     executor
         .execute(async move {
-            context.stop().unwrap();
+            context.stop().await.unwrap();
         })
         .unwrap();
 }

--- a/implementations/rust/examples/node/examples/create_ping_pong_node.rs
+++ b/implementations/rust/examples/node/examples/create_ping_pong_node.rs
@@ -1,7 +1,6 @@
 //! Spawn to workers that play some ping-pong
 
-use async_trait::async_trait;
-use ockam::{Address, Context, Result, Worker};
+use ockam::{async_worker, Address, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 struct Player {
@@ -29,7 +28,7 @@ enum Action {
     Pong,
 }
 
-#[async_trait]
+#[async_worker]
 impl Worker for Player {
     type Message = Action;
     type Context = Context;

--- a/implementations/rust/examples/worker/Cargo.toml
+++ b/implementations/rust/examples/worker/Cargo.toml
@@ -11,5 +11,4 @@ crate-type = ["rlib"]
 ockam = {path = "../../ockam/ockam", version = "*"}
 ockam_node = {path = "../../ockam/ockam_node", version = "*"}
 serde = { version = "1.0", features = ["derive"] }
-async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/implementations/rust/examples/worker/examples/worker_cancel_reply.rs
+++ b/implementations/rust/examples/worker/examples/worker_cancel_reply.rs
@@ -1,5 +1,4 @@
-use async_trait::async_trait;
-use ockam::{Context, Result, Worker};
+use ockam::{async_worker, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Serialize, Deserialize)]
@@ -11,7 +10,7 @@ enum Message {
 /// This worker requests more data and is very picky about what data it accepts.
 struct Picky;
 
-#[async_trait]
+#[async_worker]
 impl Worker for Picky {
     type Message = Message;
     type Context = Context;
@@ -45,7 +44,7 @@ impl Worker for Picky {
 
 struct Echo;
 
-#[async_trait]
+#[async_worker]
 impl Worker for Echo {
     type Message = Message;
     type Context = Context;

--- a/implementations/rust/examples/worker/examples/worker_get_reply.rs
+++ b/implementations/rust/examples/worker/examples/worker_get_reply.rs
@@ -1,5 +1,4 @@
-use async_trait::async_trait;
-use ockam::{Context, Result, Worker};
+use ockam::{async_worker, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 struct Square;
@@ -7,7 +6,7 @@ struct Square;
 #[derive(Serialize, Deserialize)]
 struct Num(usize);
 
-#[async_trait]
+#[async_worker]
 impl Worker for Square {
     type Message = Num;
     type Context = Context;

--- a/implementations/rust/examples/worker/examples/worker_initialize.rs
+++ b/implementations/rust/examples/worker/examples/worker_initialize.rs
@@ -16,8 +16,8 @@ fn main() {
     let (app, mut exe) = ockam::start_node();
 
     exe.execute(async move {
-        app.start_worker("io.ockam.nothing", Nothing).unwrap();
-        app.stop().unwrap();
+        app.start_worker("io.ockam.nothing", Nothing).await.unwrap();
+        app.stop().await.unwrap();
     })
     .unwrap();
 }

--- a/implementations/rust/examples/worker/examples/worker_ring_benchmark.rs
+++ b/implementations/rust/examples/worker/examples/worker_ring_benchmark.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use ockam::{Address, Context, Result, Worker};
+use ockam::{async_worker, Address, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -10,7 +10,7 @@ struct RingWorker {
     next: Option<Address>,
 }
 
-#[async_trait::async_trait]
+#[async_worker]
 impl Worker for RingWorker {
     type Context = Context;
     type Message = RingMessage;

--- a/implementations/rust/examples/worker/examples/worker_send_message.rs
+++ b/implementations/rust/examples/worker/examples/worker_send_message.rs
@@ -1,5 +1,4 @@
-use async_trait::async_trait;
-use ockam::{Context, Result, Worker};
+use ockam::{async_worker, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 struct Printer;
@@ -8,7 +7,7 @@ struct Printer;
 #[derive(Debug, Serialize, Deserialize)]
 struct PrintMessage(String);
 
-#[async_trait]
+#[async_worker]
 impl Worker for Printer {
     type Message = PrintMessage;
     type Context = Context;

--- a/implementations/rust/examples/worker/examples/worker_send_message.rs
+++ b/implementations/rust/examples/worker/examples/worker_send_message.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use ockam::{Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
@@ -7,6 +8,7 @@ struct Printer;
 #[derive(Debug, Serialize, Deserialize)]
 struct PrintMessage(String);
 
+#[async_trait]
 impl Worker for Printer {
     type Message = PrintMessage;
     type Context = Context;
@@ -16,7 +18,7 @@ impl Worker for Printer {
         Ok(())
     }
 
-    fn handle_message(&mut self, _context: &mut Context, msg: PrintMessage) -> Result<()> {
+    async fn handle_message(&mut self, _context: &mut Context, msg: PrintMessage) -> Result<()> {
         println!("[PRINTER]: {}", msg.0);
         Ok(())
     }
@@ -26,10 +28,13 @@ fn main() {
     let (app, mut exe) = ockam::start_node();
 
     exe.execute(async move {
-        app.start_worker("io.ockam.printer", Printer {}).unwrap();
-        app.send_message("io.ockam.printer", PrintMessage("Hello, ockam!".into()))
+        app.start_worker("io.ockam.printer", Printer {})
+            .await
             .unwrap();
-        app.stop().unwrap();
+        app.send_message("io.ockam.printer", PrintMessage("Hello, ockam!".into()))
+            .await
+            .unwrap();
+        app.stop().await.unwrap();
     })
     .unwrap();
 }

--- a/implementations/rust/examples/worker/examples/worker_stateful.rs
+++ b/implementations/rust/examples/worker/examples/worker_stateful.rs
@@ -1,5 +1,4 @@
-use async_trait::async_trait;
-use ockam::{Context, Result, Worker};
+use ockam::{async_worker, Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
 struct StatefulWorker {
@@ -9,7 +8,7 @@ struct StatefulWorker {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Message(usize);
 
-#[async_trait]
+#[async_worker]
 impl Worker for StatefulWorker {
     type Context = Context;
     type Message = Message;

--- a/implementations/rust/examples/worker/examples/worker_stateful.rs
+++ b/implementations/rust/examples/worker/examples/worker_stateful.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use ockam::{Context, Result, Worker};
 use serde::{Deserialize, Serialize};
 
@@ -8,35 +9,31 @@ struct StatefulWorker {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct Message(usize);
 
+#[async_trait]
 impl Worker for StatefulWorker {
     type Context = Context;
     type Message = Message;
 
-    fn handle_message(&mut self, ctx: &mut Context, msg: Message) -> Result<()> {
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Message) -> Result<()> {
         self.inner += msg.0;
-        ctx.send_message("app", Message(self.inner)).unwrap();
+        ctx.send_message("app", Message(self.inner)).await?;
         Ok(())
     }
 }
 
 #[ockam::node]
-async fn main(mut context: Context) {
-    context
-        .start_worker("io.ockam.state", StatefulWorker { inner: 0 })
-        .unwrap();
+async fn main(mut ctx: Context) -> Result<()> {
+    ctx.start_worker("io.ockam.state", StatefulWorker { inner: 0 })
+        .await?;
 
-    context
-        .send_message("io.ockam.state", Message(1024))
-        .unwrap();
-    context
-        .send_message("io.ockam.state", Message(256))
-        .unwrap();
-    context.send_message("io.ockam.state", Message(32)).unwrap();
+    ctx.send_message("io.ockam.state", Message(1024)).await?;
+    ctx.send_message("io.ockam.state", Message(256)).await?;
+    ctx.send_message("io.ockam.state", Message(32)).await?;
 
-    assert_eq!(context.receive::<Message>().unwrap(), Message(1024));
-    assert_eq!(context.receive::<Message>().unwrap(), Message(1280));
-    assert_eq!(context.receive::<Message>().unwrap(), Message(1312));
+    assert_eq!(ctx.receive::<Message>().await?, Message(1024));
+    assert_eq!(ctx.receive::<Message>().await?, Message(1280));
+    assert_eq!(ctx.receive::<Message>().await?, Message(1312));
 
     println!("Received expected worker state");
-    context.stop().unwrap();
+    ctx.stop().await
 }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -38,6 +38,7 @@ serde_bare = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde-big-array = "0.3"
 sha2 = { version = "0.8", optional = true }
+async-trait = "0.1"
 
 [dev-dependencies]
 trybuild = {version = "1.0.41", features = ["diff"]}

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -31,4 +31,5 @@ mod lease;
 pub use credential::*;
 pub use lease::*;
 
+pub use async_trait::async_trait as async_worker;
 pub use ockam_core::{Address, Encoded, Error, Message, Result, Worker};

--- a/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn.rs
@@ -1,4 +1,4 @@
 #[ockam::node]
 async fn foo(c: ockam::Context) {
-    c.stop().unwrap();
+    c.stop().await.unwrap();
 }

--- a/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn_ockam_use_as_o.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_any_fn_ockam_use_as_o.rs
@@ -3,5 +3,5 @@ use ockam::{self as o};
 
 #[ockam::node]
 async fn foo(c: o::Context) {
-    c.stop().unwrap();
+    c.stop().await.unwrap();
 }

--- a/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_main.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/can_be_used_on_main.rs
@@ -3,5 +3,5 @@
 
 #[ockam::node]
 async fn main(context: ockam::Context) {
-    context.stop().unwrap();
+    context.stop().await.unwrap();
 }

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.rs
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.rs
@@ -2,5 +2,5 @@
 //
 #[ockam::node]
 async fn foo(c: ockam::Context, _x: u64) {
-    c.stop().unwrap();
+    c.stop().await.unwrap();
 }

--- a/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.stderr
+++ b/implementations/rust/ockam/ockam/tests/node_attribute/fails_if_more_than_one_arg.stderr
@@ -9,6 +9,6 @@ error[E0601]: `main` function not found in crate `$CRATE`
   |
 3 | / #[ockam::node]
 4 | | async fn foo(c: ockam::Context, _x: u64) {
-5 | |     c.stop().unwrap();
+5 | |     c.stop().await.unwrap();
 6 | | }
   | |_^ consider adding a `main` function to `$DIR/tests/node_attribute/fails_if_more_than_one_arg.rs`

--- a/implementations/rust/ockam/ockam_core/src/worker.rs
+++ b/implementations/rust/ockam/ockam_core/src/worker.rs
@@ -1,6 +1,8 @@
-use crate::{Message, Result};
+use crate::{lib::Box, Message, Result};
+use async_trait::async_trait;
 
 /// Base ockam worker trait.
+#[async_trait]
 pub trait Worker: Send + 'static {
     type Message: Message;
     type Context: Send + 'static;
@@ -16,7 +18,11 @@ pub trait Worker: Send + 'static {
     }
 
     /// Try to open and handle a typed message
-    fn handle_message(&mut self, _context: &mut Self::Context, _msg: Self::Message) -> Result<()> {
+    async fn handle_message(
+        &mut self,
+        _context: &mut Self::Context,
+        _msg: Self::Message,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,4 +1,4 @@
-use crate::{block_future, error::Error, relay, Cancel, Mailbox, NodeMessage, NodeReply};
+use crate::{error::Error, relay, Cancel, Mailbox, NodeMessage, NodeReply};
 use ockam_core::{Address, Message, Result, Worker};
 use std::sync::Arc;
 use tokio::{
@@ -33,81 +33,70 @@ impl Context {
     }
 
     /// Start a new worker handle at [`Address`](ockam_core::Address)
-    pub fn start_worker<NM, NW, S>(&self, address: S, worker: NW) -> Result<()>
+    pub async fn start_worker<NM, NW, S>(&self, address: S, worker: NW) -> Result<()>
     where
         S: Into<Address>,
         NM: Message + Send + 'static,
         NW: Worker<Context = Context, Message = NM>,
     {
-        let tx = self.sender.clone();
-        let rt = self.rt.clone();
         let address = address.into();
 
-        // Wait for a worker to have started to avoid data races when
-        // sending messages to it in subsequent api calls
-        block_future(&self.rt, async move {
-            // Build the mailbox first
-            let (mb_tx, mb_rx) = channel(32);
-            let mb = Mailbox::new(mb_rx, mb_tx.clone());
+        // Build the mailbox first
+        let (mb_tx, mb_rx) = channel(32);
+        let mb = Mailbox::new(mb_rx, mb_tx.clone());
 
-            // Pass it to the context
-            let ctx = Context::new(rt.clone(), tx.clone(), address.clone(), mb);
+        // Pass it to the context
+        let ctx = Context::new(self.rt.clone(), self.sender.clone(), address.clone(), mb);
 
-            // Then initialise the worker message relay
-            let sender = relay::build::<NW, NM>(rt.as_ref(), worker, ctx);
+        // Then initialise the worker message relay
+        let sender = relay::build::<NW, NM>(self.rt.as_ref(), worker, ctx);
 
-            let msg = NodeMessage::start_worker(address, sender);
-            let _result: Result<()> = match tx.send(msg).await {
-                Ok(()) => Ok(()),
-                Err(_e) => Err(Error::FailedStartWorker.into()),
-            };
-        });
+        let msg = NodeMessage::start_worker(address, sender);
+        let _result: Result<()> = match self.sender.send(msg).await {
+            Ok(()) => Ok(()),
+            Err(_e) => Err(Error::FailedStartWorker.into()),
+        };
 
         Ok(())
     }
 
     /// Signal to the local application runner to shut down
-    pub fn stop(&self) -> Result<()> {
+    pub async fn stop(&self) -> Result<()> {
         let tx = self.sender.clone();
-        tokio::spawn(async move {
-            println!("App: shutting down all workers");
-            let _result: Result<()> = match tx.send(NodeMessage::StopNode).await {
-                Ok(()) => Ok(()),
-                Err(_e) => Err(Error::FailedStopNode.into()),
-            };
-        });
+        println!("App: shutting down all workers");
+        let _result: Result<()> = match tx.send(NodeMessage::StopNode).await {
+            Ok(()) => Ok(()),
+            Err(_e) => Err(Error::FailedStopNode.into()),
+        };
 
         Ok(())
     }
 
     /// Send a message to a particular worker
-    pub fn send_message<S, M>(&self, address: S, msg: M) -> Result<()>
+    pub async fn send_message<S, M>(&self, address: S, msg: M) -> Result<()>
     where
         S: Into<Address>,
         M: Message + Send + 'static,
     {
         let address = address.into();
-        let tx = self.sender.clone();
-        block_future(&self.rt, async move {
-            let (reply_tx, mut reply_rx) = channel(1);
-            let req = NodeMessage::SenderReq(address, reply_tx);
+        let (reply_tx, mut reply_rx) = channel(1);
+        let req = NodeMessage::SenderReq(address, reply_tx);
 
-            // FIXME/ DESIGN: error communication concept
-            let _result: Result<()> = match tx.send(req).await {
-                Ok(()) => {
-                    if let Some(NodeReply::Sender(_, s)) = reply_rx.recv().await {
-                        let msg = msg.encode().unwrap();
-                        match s.send(msg).await {
-                            Ok(()) => Ok(()),
-                            Err(_e) => Err(Error::FailedSendMessage.into()),
-                        }
-                    } else {
-                        Err(Error::FailedSendMessage.into())
+        // FIXME/ DESIGN: error communication concept
+        let _result: Result<()> = match self.sender.send(req).await {
+            Ok(()) => {
+                if let Some(NodeReply::Sender(_, s)) = reply_rx.recv().await {
+                    let msg = msg.encode().unwrap();
+                    match s.send(msg).await {
+                        Ok(()) => Ok(()),
+                        Err(_e) => Err(Error::FailedSendMessage.into()),
                     }
+                } else {
+                    Err(Error::FailedSendMessage.into())
                 }
-                Err(_e) => Err(Error::FailedSendMessage.into()),
-            };
-        });
+            }
+            Err(_e) => Err(Error::FailedSendMessage.into()),
+        };
 
         Ok(())
     }
@@ -116,33 +105,28 @@ impl Context {
     ///
     /// Will return `None` if the corresponding worker has been
     /// stopped, or the underlying Node has shut down.
-    pub fn receive<'ctx, M: Message>(&'ctx mut self) -> Result<Cancel<'ctx, M>> {
-        let mb = &mut self.mailbox;
-
-        block_future(&self.rt, async {
-            mb.next().await.and_then(|enc| M::decode(&enc).ok())
-        })
-        .map(move |msg| Cancel::new(msg, self.rt.clone(), self))
-        .ok_or_else(|| Error::FailedLoadData.into())
+    pub async fn receive<'ctx, M: Message>(&'ctx mut self) -> Result<Cancel<'ctx, M>> {
+        self.mailbox
+            .next()
+            .await
+            .and_then(|e| M::decode(&e).ok())
+            .map(move |msg| Cancel::new(msg, self))
+            .ok_or_else(|| Error::FailedLoadData.into())
     }
 
     /// Return a list of all available worker addresses on a node
-    pub fn list_workers(&self) -> Result<Vec<Address>> {
-        let tx = self.sender.clone();
+    pub async fn list_workers(&self) -> Result<Vec<Address>> {
+        let (msg, mut reply_rx) = NodeMessage::list_workers();
 
-        block_future(&self.rt, async move {
-            let (msg, mut reply_rx) = NodeMessage::list_workers();
-
-            match tx.send(msg).await {
-                Ok(()) => {
-                    if let Some(NodeReply::Workers(list)) = reply_rx.recv().await {
-                        Ok(list)
-                    } else {
-                        Ok(vec![])
-                    }
+        match self.sender.send(msg).await {
+            Ok(()) => {
+                if let Some(NodeReply::Workers(list)) = reply_rx.recv().await {
+                    Ok(list)
+                } else {
+                    Ok(vec![])
                 }
-                Err(_e) => Err(Error::FailedListWorker.into()),
             }
-        })
+            Err(_e) => Err(Error::FailedListWorker.into()),
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -23,22 +23,3 @@ pub use mailbox::*;
 pub use messages::*;
 
 pub use node::start_node;
-
-use std::future::Future;
-use tokio::{runtime::Runtime, task};
-
-/// Execute a future without blocking the executor
-///
-/// This is a wrapper around two simple tokio functions to allow
-/// ockam_node to wait for a task to be completed in a non-async
-/// environment.
-pub(crate) fn block_future<'r, F>(rt: &'r Runtime, f: F) -> <F as Future>::Output
-where
-    F: Future + Send,
-    F::Output: Send,
-{
-    task::block_in_place(move || {
-        let local = task::LocalSet::new();
-        local.block_on(&rt, f)
-    })
-}

--- a/implementations/rust/ockam/ockam_node/src/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay.rs
@@ -55,7 +55,10 @@ where
                 Err(_) => continue,
             };
 
-            self.worker.handle_message(&mut self.ctx, msg).unwrap();
+            self.worker
+                .handle_message(&mut self.ctx, msg)
+                .await
+                .unwrap();
         }
 
         self.worker.shutdown(&mut self.ctx).unwrap();


### PR DESCRIPTION
This PR changes the context API and worker traits to be async again, and updates all examples to use this API.