### PR TITLE
feat(rust): node macro uses ockam result

### DIFF
--- a/implementations/rust/ockam/ockam_examples/example_projects/node/examples/create_node_with_macro.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/node/examples/create_node_with_macro.rs
@@ -1,4 +1,4 @@
 #[ockam::node]
-async fn main(context: ockam::Context) {
-    context.stop().await.unwrap();
+async fn main(context: ockam::Context) -> Result<()> {
+    context.stop().await
 }

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -144,6 +144,8 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let output_function = quote! {
+        use ockam::Result;
+
         #[inline(always)]
         #input_function
 


### PR DESCRIPTION
Modifies the `#[ockam::node]` macro to synthesize a `use ockam::Result` statement. This allows smoother usage of the APIs.