### PR TITLE
chore: upgrade and move hex dependency to ockam_core

### DIFF
--- a/implementations/rust/examples/node/Cargo.lock
+++ b/implementations/rust/examples/node/Cargo.lock
@@ -71,9 +71,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "arrayref"
@@ -471,7 +476,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -492,9 +508,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
  "ahash",
  "serde",
@@ -699,15 +715,13 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrayref",
  "async-trait",
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hashbrown",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -727,15 +741,15 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
 [[package]]
 name = "ockam_node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
- "hashbrown",
  "ockam_core",
  "tokio",
 ]
@@ -756,8 +770,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hashbrown",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",
@@ -894,7 +906,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core 0.5.1",
@@ -932,7 +944,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1118,9 +1130,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1141,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1203,6 +1215,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/implementations/rust/examples/tcp/Cargo.lock
+++ b/implementations/rust/examples/tcp/Cargo.lock
@@ -71,9 +71,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "arrayref"
@@ -557,7 +562,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -578,9 +594,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
  "ahash",
  "serde",
@@ -815,8 +831,6 @@ dependencies = [
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hashbrown",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -836,6 +850,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -844,7 +859,6 @@ name = "ockam_node"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "hashbrown",
  "ockam_core",
  "tokio",
 ]
@@ -862,8 +876,6 @@ name = "ockam_router"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "hashbrown",
- "hex",
  "ockam",
  "ockam_core",
  "ockam_node",
@@ -880,7 +892,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
- "hashbrown",
  "ockam",
  "ockam_core",
  "ockam_router",
@@ -898,8 +909,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hashbrown",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",
@@ -1060,7 +1069,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core 0.5.1",
@@ -1098,7 +1107,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1307,9 +1316,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1359,9 +1368,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1451,6 +1460,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/implementations/rust/examples/worker/Cargo.lock
+++ b/implementations/rust/examples/worker/Cargo.lock
@@ -71,9 +71,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "arrayref"
@@ -474,6 +479,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,9 +507,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
  "ahash",
  "serde",
@@ -698,15 +714,13 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrayref",
  "async-trait",
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hashbrown",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -726,15 +740,15 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
 [[package]]
 name = "ockam_node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
- "hashbrown",
  "ockam_core",
  "tokio",
 ]
@@ -755,8 +769,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hashbrown",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",
@@ -867,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -893,7 +905,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core 0.5.1",
@@ -931,7 +943,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1114,9 +1126,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1148,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -773,7 +773,6 @@ dependencies = [
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -797,6 +796,7 @@ dependencies = [
  "bincode",
  "hashbrown",
  "heapless",
+ "hex",
  "serde",
 ]
 
@@ -825,7 +825,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -31,7 +31,6 @@ ockam_node_attribute = {path = "../ockam_node_attribute", version = "0.1.4"}
 ockam_vault_core = {path = "../ockam_vault_core", version = "0.3.0"}
 ockam_vault = {path = "../ockam_vault", version = "0.3.0"}
 arrayref = "0.3"
-hex = "0.4"
 pairing-plus = { version = "0.19", optional = true }
 serde_bare = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }

