### PR TITLE
feat[elixir]: register tcp client as worker to route back to it without reconnecting

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/node.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/node.ex
@@ -79,6 +79,21 @@ defmodule Ockam.Node do
   end
 
   @doc false
+  def stop(pid) when is_pid(pid) do
+    DynamicSupervisor.terminate_child(@processes_supervisor, pid)
+  end
+
+  def stop(address) do
+    case Registry.whereis_name(address) do
+      pid when is_pid(pid) ->
+        stop(pid)
+
+      _other ->
+        :ok
+    end
+  end
+
+  @doc false
   @impl true
   def init(nil) do
     with :ok <- Router.set_message_handler(:default, &handle_routed_message/1),

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -1,28 +1,30 @@
 defmodule Ockam.Transport.TCP.Client do
   @moduledoc false
-  use GenServer
+  use Ockam.Worker
 
   alias Ockam.Message
   alias Ockam.Transport.TCPAddress
+  alias Ockam.Wire
 
-  @wire_encoder_decoder Ockam.Wire.Binary.V2
+  require Logger
+
+  # TODO: modify this for tcp
+  @wire_encoder_decoder Wire.Binary.V2
 
   @impl true
-  def init(%{ip: ip, port: port} = state) do
+  def setup(options, state) do
+    %{ip: ip, port: port} = Keyword.fetch!(options, :destination)
     # TODO: connect/3 and controlling_process/2 should be in a callback.
     {:ok, socket} = :gen_tcp.connect(ip, port, [:binary, :inet, active: true, packet: 2])
     :gen_tcp.controlling_process(socket, self())
+    address = Ockam.Node.get_random_unregistered_address()
+    Ockam.Node.Registry.register_name(address, self())
 
-    {:ok, Map.put(state, :socket, socket)}
-  end
-
-  @spec start_link(map) :: :ignore | {:error, any} | {:ok, pid}
-  def start_link(default) when is_map(default) do
-    GenServer.start_link(__MODULE__, default)
+    {:ok, Map.merge(state, %{socket: socket, address: address, ip: ip, port: port})}
   end
 
   @impl true
-  def handle_info(:connect, %{ip: ip, port: port} = state) do
+  def handle_message(:connect, %{ip: ip, port: port} = state) do
     {:ok, socket} = :gen_tcp.connect(ip, port, [:binary, :inet, {:packet, 2}])
     :inet.setopts(socket, [{:active, true}, {:packet, 2}])
     :gen_tcp.controlling_process(socket, self())
@@ -30,33 +32,52 @@ defmodule Ockam.Transport.TCP.Client do
     {:noreply, Map.put(state, :socket, socket)}
   end
 
-  def handle_info({:tcp, socket, data}, %{socket: socket} = state) do
-    with {:ok, message} <- Ockam.Wire.decode(@wire_encoder_decoder, data),
+  def handle_message({:tcp, socket, data}, %{socket: socket} = state) do
+    with {:ok, message} <- Wire.decode(@wire_encoder_decoder, data),
          {:ok, message} <- update_return_route(message, state) do
       Ockam.Router.route(message)
     else
-      {:error, %Ockam.Wire.DecodeError{} = e} -> raise e
+      {:error, %Wire.DecodeError{} = e} -> raise e
       e -> raise e
     end
 
     {:noreply, state}
   end
 
-  def handle_info({:tcp_closed, _}, state), do: {:stop, :normal, state}
-  def handle_info({:tcp_error, _}, state), do: {:stop, :normal, state}
+  def handle_message({:tcp_closed, _}, state), do: {:stop, :normal, state}
+  def handle_message({:tcp_error, _}, state), do: {:stop, :normal, state}
 
-  @impl true
-  def handle_call({:send, data}, _from, %{socket: socket} = state) do
-    {:reply, :gen_tcp.send(socket, data), state}
+  ## TODO: implement Worker API
+  def handle_message(%{payload: _payload} = message, state) do
+    encode_and_send_over_tcp(message, state)
+    {:noreply, state}
   end
 
-  @spec send(atom | pid | {atom, any} | {:via, atom, any}, any) :: any
-  def send(pid, data) do
-    GenServer.call(pid, {:send, data})
+  defp encode_and_send_over_tcp(message, state) do
+    with {:ok, message} <- remove_itself_from_onward_route(message, state),
+         {:ok, encoded_message} <- Wire.encode(@wire_encoder_decoder, message),
+         :ok <- send_over_tcp(encoded_message, state) do
+      :ok
+    end
   end
 
-  defp update_return_route(message, %{ip: ip, port: port}) do
+  defp remove_itself_from_onward_route(message, %{address: address}) do
+    new_onward_route =
+      case Message.onward_route(message) do
+        [^address | rest] -> rest
+        ## TODO: error message?
+        other -> other
+      end
+
+    {:ok, Map.put(message, :onward_route, new_onward_route)}
+  end
+
+  defp send_over_tcp(data, %{socket: socket}) do
+    :gen_tcp.send(socket, data)
+  end
+
+  defp update_return_route(message, %{address: address}) do
     return_route = Message.return_route(message)
-    {:ok, Map.put(message, :return_route, [%TCPAddress{ip: ip, port: port} | return_route])}
+    {:ok, Map.put(message, :return_route, [address | return_route])}
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -3,7 +3,6 @@ defmodule Ockam.Transport.TCP.Client do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Transport.TCPAddress
   alias Ockam.Wire
 
   require Logger

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/listener.ex
@@ -135,7 +135,6 @@ if Code.ensure_loaded?(:ranch) do
     use GenServer
 
     alias Ockam.Message
-    alias Ockam.Transport.TCPAddress
 
     require Logger
 
