### PR TITLE
docs: markdown links in guide

### DIFF
--- a/documentation/guides/rust/01-workers/README.md
+++ b/documentation/guides/rust/01-workers/README.md
@@ -153,4 +153,4 @@ async fn main(mut ctx: Context) -> Result<()> {
 
 ```
 
-Now we are ready to <a href="02-transports">Use a transport</a> to connect to remote nodes.
+Now we are ready to [Use a transport](../02-transports) to connect to remote nodes.

--- a/documentation/guides/rust/02-transports/README.md
+++ b/documentation/guides/rust/02-transports/README.md
@@ -124,4 +124,4 @@ async fn main(mut ctx: Context) -> Result<()> {
 
 ```
 
-The Ockam Hub <a href="03-hub">creates a node for you instantly</a>. Let's move the `echo_service` to a node on the hub.
+The Ockam Hub  [creates a node for you instantly](../03-hub). Let's move the `echo_service` to a node on the hub.

--- a/documentation/guides/rust/03-hub/README.md
+++ b/documentation/guides/rust/03-hub/README.md
@@ -55,6 +55,6 @@ async fn main(mut ctx: Context) -> Result<()> {
 
 ```
 
-It's even easier to send messages to remote nodes using a <a href="04-forwarding">forwarding addresses</a>. The next step registers the
+It's even easier to send messages to remote nodes using a [forwarding addresses](../04-forwarding). The next step registers the
 `echo_service` with the forwarding service. The forwarding service sends a forwarding address that we can use to send
 messages to the worker. The forwarding address is an alias for a route to a worker on a remote node.

--- a/documentation/guides/rust/README.md
+++ b/documentation/guides/rust/README.md
@@ -8,29 +8,29 @@ order: 1
 This is a guide to using the Ockam Rust SDK. Over the course of four examples, the guide builds a distributed echo service
 that forwards messages between nodes.
 
-The <a href="get-started">Get Started</a> guide walks developers through the fundamentals of using
+The [Get Started](get-started) guide walks developers through the fundamentals of using
 Ockam in a rust project.
 
-In <a href="01-workers">Step 1</a> we build a basic Ockam node and worker. The core data types and traits that comprise
+In [Step 1](01-workers) we build a basic Ockam node and worker. The core data types and traits that comprise
 the Ockam API are introduced, along with the asynchronous runtime.
 
-<a href="02-transports">Step 2</a> introduces Ockam transports and message routing. The Ockam TCP transport is used to
+[Step 2](02-transports) introduces Ockam transports and message routing. The Ockam TCP transport is used to
 send messages between two nodes.
 
-The Ockam Hub is a remote node that can send, receive, and route messages between nodes. <a href="03-hub">Step 3</a>
+The Ockam Hub is a remote node that can send, receive, and route messages between nodes. [Step 3](03-hub)
 shows you how to use the TCP transport to send messages to a node hosted on the Hub.
 
-Message forwarding is discussed in <a href="04-forwarding">Step 4</a>, enabling you to route messages between remote nodes.
+Message forwarding is discussed in [Step 4](04-forwarding), enabling you to route messages between remote nodes.
 
 ## Guides
 
 | Name                                                                                           | Description                                     |
 | ---------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-|<a href="get-started">Get Started</a>| Get ready to use the Ockam Rust SDK.|
-|<a href="01-workers">Step 1</a>| Build your first node and worker.|
-|<a href="02-transports">Step 2</a>| Send messages between nodes.|
-|<a href="03-hub">Step 3</a>| Learn how to use the Ockam Hub.|
-|<a href="04-forwarding">Step 4</a>| Use Ockam Hub to forward messages between nodes.|
+|[Get Started](get-started)| Get ready to use the Ockam Rust SDK.|
+|[Step 1](01-workers)| Build your first node and worker.|
+|[Step 2](02-transports)| Send messages between nodes.|
+|[Step 3](03-hub)| Learn how to use the Ockam Hub.|
+|[Step 4](04-forwarding)| Use Ockam Hub to forward messages between nodes.|
 
 # Have questions? Let us help!
 

--- a/documentation/guides/rust/get-started/README.md
+++ b/documentation/guides/rust/get-started/README.md
@@ -39,4 +39,4 @@ For example:
 1. Create `client.rs` and `server.rs` source files in the `examples` directory.
 1. The programs can be executed using cargo: `cargo run --example server` and `cargo run --example client`.
 
-Now we are ready to <a href="documentation/guides/rust/01-workers">Start building the Echo Service</a>
+Now we are ready to [Start building the Echo Service](../01-workers)


### PR DESCRIPTION
Restores markdown based links in guide