### PR TITLE
docs: fix link to rust guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ within modern enterprise architectures.
 
 We've put together a short walk through of building your first
 Ockam application,
-[click here to begin]("documentation/guides/rust/README.md#rust-guide").
+[click here to begin](documentation/guides/rust/README.md#rust-guide).
 
 ## License
 


### PR DESCRIPTION
### Proposed Changes
- The Get Started section has a link to the rust guide but it's pointing it to https://github.com/ockam-network/ockam/blob/develop/%22documentation/guides/rust/README.md#rust-guide%22 which gives you a 404
- This is fixed by removing the quotes 