### PR TITLE
Forwarder example

### DIFF
--- a/implementations/rust/examples/tcp/Cargo.lock
+++ b/implementations/rust/examples/tcp/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
+name = "ahash"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
@@ -78,6 +84,15 @@ dependencies = [
  "getrandom 0.2.2",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -134,16 +149,6 @@ dependencies = [
  "rayon",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175dfa69e619905c4c3cdb7c3c203fa3bdd5d51184e3afdb2742c0280493772"
-dependencies = [
- "byteorder",
- "serde",
 ]
 
 [[package]]
@@ -217,6 +222,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
 
 [[package]]
 name = "cipher"
@@ -428,16 +445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-dependencies = [
- "matches",
- "percent-encoding",
-]
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,11 +601,20 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
 dependencies = [
- "ahash",
+ "ahash 0.7.2",
  "serde",
 ]
 
@@ -658,17 +674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,10 +719,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.8"
+name = "matchers"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -824,7 +832,7 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "bbs",
@@ -844,21 +852,23 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
- "bincode",
- "hashbrown",
+ "hashbrown 0.11.0",
  "hex",
  "serde",
+ "serde_bare",
 ]
 
 [[package]]
 name = "ockam_node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam_core",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -870,36 +880,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ockam_router"
-version = "0.1.0"
-dependencies = [
- "ockam",
- "ockam_core",
- "ockam_node",
- "serde",
- "serde_bare",
- "serde_json",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "ockam_transport_tcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
+ "hashbrown 0.9.1",
  "ockam",
- "ockam_core",
- "ockam_router",
  "rand 0.7.3",
  "serde",
  "serde_bare",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "ockam_vault"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -916,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -980,12 +976,6 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1168,6 +1158,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,36 +1361,27 @@ dependencies = [
 name = "tcp_examples"
 version = "0.0.0"
 dependencies = [
- "async-trait",
  "ockam",
  "ockam_node",
- "ockam_router",
  "ockam_transport_tcp",
  "serde",
- "serde_bare",
- "tokio",
+ "tracing",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.1.1"
+name = "thread_local"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "tinyvec_macros",
+ "once_cell",
 ]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1394,28 +1409,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-xid"
@@ -1431,18 +1503,6 @@ checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.4",
  "subtle 2.4.0",
-]
-
-[[package]]
-name = "url"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
-dependencies = [
- "form_urlencoded",
- "idna",
- "matches",
- "percent-encoding",
 ]
 
 [[package]]

--- a/implementations/rust/examples/tcp/examples/network_relay_echo.rs
+++ b/implementations/rust/examples/tcp/examples/network_relay_echo.rs
@@ -1,0 +1,91 @@
+#[macro_use]
+extern crate tracing;
+
+use ockam::{async_worker, Context, Result, Route, Routed, Worker};
+use ockam_transport_tcp::{self as tcp, TcpRouter};
+use std::net::SocketAddr;
+
+fn get_peer_addr() -> SocketAddr {
+    std::env::args()
+        .skip(1)
+        .take(1)
+        .next()
+        // This value can be used when running the ockam-hub locally
+        .unwrap_or(format!("127.0.0.1:4000"))
+        .parse()
+        .ok()
+        .unwrap_or_else(|| {
+            error!("Failed to parse socket address!");
+            eprintln!("Usage: network_echo_client <ip>:<port>");
+            std::process::exit(1);
+        })
+}
+
+/// A worker who isn't always available.  It registers itself with the
+/// hub forwarding service to never miss a message.
+struct ProxiedWorker {
+    /// The hub's address
+    peer: SocketAddr,
+}
+
+#[async_worker]
+impl Worker for ProxiedWorker {
+    type Context = Context;
+    type Message = String;
+
+    async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        // Register this service with the hub's forwarding service
+        ctx.send_message(
+            Route::new()
+                .append(format!("1#{}", self.peer))
+                .append("forwarding_service"),
+            String::from("register"),
+        )
+        .await
+    }
+
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        msg: Routed<Self::Message>,
+    ) -> Result<()> {
+        // This condition is true when we receive the forwarding route
+        // from our registration - forward this to the app.
+        if &msg.as_str() == &"register" {
+            println!("Receiving message: {}", msg);
+            ctx.send_message("app", msg.reply()).await?;
+        }
+        // This condition is true when we receive a message that is
+        // being forwarded
+        else {
+            println!("Forwarded message: {}", msg.take());
+        }
+
+        Ok(())
+    }
+}
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    // Get our peer address
+    let peer = get_peer_addr();
+
+    // Create and register a TcpRouter
+    let rh = TcpRouter::register(&ctx).await?;
+
+    // Create and register a connection worker pair
+    let w_pair = tcp::start_tcp_worker(&ctx, peer.clone()).await?;
+    rh.register(&w_pair).await?;
+
+    ctx.start_worker("not.always.there", ProxiedWorker { peer })
+        .await?;
+
+    // Receive the forwarding address from our worker
+    let fwd_route = ctx.receive::<Route>().await?.take();
+
+    // Then send a message to our worker, via the hub
+    ctx.send_message(fwd_route, "Hello you!".to_string())
+        .await?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 default = ["std"]
 
 # Requires the Rust Standard Library.
