### PR TITLE
fix(rust): update reverted vers number in ockam toml

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "bbs",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam"
-version = "0.3.0"
+version = "0.4.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Bumping accidentally reverted version number for ockam crate