### PR TITLE
feat(rust): support multiple addresses per worker

### DIFF
--- a/implementations/rust/examples/worker/examples/worker_multi_address.rs
+++ b/implementations/rust/examples/worker/examples/worker_multi_address.rs
@@ -1,0 +1,34 @@
+use ockam::{async_worker, Context, Result, Worker};
+
+struct MultiAddressWorker;
+
+#[async_worker]
+impl Worker for MultiAddressWorker {
+    type Message = String;
+    type Context = Context;
+
+    async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
+        println!("Worker main address: '{}'", ctx.address());
+        Ok(())
+    }
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: String) -> Result<()> {
+        println!("Addr '{}' received: '{}'", ctx.address(), msg);
+        Ok(())
+    }
+}
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    ctx.start_worker(
+        vec!["addr.main", "addr.input", "addr.output"],
+        MultiAddressWorker,
+    )
+    .await?;
+
+    ctx.send_message("addr.main", String::from("Hi")).await?;
+    ctx.send_message("addr.input", String::from("Hi")).await?;
+    ctx.send_message("addr.output", String::from("Hi")).await?;
+
+    ctx.stop().await
+}

--- a/implementations/rust/ockam/ockam_core/src/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/address.rs
@@ -1,9 +1,48 @@
 use crate::lib::{
     fmt::{self, Display},
+    iter::Iterator,
     String, Vec,
 };
 use core::ops::Deref;
 use serde::{Deserialize, Serialize};
+
+/// A collection of Addresses
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AddressSet(Vec<Address>);
+
+impl AddressSet {
+    pub fn iter(&self) -> impl Iterator<Item = &Address> {
+        self.0.iter()
+    }
+
+    pub fn first(&self) -> Address {
+        self.0.first().cloned().unwrap()
+    }
+}
+
+impl<T: Into<Address>> From<Vec<T>> for AddressSet {
+    fn from(v: Vec<T>) -> Self {
+        Self(v.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<Address> for AddressSet {
+    fn from(a: Address) -> Self {
+        Self(vec![a])
+    }
+}
+
+impl<'a> From<&'a Address> for AddressSet {
+    fn from(a: &'a Address) -> Self {
+        Self(vec![a.clone()])
+    }
+}
+
+impl<'a> From<&'a str> for AddressSet {
+    fn from(a: &'a str) -> Self {
+        Self(vec![a.into()])
+    }
+}
 
 #[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Address(Vec<u8>);

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,5 +1,9 @@
-use crate::{error::Error, relay, Cancel, Mailbox, NodeMessage, NodeReply};
-use ockam_core::{Address, Message, Result, Worker};
+use crate::{
+    error::Error,
+    relay::{self, RelayMessage},
+    Cancel, Mailbox, NodeMessage, NodeReply,
+};
+use ockam_core::{Address, AddressSet, Message, Result, Worker};
 use std::sync::Arc;
 use tokio::{
     runtime::Runtime,
@@ -7,7 +11,8 @@ use tokio::{
 };
 
 pub struct Context {
-    address: Address,
+    address: AddressSet,
+    msg_addr: Option<Address>,
     sender: Sender<NodeMessage>,
     rt: Arc<Runtime>,
     pub(crate) mailbox: Mailbox,
@@ -17,25 +22,39 @@ impl Context {
     pub(crate) fn new(
         rt: Arc<Runtime>,
         sender: Sender<NodeMessage>,
-        address: Address,
+        address: AddressSet,
         mailbox: Mailbox,
     ) -> Self {
         Self {
             rt,
             sender,
             address,
+            msg_addr: None,
             mailbox,
         }
     }
 
+    /// Override the worker address for a specific message address
+    pub(crate) fn message_address<A: Into<Option<Address>>>(&mut self, a: A) {
+        self.msg_addr = a.into();
+    }
+
+    /// Return the current context address
+    ///
+    /// During initialisation and shutdown this will return the
+    /// primary worker address.  During message handling it will
+    /// return the address the message was addressed to.
     pub fn address(&self) -> Address {
-        self.address.clone()
+        self.msg_addr
+            .clone()
+            .or(Some(self.address.first().clone()))
+            .unwrap()
     }
 
     /// Start a new worker handle at [`Address`](ockam_core::Address)
     pub async fn start_worker<NM, NW, S>(&self, address: S, worker: NW) -> Result<()>
     where
-        S: Into<Address>,
+        S: Into<AddressSet>,
         NM: Message + Send + 'static,
         NW: Worker<Context = Context, Message = NM>,
     {
@@ -80,13 +99,13 @@ impl Context {
     {
         let address = address.into();
         let (reply_tx, mut reply_rx) = channel(1);
-        let req = NodeMessage::SenderReq(address, reply_tx);
+        let req = NodeMessage::SenderReq(address.clone(), reply_tx);
 
         match self.sender.send(req).await {
             Ok(()) => {
                 if let Some(NodeReply::Sender(_, s)) = reply_rx.recv().await {
                     let msg = msg.encode().unwrap();
-                    match s.send(msg).await {
+                    match s.send(RelayMessage::new(address, msg)).await {
                         Ok(()) => Ok(()),
                         Err(_e) => Err(Error::FailedSendMessage.into()),
                     }
@@ -106,8 +125,10 @@ impl Context {
         self.mailbox
             .next()
             .await
-            .and_then(|e| M::decode(&e).ok())
-            .map(move |msg| Cancel::new(msg, self))
+            .and_then(|RelayMessage { addr, data }| {
+                M::decode(&data).ok().map(move |msg| (msg, addr))
+            })
+            .map(move |(msg, addr)| Cancel::new(msg, addr, self))
             .ok_or_else(|| Error::FailedLoadData.into())
     }
 

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -1,12 +1,12 @@
 use crate::relay::RelayMessage;
-use ockam_core::Address;
+use ockam_core::{Address, AddressSet};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// Messages sent from the Node to the Executor
 #[derive(Debug)]
 pub enum NodeMessage {
     /// Start a new worker and store the send handle
-    StartWorker(Address, Sender<RelayMessage>),
+    StartWorker(AddressSet, Sender<RelayMessage>),
     /// Return a list of all worker addresses
     ListWorkers(Sender<NodeReply>),
     /// Stop an existing worker
@@ -19,7 +19,7 @@ pub enum NodeMessage {
 
 impl NodeMessage {
     /// Create a start worker message
-    pub fn start_worker(address: Address, sender: Sender<RelayMessage>) -> Self {
+    pub fn start_worker(address: AddressSet, sender: Sender<RelayMessage>) -> Self {
         Self::StartWorker(address, sender)
     }
 

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -31,6 +31,6 @@ pub fn start_node() -> (Context, Executor) {
 fn root_app_context(rt: Arc<Runtime>, addr: &Address, tx: Sender<NodeMessage>) -> Context {
     let (mb_tx, mb_rx) = channel(32);
     let mb = Mailbox::new(mb_rx, mb_tx.clone());
-    let ctx = Context::new(rt, tx, addr.clone(), mb);
+    let ctx = Context::new(rt, tx, addr.into(), mb);
     ctx
 }


### PR DESCRIPTION
### Proposed Changes

* Each worker has a primary address (the first one)
* Only primary addresses can shut down the worker
* Message handle provides address of the message