@@ -189,11 +188,7 @@ if Code.ensure_loaded?(:ranch) do
           %{payload: _payload} = message,
           %{transport: transport, socket: socket, address: address} = state
         ) do
-      {:ok, {ip, port}} = transport.sockname(socket)
-      return_address = %TCPAddress{ip: ip, port: port}
-
       with {:ok, message} <- set_onward_route(message, address),
-           {:ok, message} <- set_return_route(message, return_address),
            {:ok, encoded} <- Ockam.Wire.encode(@wire_encoder_decoder, message) do
         transport.send(socket, encoded)
       else

--- a/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
@@ -9,10 +9,71 @@ defmodule Ockam.Router.Tests.Printer do
   end
 end
 
+defmodule Ockam.Router.Tests.Echo do
+  @moduledoc false
+
+  use Ockam.Worker
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  require Logger
+
+  @impl true
+  def handle_message(message, state) do
+    reply = %{
+      onward_route: Message.return_route(message),
+      return_route: [state.address],
+      payload: Message.payload(message)
+    }
+
+    Logger.info("\nMESSAGE: #{inspect(message)}\nREPLY: #{inspect(reply)}")
+    Router.route(reply)
+
+    {:ok, state}
+  end
+end
+
+defmodule Ockam.Router.Tests.Forwarder do
+  # this has to be outside the test module for the macro to work
+  # because the macro uses defp.
+  use Ockam.Worker
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  require Logger
+
+  @impl true
+  def handle_message(message, state) do
+    address = state.address
+
+    case Message.onward_route(message) do
+      [^address] ->
+        Logger.info("\nMESSAGE BACK: #{inspect(message)}}")
+        {:ok, state}
+
+      [^address | rest] ->
+        forward = %{
+          onward_route: rest,
+          return_route: [address],
+          payload: Message.payload(message)
+        }
+
+        Logger.info("\nMESSAGE: #{inspect(message)}\nFORWARD: #{inspect(forward)}")
+        Router.route(forward)
+
+        {:ok, state}
+    end
+  end
+end
+
 defmodule Ockam.Router.Tests do
   use ExUnit.Case, async: true
   doctest Ockam.Router
 
+  alias Ockam.Router.Tests.Echo
+  alias Ockam.Router.Tests.Forwarder
   alias Ockam.Router.Tests.Printer
   alias Ockam.Transport.TCP
   alias Ockam.Transport.TCPAddress
@@ -21,8 +82,12 @@ defmodule Ockam.Router.Tests do
 
   setup_all do
     {:ok, "printer"} = Printer.create(address: "printer")
+    {:ok, "echo"} = Echo.create(address: "echo")
+    {:ok, "client_forwarder"} = Forwarder.create(address: "client_forwarder")
     printer_pid = Ockam.Node.whereis("printer")
-    [printer_pid: printer_pid]
+    echo_pid = Ockam.Node.whereis("echo")
+    forwarder_pid = Ockam.Node.whereis("client_forwarder")
+    [printer_pid: printer_pid, echo_pid: echo_pid, forwarder_pid: forwarder_pid]
   end
 
   describe "Ockam.Router" do
@@ -81,6 +146,87 @@ defmodule Ockam.Router.Tests do
                payload: "hello",
                return_route: [_address]
              } = result
+    end
+
+    test "TCP echo test", %{echo_pid: echo, forwarder_pid: client_forwarder} do
+      # client
+      request = %{
+        onward_route: [
+          "client_forwarder",
+          %TCPAddress{ip: {127, 0, 0, 1}, port: 5000},
+          "echo"
+        ],
+        return_route: [],
+        payload: "hello"
+      }
+
+      :erlang.trace(echo, true, [:receive])
+      :erlang.trace(client_forwarder, true, [:receive])
+
+      assert {:ok, _address_a} = TCP.create_listener(port: 6000, route_outgoing: true)
+
+      assert {:ok, _address_b} = TCP.create_listener(port: 5000)
+
+      Ockam.Router.route(request)
+
+      assert_receive(
+        {
+          :trace,
+          ^client_forwarder,
+          :receive,
+          %{
+            onward_route: [
+              "client_forwarder",
+              %TCPAddress{ip: {127, 0, 0, 1}, port: 5000},
+              "echo"
+            ],
+            return_route: []
+          }
+        },
+        1_000
+      )
+
+      # tcp sends to echo on hub
+      assert_receive(
+        {:trace, ^echo, :receive,
+         %{
+           onward_route: [
+             "echo"
+           ],
+           return_route: [registered_tcp_thing, "client_forwarder"],
+           payload: _
+         }},
+        1_000
+      )
+
+      tcp_pid = Ockam.Node.whereis(registered_tcp_thing)
+
+      assert is_pid(tcp_pid)
+
+      :erlang.trace(tcp_pid, true, [:receive])
+
+      # echo service response
+      assert_receive(
+        {:trace, ^tcp_pid, :receive,
+         %{
+           onward_route: [^registered_tcp_thing, "client_forwarder"],
+           return_route: ["echo"]
+         }},
+        1_000
+      )
+
+      assert_receive(
+        {
+          :trace,
+          ^client_forwarder,
+          :receive,
+          %{
+            onward_route: ["client_forwarder"],
+            return_route: [%TCPAddress{ip: {127, 0, 0, 1}, port: 5000}, "echo"]
+          }
+        },
+        1_000
+      )
     end
   end
 end


### PR DESCRIPTION
### Proposed Changes
Move code for sending messages from tcp listener to tcp client
Establish connections by creating new clients as workers
Make clients add its own identity instead of ip/port to return route

This allows the ping-pong example when two workers on different machines can talk back and forth using the same connection.

Depends on #1074 