--- a/implementations/rust/ockam/ockam/src/profile/identifiers.rs
+++ b/implementations/rust/ockam/ockam/src/profile/identifiers.rs
@@ -1,3 +1,4 @@
+use ockam_core::hex::encode;
 use ockam_vault_core::KeyId;
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +33,7 @@ impl EventIdentifier {
     }
     /// Human-readable form of the id
     pub fn to_string_representation(&self) -> String {
-        format!("E_ID.{}", hex::encode(&self.0))
+        format!("E_ID.{}", encode(&self.0))
     }
 }
 

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "libc"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +146,7 @@ dependencies = [
  "bincode",
  "hashbrown",
  "heapless",
+ "hex",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 default = ["std"]
 
 # Requires the Rust Standard Library.
-std = ["bincode", "serde", "async-trait"]
+std = ["bincode", "serde", "async-trait", "hex/std"]
 
 # Requires the Rust alloc library
 alloc = []
@@ -34,4 +34,5 @@ async-trait =  { version = "0.1.42", optional = true }
 bincode = { version =  "1.3", optional = true }
 hashbrown =  { version = "0.11", features = ["serde"]}
 heapless = { version = "0.6", optional = true }
+hex = { version = "0.4", default-features = false }
 serde =  { version = "1.0", features = ["derive"], optional = true }

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -27,6 +27,10 @@ extern crate std;
 
 pub extern crate hashbrown;
 
+#[allow(unused_imports)]
+#[macro_use]
+pub extern crate hex;
+
 mod address;
 mod error;
 mod message;

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -71,9 +71,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ansi_term"
@@ -529,6 +534,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,9 +562,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
  "ahash",
  "serde",
@@ -773,15 +789,13 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrayref",
  "async-trait",
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hashbrown",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -801,6 +815,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -810,8 +825,8 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
- "hex",
  "ockam",
+ "ockam_core",
  "ockam_node",
  "serde",
  "serde-big-array",
@@ -824,7 +839,6 @@ name = "ockam_node"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "hashbrown",
  "ockam_core",
  "tokio",
 ]
@@ -845,8 +859,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hashbrown",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",
@@ -1007,7 +1019,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core 0.5.1",
@@ -1045,7 +1057,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1273,9 +1285,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1316,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",

--- a/implementations/rust/ockam/ockam_examples/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 
 [dependencies]
 ockam = { path = "../ockam", version = "0" }
