### PR TITLE
feat(rust): ockam_transport_tcp v0.2.0

### DIFF
--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
  "hashbrown 0.9.1",

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.0 - 2021-02-22
+### Added
+- Route metadata wrapper type.
+- New implementations of TCP Router and TCP Listener.
+
+### Changed
+
+- Dependencies updated.
+- Split TCP worker into two parts: sender & receiver.
+
+
 ## v0.1.0 - 2021-02-10
 ### Added
 

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
  "hashbrown 0.9.1",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.1.0"
+ockam_transport_tcp = "0.2.0"
 ```
 
 This crate requires the rust standard library `"std"`.


### PR DESCRIPTION
## v0.2.0 - 2021-02-22
### Added
- Route metadata wrapper type.
- New implementations of TCP Router and TCP Listener.

### Changed

- Dependencies updated.
- Split TCP worker into two parts: sender & receiver.

