### PR TITLE
feat(rust): add receive_match to filter messages via conditional

### DIFF
--- a/implementations/rust/examples/worker/examples/worker_receive_match.rs
+++ b/implementations/rust/examples/worker/examples/worker_receive_match.rs
@@ -1,0 +1,44 @@
+use ockam::{async_worker, Context, Result, Routed, Worker};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+struct Echo;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Number(u8);
+
+#[async_worker]
+impl Worker for Echo {
+    type Context = Context;
+    type Message = Number;
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Number>) -> Result<()> {
+        let addr = msg.reply();
+        let msg = msg.take();
+
+        // Send three messages back, but only have the third message
+        // be the 'correct' value.
+        ctx.send_message(addr.clone(), Number(msg.0 - 2)).await?;
+        ctx.send_message(addr.clone(), Number(msg.0 - 1)).await?;
+        ctx.send_message(addr.clone(), Number(msg.0)).await?;
+        Ok(())
+    }
+}
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    let num = Number(5);
+
+    // Start the echo service
+    ctx.start_worker("echo", Echo).await?;
+
+    // Send a message
+    ctx.send_message("echo", num.clone()).await?;
+
+    // Wait for the 'correct' reply
+    let reply = ctx.receive_match::<Number, _>(|msg| msg == &num).await?;
+    info!("Received correct reply: {:?}", reply);
+
+
+    ctx.stop().await
+}


### PR DESCRIPTION
This PR adds a convenience function to the Context API that allows users to receive based on a conditional filter.


<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->