### PR TITLE
Split forwarding example

### DIFF
--- a/implementations/rust/examples/tcp/examples/network_echo_server.rs
+++ b/implementations/rust/examples/tcp/examples/network_echo_server.rs
@@ -40,7 +40,7 @@ fn get_bind_addr() -> SocketAddr {
 }
 
 #[ockam::node]
-async fn main(mut ctx: Context) -> Result<()> {
+async fn main(ctx: Context) -> Result<()> {
     // Get either the default socket address, or a user-input
     let bind_addr = get_bind_addr();
     debug!("Binding to: {}", bind_addr);

--- a/implementations/rust/examples/tcp/examples/relay_echo_client.rs
+++ b/implementations/rust/examples/tcp/examples/relay_echo_client.rs
@@ -1,0 +1,53 @@
+#[macro_use]
+extern crate tracing;
+
+use ockam::{Context, Result, Route};
+use ockam_transport_tcp::{self as tcp, TcpRouter};
+use std::{io, net::SocketAddr};
+
+fn get_peer_addr() -> SocketAddr {
+    std::env::args()
+        .skip(1)
+        .take(1)
+        .next()
+        // This value can be used when running the ockam-hub locally
+        .unwrap_or(format!("127.0.0.1:4000"))
+        .parse()
+        .ok()
+        .unwrap_or_else(|| {
+            error!("Failed to parse socket address!");
+            eprintln!("Usage: network_echo_client <ip>:<port>");
+            std::process::exit(1);
+        })
+}
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    // Get our peer address
+    let peer = get_peer_addr();
+
+    // Create and register a TcpRouter
+    let rh = TcpRouter::register(&ctx).await?;
+
+    // Create and register a connection worker pair
+    let w_pair = tcp::start_tcp_worker(&ctx, peer.clone()).await?;
+    rh.register(&w_pair).await?;
+
+    // Get the forwarding route from user input
+    let mut buffer = String::new();
+    println!("Paste the forwarding route below ↓");
+    io::stdin().read_line(&mut buffer).unwrap();
+    let route = Route::parse(buffer).unwrap_or_else(|| {
+        error!("Failed to parse route!");
+        eprintln!("Route format [type#]<address> [=> [type#]<address>]+");
+        std::process::exit(1);
+    });
+
+    debug!("Sending message to route: {}", route);
+
+    ctx.send_message(route, String::from("Hello you!")).await?;
+
+    // We can't shut down the node here because otherwise a race
+    // condition will drop the tcp messages in transit.
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -100,7 +100,7 @@ impl Address {
 impl Display for Address {
     fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
         let inner: &'a str = from_utf8(&self.inner.as_slice()).unwrap_or("Invalid UTF-8");
-        write!(f, "{}:{}", self.tt, inner)
+        write!(f, "{}#{}", self.tt, inner)
     }
 }
 

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -19,6 +19,28 @@ impl Route {
         RouteBuilder::new()
     }
 
+    /// Parse a route from a string
+    pub fn parse<S: Into<String>>(s: S) -> Option<Route> {
+        let s = s.into();
+        if s == "" {
+            return None;
+        }
+
+        let addrs = s.split("=>").collect::<Vec<_>>();
+
+        // Invalid route
+        if addrs.len() == 0 {
+            return None;
+        }
+
+        Some(
+            addrs
+                .into_iter()
+                .fold(Route::new(), |r, addr| r.append(addr.trim()))
+                .into(),
+        )
+    }
+
     /// Create a new [`RouteBuilder`] from the current Route
     ///
     /// [`RouteBuilder`]: crate::RouteBuilder


### PR DESCRIPTION
This change splits the forwarding example up into two binaries that people can run.

The code currently assumes that https://github.com/ockam-network/ockam/commit/ad66ce8c1f4184f975c5c668209a86bfd3964c4f has been applied to the target hub implementation