### PR TITLE
chore(rust): change worker initialize to be async

### DIFF
--- a/implementations/rust/examples/node/examples/create_ping_pong_node.rs
+++ b/implementations/rust/examples/node/examples/create_ping_pong_node.rs
@@ -33,7 +33,7 @@ impl Worker for Player {
     type Message = Action;
     type Context = Context;
 
-    fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
+    async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
         println!("Starting player {}", ctx.address());
         Ok(())
     }

--- a/implementations/rust/examples/worker/examples/worker_initialize.rs
+++ b/implementations/rust/examples/worker/examples/worker_initialize.rs
@@ -1,12 +1,13 @@
-use ockam::{Context, Result, Worker};
+use ockam::{async_worker, Context, Result, Worker};
 
 struct Nothing;
 
+#[async_worker]
 impl Worker for Nothing {
     type Message = ();
     type Context = Context;
 
-    fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
+    async fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
         println!("Worker that does nothing is starting");
         Ok(())
     }

--- a/implementations/rust/examples/worker/examples/worker_send_message.rs
+++ b/implementations/rust/examples/worker/examples/worker_send_message.rs
@@ -12,7 +12,7 @@ impl Worker for Printer {
     type Message = PrintMessage;
     type Context = Context;
 
-    fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
+    async fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
         println!("[PRINTER]: starting");
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_core/src/worker.rs
+++ b/implementations/rust/ockam/ockam_core/src/worker.rs
@@ -8,7 +8,7 @@ pub trait Worker: Send + 'static {
     type Context: Send + 'static;
 
     /// Override initialisation behaviour
-    fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
+    async fn initialize(&mut self, _context: &mut Self::Context) -> Result<()> {
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_node/src/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay.rs
@@ -47,7 +47,7 @@ where
     }
 
     async fn run(mut self) {
-        self.worker.initialize(&mut self.ctx).unwrap();
+        self.worker.initialize(&mut self.ctx).await.unwrap();
 
         while let Some(ref enc) = self.ctx.mailbox.next().await {
             let msg = match M::decode(enc) {


### PR DESCRIPTION
Change the worker initialisation to use an async function.