### PR TITLE
fix(rust): un-wildcard ockam dep for ockam_transport_tcp

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -23,7 +23,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-ockam = {path = "../ockam", version = "*"}
+ockam = {path = "../ockam", version = "0"}
 serde_bare = "0.3.0"
 serde = {version = "1.0.120", features = ["derive"]}
 tokio = {version = "1.1.0", features = ["rt-multi-thread","sync","net","macros","time"]}


### PR DESCRIPTION
Removes wildcard dependency