### PR TITLE
ockam_node v0.5.0

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -26,12 +26,12 @@ no_std = ["ockam_core/no_std", "serde"]
 bbs = { version = "0.4", optional = true }
 digest = { version = "0.8", optional = true }
 ff = { version = "0.6", package = "ff-zeroize", optional = true }
-ockam_core = {path = "../ockam_core", version = "0.6.0"}
-ockam_node = {path = "../ockam_node", version = "0.4.0", optional = true}
-ockam_node_attribute = {path = "../ockam_node_attribute", version = "0.1.4"}
-ockam_vault_core = {path = "../ockam_vault_core", version = "0.3.1"}
-ockam_vault = {path = "../ockam_vault", version = "0.3.1"}
-ockam_channel = {path = "../ockam_channel", version = "0.1.0"}
+ockam_core = {path = "../ockam_core", version = "0"}
+ockam_node = {path = "../ockam_node", version = "0", optional = true}
+ockam_node_attribute = {path = "../ockam_node_attribute", version = "0"}
+ockam_vault_core = {path = "../ockam_vault_core", version = "0"}
+ockam_vault = {path = "../ockam_vault", version = "0"}
+ockam_channel = {path = "../ockam_channel", version = "0"}
 arrayref = "0.3"
 pairing-plus = { version = "0.19", optional = true }
 serde_bare = "0.3"

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.0 - 2021-04-05
+### Added
+- Expose onward route information to user workers.
+- Random address generation.
+
+### Changed
+- Switch payload encoding from bincode to bare.
+- Split forwarding examples into two binaries.
+- Updated dependencies.
+- Rename route fields in transport message.
+
+### Removed
+- RemoteMailbox has been moved to the `ockam` crate.
+
+
 ## v0.6.0 - 2021-03-22
 ### Added
 - Routable message abstraction.

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.6.0"
+ockam_core = "0.7.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.6.0", default-features = false }
+ockam_core = { version = "0.7.0", default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
  "bbs",
  "digest 0.8.1",
  "ff-zeroize",
- "ockam_core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ockam_core 0.6.0",
  "ockam_node 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ockam_node_attribute 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ockam_vault 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1203,7 +1203,7 @@ dependencies = [
  "digest 0.8.1",
  "ff-zeroize",
  "ockam_channel",
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "ockam_node 0.4.0",
  "ockam_node_attribute 0.1.4",
  "ockam_vault 0.3.1",
@@ -1222,7 +1222,7 @@ name = "ockam_channel"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "ockam_key_exchange_core",
  "ockam_key_exchange_xx",
  "ockam_node 0.4.0",
@@ -1232,18 +1232,6 @@ dependencies = [
  "serde",
  "serde_bare",
  "tracing",
-]
-
-[[package]]
-name = "ockam_core"
-version = "0.6.0"
-dependencies = [
- "async-trait",
- "hashbrown 0.11.2",
- "hex",
- "rand 0.8.3",
- "serde",
- "serde_bare",
 ]
 
 [[package]]
@@ -1260,6 +1248,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_core"
+version = "0.7.0"
+dependencies = [
+ "async-trait",
+ "hashbrown 0.11.2",
+ "hex",
+ "rand 0.8.3",
+ "serde",
+ "serde_bare",
+]
+
+[[package]]
 name = "ockam_examples"
 version = "0.1.0"
 dependencies = [
@@ -1271,7 +1271,7 @@ dependencies = [
 name = "ockam_key_exchange_core"
 version = "0.1.0"
 dependencies = [
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "ockam_vault_core 0.3.1",
  "zeroize",
 ]
@@ -1280,7 +1280,7 @@ dependencies = [
 name = "ockam_key_exchange_xx"
 version = "0.1.0"
 dependencies = [
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "ockam_key_exchange_core",
  "ockam_vault_core 0.3.1",
  "zeroize",
@@ -1290,7 +1290,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.4.0"
 dependencies = [
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1302,7 +1302,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cf1b1aad6e43ec10916f06aca3cd19e3f682ea16b4be58b37547fe32c10d34"
 dependencies = [
- "ockam_core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ockam_core 0.6.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1365,7 +1365,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf 0.10.0",
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "ockam_vault_core 0.3.1",
  "rand 0.7.3",
  "sha2 0.9.3",
@@ -1384,7 +1384,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf 0.10.0",
- "ockam_core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ockam_core 0.6.0",
  "ockam_vault_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3",
  "sha2 0.9.3",
@@ -1397,7 +1397,7 @@ name = "ockam_vault_core"
 version = "0.3.1"
 dependencies = [
  "cfg-if",
- "ockam_core 0.6.0",
+ "ockam_core 0.7.0",
  "zeroize",
 ]
 
@@ -1408,7 +1408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5c6676d519992783d44a0763588ce180eda06433efa25993a15a6cf7ef4a6f"
 dependencies = [
  "cfg-if",
- "ockam_core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ockam_core 0.6.0",
  "zeroize",
 ]
 

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 lto = true
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.6.0" }
-ockam_vault_core = {path = "../ockam_vault_core", version = "0.3.0" }
-ockam_vault = { path = "../ockam_vault", version = "0.3.0" }
+ockam_core = { path = "../ockam_core", version = "0" }
+ockam_vault_core = {path = "../ockam_vault_core", version = "0" }
+ockam_vault = { path = "../ockam_vault", version = "0" }
 lazy_static = { version = "1.4" }

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -13,6 +13,6 @@ description = """The Ockam Key Exchange trait.
 """
 
 [dependencies]
-ockam_core = { version = "0.6.0", path = "../ockam_core" }
-ockam_vault_core = { version = "0.3.1", path = "../ockam_vault_core" }
+ockam_core = { version = "0", path = "../ockam_core" }
+ockam_vault_core = { version = "0", path = "../ockam_vault_core" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -13,12 +13,12 @@ description = """The Ockam X3DH impementation.
 """
 
 [dependencies]
-ockam_core = { version = "0.6.0", path = "../ockam_core" }
-ockam_vault_core = { version = "0.3.0", path = "../ockam_vault_core" }
-ockam_key_exchange_core = { version = "0.1.0", path = "../ockam_key_exchange_core" }
+ockam_core = { version = "0", path = "../ockam_core" }
+ockam_vault_core = { version = "0", path = "../ockam_vault_core" }
+ockam_key_exchange_core = { version = "0", path = "../ockam_key_exchange_core" }
 arrayref = "0.3"
 subtle = "2.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault = { version = "0.3.0", path = "../ockam_vault" }
+ockam_vault = { version = "0", path = "../ockam_vault" }

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -13,10 +13,10 @@ description = """The Ockam Noise XX impementation.
 """
 
 [dependencies]
-ockam_core = { version = "0.6.0", path = "../ockam_core" }
-ockam_vault_core = { version = "0.3.0", path = "../ockam_vault_core" }
-ockam_key_exchange_core = { version = "0.1.0", path = "../ockam_key_exchange_core" }
+ockam_core = { version = "0", path = "../ockam_core" }
+ockam_vault_core = { version = "0", path = "../ockam_vault_core" }
+ockam_key_exchange_core = { version = "0", path = "../ockam_key_exchange_core" }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault = { version = "0.3.0", path = "../ockam_vault" }
+ockam_vault = { version = "0", path = "../ockam_vault" }

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 - 2021-04-05
+### Added
+- Expose onward route information to user workers.
+- Make context receive retry receiving if wrong type.
+- Handle message payloads without inner length.
+- Make consuming cancel wrapper yield routed wrapper
+- Use special message parsing for context receive.
+
+### Changed
+- Updated dependencies.
+- Log worker errors instead of panicking.
+
+### Deleted
+
 ## v0.4.0 - 2021-03-22
 ### Added
 

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ockam_core",
  "tokio",

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 keywords = ["ockam", "crypto", "p2p", "async", "distributed"]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 ockam_core = {path = "../ockam_core", version = "0"}

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -9,7 +9,7 @@ name = "ockam_node"
 version = "0.4.0"
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.6.0"}
+ockam_core = {path = "../ockam_core", version = "0"}
 tokio = {version = "1.4.0", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"] }

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.4.0"
+ockam_node = "0.5.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.0",

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -21,8 +21,8 @@ std = ["ockam_core/std"]
 no_std = ["ockam_vault_core/heapless"]
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.6.0"}
-ockam_vault_core = {path = "../ockam_vault_core", version = "0.3.1"}
+ockam_core = {path = "../ockam_core", version = "0"}
+ockam_vault_core = {path = "../ockam_vault_core", version = "0"}
 arrayref = "0.3"
 aes-gcm = "0.8"
 curve25519-dalek = "3.0"

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "ockam_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -18,7 +18,7 @@ std = ["ockam_core/std"]
 no_std = ["heapless"]
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.6.0"}
+ockam_core = {path = "../ockam_core", version = "0"}
 heapless = { version = "0.6", optional = true }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 cfg-if = "1.0"


### PR DESCRIPTION
## v0.5.0 - 2021-04-05
### Added
- Expose onward route information to user workers.
- Make context receive retry receiving if wrong type.
- Handle message payloads without inner length.
- Make consuming cancel wrapper yield routed wrapper
- Use special message parsing for context receive.

### Changed
- Updated dependencies.
- Log worker errors instead of panicking.
