### PR TITLE
Spacekookie/route renames

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -43,25 +43,36 @@ impl From<serde_bare::Error> for crate::Error {
 /// without requiring changes in the user message types.
 pub struct Routed<M: Message> {
     inner: M,
-    route: Route,
+    return_: Route,
+    onward: Route,
 }
 
 impl<M: Message> Routed<M> {
     /// Create a new Routed message wrapper
-    pub fn new(inner: M, route: Route) -> Self {
-        Self { inner, route }
+    pub fn new(inner: M, return_: Route, onward: Route) -> Self {
+        Self {
+            inner,
+            return_,
+            onward,
+        }
     }
 
     /// Return a copy of the full return route of the wrapped message
     #[inline]
     pub fn reply(&self) -> Route {
-        self.route.clone()
+        self.return_.clone()
+    }
+
+    /// Return a copy of the onward route for this message
+    #[inline]
+    pub fn onward(&self) -> Route {
+        self.onward.clone()
     }
 
     /// Get a copy of the message sender address
     #[inline]
     pub fn sender(&self) -> Address {
-        self.route.recipient()
+        self.return_.recipient()
     }
 
     /// Consume the message wrapper

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -43,36 +43,36 @@ impl From<serde_bare::Error> for crate::Error {
 /// without requiring changes in the user message types.
 pub struct Routed<M: Message> {
     inner: M,
-    return_: Route,
-    onward: Route,
+    return_route: Route,
+    onward_route: Route,
 }
 
 impl<M: Message> Routed<M> {
     /// Create a new Routed message wrapper
-    pub fn new(inner: M, return_: Route, onward: Route) -> Self {
+    pub fn new(inner: M, return_route: Route, onward_route: Route) -> Self {
         Self {
             inner,
-            return_,
-            onward,
+            return_route,
+            onward_route,
         }
     }
 
     /// Return a copy of the full return route of the wrapped message
     #[inline]
     pub fn reply(&self) -> Route {
-        self.return_.clone()
+        self.return_route.clone()
     }
 
     /// Return a copy of the onward route for this message
     #[inline]
     pub fn onward(&self) -> Route {
-        self.onward.clone()
+        self.onward_route.clone()
     }
 
     /// Get a copy of the message sender address
     #[inline]
     pub fn sender(&self) -> Address {
-        self.return_.recipient()
+        self.return_route.recipient()
     }
 
     /// Consume the message wrapper

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::Error,
+    parser,
     relay::{self, RelayMessage},
     Cancel, Mailbox, NodeMessage,
 };
@@ -269,7 +270,8 @@ impl Context {
                 .ok_or_else(|| Error::FailedLoadData)?;
             let (addr, data) = msg.transport();
 
-            match M::decode(&data.payload).ok() {
+            // FIXME: make message parsing idempotent to avoid cloning
+            match parser::message(data.payload.clone()).ok() {
                 Some(msg) => return Ok((msg, data, addr)),
                 None => {
                     let onward = data.onward.clone();

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -18,6 +18,7 @@ mod executor;
 mod mailbox;
 mod messages;
 mod node;
+mod parser;
 mod relay;
 mod router;
 

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -64,8 +64,9 @@ impl<'ctx, M: Message> Cancel<'ctx, M> {
     /// Cancel this message
     pub async fn cancel(self) {
         let ctx = self.ctx;
+        let onward = self.trans.onward.clone();
         ctx.mailbox
-            .requeue(RelayMessage::direct(self.addr, self.trans))
+            .requeue(RelayMessage::direct(self.addr, self.trans, onward))
             .await;
     }
 

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -1,5 +1,5 @@
 use crate::{relay::RelayMessage, Context};
-use ockam_core::{Address, Message, TransportMessage};
+use ockam_core::{Address, Message, Routed, TransportMessage};
 use std::fmt::{self, Debug, Display, Formatter};
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -74,8 +74,8 @@ impl<'ctx, M: Message> Cancel<'ctx, M> {
     ///
     /// After calling this function it is no longer possible to
     /// re-queue the message into the worker mailbox.
-    pub fn take(self) -> M {
-        self.inner
+    pub fn take(self) -> Routed<M> {
+        Routed::new(self.inner, self.trans.return_, self.trans.onward)
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/parser.rs
+++ b/implementations/rust/ockam/ockam_node/src/parser.rs
@@ -1,0 +1,19 @@
+use ockam_core::{Message, Result};
+
+pub(crate) fn message<M: Message>(mut vec: Vec<u8>) -> Result<M> {
+    M::decode(&vec).or_else(|_| {
+        trace!("Parsing payload without inner length...");
+
+        // This condition means we _may_ be dealing with a payload
+        // sent by a non-Rust implementation.  In this case we
+        // prepend the length of the mesage to the vector and try
+        // again.  I know it's bad, but as long as we don't have
+        // properly specified payload encoding this is what will
+        // have to do.
+        let mut new_v = vec![vec.len() as u8]; // FIXME: does not handle message sizes over 255
+        trace!("New message length: {:?}", new_v);
+
+        new_v.append(&mut vec);
+        M::decode(&new_v)
+    })
+}

--- a/implementations/rust/ockam/ockam_node/src/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay.rs
@@ -95,10 +95,32 @@ where
         }
     }
 
+    fn try_decode(mut v: Vec<u8>) -> Result<M> {
+        M::decode(&v).or_else(|_| {
+            trace!("Parsing payload without inner length...");
+
+            // This condition means we _may_ be dealing with a payload
+            // sent by a non-Rust implementation.  In this case we
+            // prepend the length of the mesage to the vector and try
+            // again.  I know it's bad, but as long as we don't have
+            // properly specified payload encoding this is what will
+            // have to do.
+            let mut new_v = vec![v.len() as u8]; // FIXME: does not handle message sizes over 255
+            trace!("New message length: {:?}", new_v);
+
+            new_v.append(&mut v);
+            M::decode(&new_v)
+        })
+    }
+
     /// Convenience function to handle an incoming direct message
     #[inline]
     fn handle_direct(&mut self, msg: TransportMessage) -> Result<(M, Route)> {
-        M::decode(&msg.payload)
+        let TransportMessage {
+            payload, return_, ..
+        } = msg;
+
+        Self::try_decode(payload)
             .map_err(|e| {
                 error!(
                     "Failed to decode message payload for worker {}",
@@ -106,7 +128,7 @@ where
                 );
                 e.into()
             })
-            .map(|m| (m, msg.return_.clone()))
+            .map(|m| (m, return_.clone()))
     }
 
     #[inline]

--- a/implementations/rust/ockam/ockam_node/src/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay.rs
@@ -15,7 +15,7 @@
 //! The `Relay` is then responsible for turning the message back into
 //! a type and notifying the companion actor.
 
-use crate::{Context, Mailbox};
+use crate::{parser, Context, Mailbox};
 use ockam_core::{
     Address, Message, Result, Route, Routed, RouterMessage, TransportMessage, Worker,
 };
@@ -95,24 +95,6 @@ where
         }
     }
 
-    fn try_decode(mut v: Vec<u8>) -> Result<M> {
-        M::decode(&v).or_else(|_| {
-            trace!("Parsing payload without inner length...");
-
-            // This condition means we _may_ be dealing with a payload
-            // sent by a non-Rust implementation.  In this case we
-            // prepend the length of the mesage to the vector and try
-            // again.  I know it's bad, but as long as we don't have
-            // properly specified payload encoding this is what will
-            // have to do.
-            let mut new_v = vec![v.len() as u8]; // FIXME: does not handle message sizes over 255
-            trace!("New message length: {:?}", new_v);
-
-            new_v.append(&mut v);
-            M::decode(&new_v)
-        })
-    }
-
     /// Convenience function to handle an incoming direct message
     #[inline]
     fn handle_direct(&mut self, msg: TransportMessage) -> Result<(M, Route)> {
@@ -120,7 +102,7 @@ where
             payload, return_, ..
         } = msg;
 
-        Self::try_decode(payload)
+        parser::message::<M>(payload)
             .map_err(|e| {
                 error!(
                     "Failed to decode message payload for worker {}",

--- a/implementations/rust/ockam/ockam_node/src/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay.rs
@@ -150,10 +150,17 @@ Is your router accepting the correct message type? (ockam_core::RouterMessage)",
             let routed = Routed::new(msg, return_, onward);
 
             // Call the worker handle function
-            self.worker
-                .handle_message(&mut self.ctx, routed)
-                .await
-                .unwrap();
+            match self.worker.handle_message(&mut self.ctx, routed).await {
+                Ok(()) => {}
+                Err(e) => {
+                    error!(
+                        "Worker {} error while handling message: {}",
+                        self.ctx.address(),
+                        e
+                    );
+                    continue;
+                }
+            }
 
             // Unset the message address
             self.ctx.message_address(None);


### PR DESCRIPTION
Rename the onward and return route fields in TransportMessage. Required for #1149 