### PR TITLE
feat(rust): ockam_node v0.4.0

### DIFF
--- a/implementations/rust/examples/node/Cargo.lock
+++ b/implementations/rust/examples/node/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam_core",
  "tokio",

--- a/implementations/rust/examples/worker/Cargo.lock
+++ b/implementations/rust/examples/worker/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam_core",
  "tokio",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -26,7 +26,7 @@ bbs = { version = "0.4", optional = true }
 digest = { version = "0.8", optional = true }
 ff = { version = "0.6", package = "ff-zeroize", optional = true }
 ockam_core = {path = "../ockam_core", version = "0.6.0"}
-ockam_node = {path = "../ockam_node", version = "0.3.0", optional = true}
+ockam_node = {path = "../ockam_node", version = "0.4.0", optional = true}
 ockam_node_attribute = {path = "../ockam_node_attribute", version = "0.1.4"}
 ockam_vault_core = {path = "../ockam_vault_core", version = "0.3.0"}
 ockam_vault = {path = "../ockam_vault", version = "0.3.0"}

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam_core",
  "tokio",

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.0 - 2021-03-22
+### Added
+
+- Routing APIs.
+- Router registration.
+- Message forwarding.
+- Mechanism for stopping a single worker.
+- The `receive_match` API allows workers to block until receivng a specific message type.
+
+
+### Changed
+
+- Dependency updates.
+- External router implementations don't need to accept TransportMessage, or parse specific user message types.
+- Improved logging.
+
 ## v0.3.0 - 2021-03-04
 ### Added
 
@@ -21,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Context `send_message` no longer silently eats errors.
 
 ## v0.2.0 - 2021-02-16
+
 ### Added
 - Message trait implementation.
 - Messages for starting and stopping Workers.

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam_core",
  "tokio",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 keywords = ["ockam"]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 ockam_core = {path = "../ockam_core", version = "0.6.0"}

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.3.0"
+ockam_node = "0.4.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam_core",
  "tokio",


### PR DESCRIPTION
## v0.4.0 - 2021-03-22
### Added

- Routing APIs.
- Router registration.
- Message forwarding.
- Mechanism for stopping a single worker.
- The `receive_match` API allows workers to block until receivng a specific message type.


### Changed

- Dependency updates.
- External router implementations don't need to accept TransportMessage, or parse specific user message types.
- Improved logging.