+ockam_core = { path = "../ockam_core", version = "0" }
 ockam_node = { path = "../ockam_node", version = "0" }
 async-trait = "0"
 chrono = { version = "0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_bare = "0"
 serde-big-array = "0"
-hex = "0.4"
 structopt = "0.3"
 
 [[bin]]

--- a/implementations/rust/ockam/ockam_examples/src/issuer.rs
+++ b/implementations/rust/ockam/ockam_examples/src/issuer.rs
@@ -1,6 +1,7 @@
 mod util;
 
 use ockam::{CredentialAttribute, CredentialIssuer};
+use ockam_core::hex::decode;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::io::Write;
@@ -32,7 +33,7 @@ fn main() {
         CredentialIssuer::new()
     } else {
         let sk = <[u8; 32]>::try_from(
-            hex::decode(args.secret_key.as_ref().unwrap())
+            decode(args.secret_key.as_ref().unwrap())
                 .unwrap()
                 .as_slice(),
         )

--- a/implementations/rust/ockam/ockam_examples/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_examples/src/verifier.rs
@@ -1,6 +1,7 @@
 mod util;
 
 use ockam::{CredentialVerifier, PresentationManifest};
+use ockam_core::hex::decode;
 use std::{
     convert::TryFrom,
     path::PathBuf,
@@ -25,7 +26,7 @@ fn main() {
 
     // TODO: retrieve public key from published location
     // Placeholder for now
-    let pk = <[u8; 96]>::try_from(hex::decode(args.issuer_pk).unwrap()).unwrap();
+    let pk = <[u8; 96]>::try_from(decode(args.issuer_pk).unwrap()).unwrap();
 
     // Use credential to prove to service
     // The manifest is common to everyone so it can be

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -316,7 +317,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "libc"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +84,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -306,7 +307,6 @@ name = "ockam_key_exchange_x3dh"
 version = "0.1.0"
 dependencies = [
  "arrayref",
- "hex",
  "ockam_core",
  "ockam_key_exchange_core",
  "ockam_vault",
@@ -323,7 +323,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -17,7 +17,6 @@ ockam_core = { version = "0.5.0", path = "../ockam_core" }
 ockam_vault_core = { version = "0.3.0", path = "../ockam_vault_core" }
 ockam_key_exchange_core = { version = "0.1.0", path = "../ockam_key_exchange_core" }
 arrayref = "0.3"
-hex = "0.4"
 subtle = "2.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -1,4 +1,5 @@
 use arrayref::array_ref;
+use ockam_core::hex::encode;
 use ockam_core::lib::convert::TryFrom;
 use ockam_vault_core::{
     AsymmetricVault, Hasher, PublicKey, SecretVault, Signer, SymmetricVault, Verifier,
@@ -39,7 +40,7 @@ impl From<&[u8; 64]> for Signature {
 
 impl std::fmt::Debug for Signature {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Signature {{ {} }}", hex::encode(self.0.as_ref()))
+        write!(f, "Signature {{ {} }}", encode(self.0.as_ref()))
     }
 }
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -305,7 +306,6 @@ dependencies = [
 name = "ockam_key_exchange_xx"
 version = "0.1.0"
 dependencies = [
- "hex",
  "ockam_core",
  "ockam_key_exchange_core",
  "ockam_vault",
@@ -321,7 +321,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -20,4 +20,3 @@ zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ockam_vault = { version = "0.3.0", path = "../ockam_vault" }
-hex = "0.4"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
@@ -527,6 +527,7 @@ impl State {
 mod tests {
     use crate::state::{DhState, State};
     use crate::{Initiator, Responder, XXVault};
+    use ockam_core::hex::{decode, encode};
     use ockam_key_exchange_core::KeyExchanger;
     use ockam_vault::SoftwareVault;
     use ockam_vault_core::{
@@ -604,25 +605,25 @@ mod tests {
         // let mut initiator = Initiator::new(ss_init);
         // let mut responder = Responder::new(ss_resp);
 
-        let res = initiator.encode_message_1(hex::decode(msg_1_payload).unwrap());
+        let res = initiator.encode_message_1(decode(msg_1_payload).unwrap());
         assert!(res.is_ok());
         let msg1 = res.unwrap();
-        assert_eq!(hex::encode(&msg1), msg_1_ciphertext);
+        assert_eq!(encode(&msg1), msg_1_ciphertext);
 
         let res = responder.decode_message_1(msg1);
         assert!(res.is_ok());
 
-        let res = responder.encode_message_2(hex::decode(msg_2_payload).unwrap());
+        let res = responder.encode_message_2(decode(msg_2_payload).unwrap());
         assert!(res.is_ok());
         let msg2 = res.unwrap();
-        assert_eq!(hex::encode(&msg2), msg_2_ciphertext);
+        assert_eq!(encode(&msg2), msg_2_ciphertext);
 
         let res = initiator.decode_message_2(msg2);
         assert!(res.is_ok());
-        let res = initiator.encode_message_3(hex::decode(msg_3_payload).unwrap());
+        let res = initiator.encode_message_3(decode(msg_3_payload).unwrap());
         assert!(res.is_ok());
         let msg3 = res.unwrap();
-        assert_eq!(hex::encode(&msg3), msg_3_ciphertext);
+        assert_eq!(encode(&msg3), msg_3_ciphertext);
 
         let res = responder.decode_message_3(msg3);
         assert!(res.is_ok());
@@ -690,24 +691,24 @@ mod tests {
 
         let res = responder.process(&[]);
         assert!(res.is_err());
-        let res = initiator.process(&hex::decode(MSG_1_PAYLOAD).unwrap());
+        let res = initiator.process(&decode(MSG_1_PAYLOAD).unwrap());
         assert!(res.is_ok());
         let msg1 = res.unwrap();
-        assert_eq!(hex::encode(&msg1), MSG_1_CIPHERTEXT);
+        assert_eq!(encode(&msg1), MSG_1_CIPHERTEXT);
 
         let res = responder.process(&msg1);
         assert!(res.is_ok());
-        let res = responder.process(&hex::decode(MSG_2_PAYLOAD).unwrap());
+        let res = responder.process(&decode(MSG_2_PAYLOAD).unwrap());
         assert!(res.is_ok());
         let msg2 = res.unwrap();
-        assert_eq!(hex::encode(&msg2), MSG_2_CIPHERTEXT);
+        assert_eq!(encode(&msg2), MSG_2_CIPHERTEXT);
 
         let res = initiator.process(&msg2);
         assert!(res.is_ok());
-        let res = initiator.process(&hex::decode(MSG_3_PAYLOAD).unwrap());
+        let res = initiator.process(&decode(MSG_3_PAYLOAD).unwrap());
         assert!(res.is_ok());
         let msg3 = res.unwrap();
-        assert_eq!(hex::encode(&msg3), MSG_3_CIPHERTEXT);
+        assert_eq!(encode(&msg3), MSG_3_CIPHERTEXT);
 
         let res = responder.process(&msg3);
         assert!(res.is_ok());
@@ -760,13 +761,13 @@ mod tests {
         // Static x25519 for this handshake, `s`
         let mut vault = vault_mutex.lock().unwrap();
         let static_secret_handle = vault
-            .secret_import(&hex::decode(static_private).unwrap(), attributes)
+            .secret_import(&decode(static_private).unwrap(), attributes)
             .unwrap();
         let static_public_key = vault.secret_public_key_get(&static_secret_handle).unwrap();
 
         // Ephemeral x25519 for this handshake, `e`
         let ephemeral_secret_handle = vault
-            .secret_import(&hex::decode(ephemeral_private).unwrap(), attributes)
+            .secret_import(&decode(ephemeral_private).unwrap(), attributes)
             .unwrap();
         let ephemeral_public_key = vault
             .secret_public_key_get(&ephemeral_secret_handle)

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -87,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +180,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_router/Cargo.lock
+++ b/implementations/rust/ockam/ockam_router/Cargo.lock
@@ -739,7 +739,6 @@ dependencies = [
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -759,6 +758,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -784,7 +784,6 @@ name = "ockam_router"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "hex",
  "ockam",
  "ockam_core",
  "ockam_node",
@@ -803,7 +802,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_router/Cargo.toml
+++ b/implementations/rust/ockam/ockam_router/Cargo.toml
@@ -19,6 +19,5 @@ serde = {version = "1.0.120", features = ["derive"]}
 serde_json = "1.0.61"
 tokio = {version = "1.1.0", features = ["rt-multi-thread","sync","net","macros","time"]}
 url = "2.2.0"
-hex = "0.4.2"
 ockam_core = {path = "../ockam_core", version = "*"}
 async-trait = "0.1.42"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -843,7 +843,6 @@ dependencies = [
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "hex",
  "ockam_core",
  "ockam_node",
  "ockam_node_attribute",
@@ -863,6 +862,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -888,7 +888,6 @@ name = "ockam_router"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "hex",
  "ockam",
  "ockam_core",
  "ockam_node",
@@ -924,7 +923,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf 0.10.0",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 
@@ -351,7 +352,6 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
- "hex",
  "hkdf",
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = ["std"]
-std = ["ockam_core/std", "hex/std"]
+std = ["ockam_core/std"]
 no_std = ["ockam_vault_core/heapless"]
 
 [dependencies]
@@ -28,7 +28,6 @@ aes-gcm = "0.8"
 curve25519-dalek = "3.0"
 ed25519-dalek = "1.0"
 hkdf = "0.10"
-hex = {version = "0.4", default-features = false }
 rand = "0.7"
 sha2 = "0.9"
 x25519-dalek = "1.0"

--- a/implementations/rust/ockam/ockam_vault/src/hasher_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/hasher_impl.rs
@@ -81,6 +81,7 @@ impl Hasher for SoftwareVault {
 #[cfg(test)]
 mod tests {
     use crate::SoftwareVault;
+    use ockam_core::hex::encode;
     use ockam_vault_core::{Hasher, SecretAttributes, SecretPersistence, SecretType, SecretVault};
 
     #[test]
@@ -90,7 +91,7 @@ mod tests {
         assert!(res.is_ok());
         let digest = res.unwrap();
         assert_eq!(
-            hex::encode(digest),
+            encode(digest),
             "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
         );
     }
@@ -124,7 +125,7 @@ mod tests {
         assert_eq!(digest.len(), 1);
         let digest = vault.secret_export(&digest[0]).unwrap();
         assert_eq!(
-            hex::encode(digest.as_ref()),
+            encode(digest.as_ref()),
             "921ab9f260544b71941dbac2ca2d42c417aa07b53e055a8f"
         );
     }

--- a/implementations/rust/ockam/ockam_vault/src/key_id_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/key_id_impl.rs
@@ -1,5 +1,6 @@
 use crate::software_vault::SoftwareVault;
 use crate::VaultError;
+use ockam_core::hex::encode;
 use ockam_vault_core::{Hasher, KeyId, KeyIdVault, PublicKey, Secret};
 
 impl KeyIdVault for SoftwareVault {
@@ -22,13 +23,14 @@ impl KeyIdVault for SoftwareVault {
 
     fn compute_key_id_for_public_key(&self, public_key: &PublicKey) -> ockam_core::Result<KeyId> {
         let key_id = self.sha256(public_key.as_ref())?;
-        Ok(hex::encode(key_id))
+        Ok(encode(key_id))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::SoftwareVault;
+    use ockam_core::hex::decode;
     use ockam_vault_core::{
         KeyIdVault, PublicKey, SecretAttributes, SecretPersistence, SecretType, SecretVault,
         CURVE25519_SECRET_LENGTH,
@@ -39,8 +41,7 @@ mod tests {
         let vault = SoftwareVault::new();
 
         let public =
-            hex::decode("68858ea1ea4e1ade755df7fb6904056b291d9781eb5489932f46e32f12dd192a")
-                .unwrap();
+            decode("68858ea1ea4e1ade755df7fb6904056b291d9781eb5489932f46e32f12dd192a").unwrap();
         let public = PublicKey::new(public.to_vec());
 
         let key_id = vault.compute_key_id_for_public_key(&public).unwrap();

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -115,6 +115,7 @@ impl SecretVault for SoftwareVault {
 #[cfg(test)]
 mod tests {
     use crate::SoftwareVault;
+    use ockam_core::hex::{decode, encode};
     use ockam_vault_core::{
         SecretAttributes, SecretPersistence, SecretType, SecretVault, CURVE25519_PUBLIC_LENGTH,
         CURVE25519_SECRET_LENGTH,
@@ -180,12 +181,12 @@ mod tests {
         let secret_str = "98d589b0dce92c9e2442b3093718138940bff71323f20b9d158218b89c3cec6e";
 
         let secret = vault
-            .secret_import(hex::decode(secret_str).unwrap().as_slice(), attributes)
+            .secret_import(decode(secret_str).unwrap().as_slice(), attributes)
             .unwrap();
 
         assert_eq!(secret.index(), 1);
         assert_eq!(
-            hex::encode(vault.secret_export(&secret).unwrap().as_ref()),
+            encode(vault.secret_export(&secret).unwrap().as_ref()),
             secret_str
         );
 
@@ -193,13 +194,13 @@ mod tests {
             SecretAttributes::new(SecretType::Buffer, SecretPersistence::Ephemeral, 24);
         let secret_str = "5f791cc52297f62c7b8829b15f828acbdb3c613371d21aa1";
         let secret = vault
-            .secret_import(hex::decode(secret_str).unwrap().as_slice(), attributes)
+            .secret_import(decode(secret_str).unwrap().as_slice(), attributes)
             .unwrap();
 
         assert_eq!(secret.index(), 2);
 
         assert_eq!(
-            hex::encode(vault.secret_export(&secret).unwrap().as_ref()),
+            encode(vault.secret_export(&secret).unwrap().as_ref()),
             secret_str
         );
     }

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "libc"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +145,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "hashbrown",
+ "hex",
  "serde",
 ]
 


### PR DESCRIPTION
Centralizing management of hex crate