### PR TITLE
chore(elixir): bump test duration to see if ci is really that slow

### DIFF
--- a/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
@@ -43,7 +43,7 @@ defmodule Ockam.Router.Tests do
 
       Ockam.Router.route(message)
 
-      assert_receive({:trace, ^printer, :receive, result}, 1_000)
+      assert_receive({:trace, ^printer, :receive, result}, 5_000)
 
       assert result == %{
                version: 1,
@@ -73,7 +73,7 @@ defmodule Ockam.Router.Tests do
 
       Ockam.Router.route(message)
 
-      assert_receive({:trace, ^printer, :receive, result}, 1_000)
+      assert_receive({:trace, ^printer, :receive, result}, 5_000)
 
       assert %{
                version: 1,


### PR DESCRIPTION
Bump the timeout for assert_receive() again to see if it solves an intermittent CI failure.  Why is talking to localhost so slow on CI??