-std = ["bincode", "serde", "async-trait", "hex/std"]
+std = ["serde_bare", "serde", "async-trait", "hex/std"]
 
 # Requires the Rust alloc library
 alloc = []
@@ -31,7 +31,7 @@ no_std = ["heapless"]
 
 [dependencies]
 async-trait =  { version = "0.1", optional = true }
-bincode = { version =  "1.3", optional = true }
+serde_bare = { version =  "0.3", optional = true }
 hashbrown =  { version = "0.11", features = ["serde"]}
 heapless = { version = "0.6", optional = true }
 hex = { version = "0.4", default-features = false }

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -14,13 +14,13 @@ pub type Encoded = Vec<u8>;
 pub trait Message: Serialize + DeserializeOwned + Send + 'static {
     /// Encode the type representation into an [`Encoded`] type.
     fn encode(&self) -> Result<Encoded> {
-        Ok(bincode::serialize(self)?)
+        Ok(serde_bare::to_vec(self)?)
     }
 
     /// Decode an [`Encoded`] type into the Message's type.
     #[allow(clippy::ptr_arg)]
     fn decode(e: &Encoded) -> Result<Self> {
-        Ok(bincode::deserialize(e)?)
+        Ok(serde_bare::from_slice(e.as_slice())?)
     }
 }
 
@@ -28,9 +28,9 @@ pub trait Message: Serialize + DeserializeOwned + Send + 'static {
 impl<T> Message for T where T: Serialize + DeserializeOwned + Send + 'static {}
 
 // TODO: see comment in Cargo.toml about this dependency
-impl From<bincode::Error> for crate::Error {
-    fn from(_: bincode::Error) -> Self {
-        Self::new(1, "bincode")
+impl From<serde_bare::Error> for crate::Error {
+    fn from(_: serde_bare::Error) -> Self {
+        Self::new(1, "serde_bare")
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -68,6 +68,14 @@ impl<'ctx, M: Message> Cancel<'ctx, M> {
             .requeue(RelayMessage::direct(self.addr, self.trans))
             .await;
     }
+
+    /// Consume the Cancel wrapper to take the underlying message
+    ///
+    /// After calling this function it is no longer possible to
+    /// re-queue the message into the worker mailbox.
+    pub fn take(self) -> M {
+        self.inner
+    }
 }
 
 impl<'ctx, M: Message> std::ops::Deref for Cancel<'ctx, M> {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/error.rs
@@ -21,6 +21,8 @@ pub enum TcpError {
     PeerNotFound,
     /// Peer requected the incoming connection
     PeerBusy,
+    /// A generic I/O failure
+    GenericIo,
 }
 
 impl TcpError {
@@ -33,5 +35,16 @@ impl TcpError {
 impl From<TcpError> for Error {
     fn from(e: TcpError) -> Error {
         Error::new(TcpError::DOMAIN_CODE + (e as u32), TcpError::DOMAIN_NAME)
+    }
+}
+
+impl From<std::io::Error> for TcpError {
+    fn from(e: std::io::Error) -> Self {
+        use std::io::ErrorKind::*;
+        dbg!();
+        match e.kind() {
+            ConnectionRefused => Self::PeerNotFound,
+            _ => Self::GenericIo,
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/receiver.rs
@@ -41,7 +41,13 @@ impl Worker for TcpRecvWorker {
         // FIXME: see ArcBool future note
         while atomic::check(&self.run) {
             // First read a message length header...
-            let len = self.rx.read_u16().await.unwrap();
+            let len = match self.rx.read_u16().await {
+                Ok(len) => len,
+                Err(e) => {
+                    error!("Failed to receive message: {}", e);
+                    break;
+                }
+            };
 
             trace!("Received message header for {} bytes", len);
 


### PR DESCRIPTION
Currently the example uses a patch from @hairyhum to make the `forwarder_service` use the return route of the message its sending back to communicate the forwarding address.

This is required because of incompatible payload encodings between the Rust code and Elixir code.