### PR TITLE
fix(elixir): use return route instead of payload to return forwarding address

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/echo.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/echo.ex
@@ -16,7 +16,7 @@ defmodule Ockam.Hub.Service.Echo do
       payload: Message.payload(message)
     }
 
-    Logger.info("\nMESSAGE: #{inspect(message)}\nREPLY: #{inspect(reply)}")
+    Logger.info("\nECHO\nMESSAGE: #{inspect(message)}\nREPLY: #{inspect(reply)}")
     Router.route(reply)
 
     {:ok, state}

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/forward.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/forward.ex
@@ -12,22 +12,22 @@ defmodule Ockam.Hub.Service.Forward do
 
   @impl true
   def handle_message(message, state) do
-    Logger.info("MESSAGE: #{inspect(message)}")
+    Logger.info("FORWARD\nMESSAGE: #{inspect(message)}")
     forward_route = Message.return_route(message)
 
     with {:ok, inbox} <- Inbox.create(forward_route: forward_route),
          outbox <- Inbox.outbox_address(inbox),
          {:ok, _} <- Outbox.create(address: outbox, inbox_address: state.address),
-         :ok <- send_reply(inbox, message, state) do
+         :ok <- send_reply(inbox, message) do
       {:ok, state}
     end
   end
 
-  def send_reply(inbox_address, message, state) do
+  def send_reply(inbox_address, message) do
     reply = %{
       onward_route: Message.return_route(message),
-      return_route: [state.address],
-      payload: inbox_address
+      return_route: [inbox_address],
+      payload: Message.payload(message)
     }
 
     Logger.info("REPLY: #{inspect(reply)}")


### PR DESCRIPTION
### Proposed Changes

Instead of using payload to communicate the forwadring mailbox address, use the return route.

Payload encoding might be different in different implementations
Return route sounds like a reasonable way to communicate changes in the
routing
