### PR TITLE
feat(rust): reject to spawn worker with colliding addresses

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -8,6 +8,10 @@ pub enum Error {
     FailedStopNode,
     /// Unable to start a worker
     FailedStartWorker,
+    /// Worker start failed because the address was already taken
+    WorkerAddressTaken,
+    /// The requested worker address is unknown
+    UnknownWorker,
     /// Unable to stop a worker
     FailedStopWorker,
     /// Unable to list available workers
@@ -34,8 +38,14 @@ impl From<Error> for ockam_core::Error {
 }
 
 impl From<crate::NodeError> for ockam_core::Error {
-    fn from(_: crate::NodeError) -> Self {
-        Error::InternalIOFailure.into()
+    fn from(err: crate::NodeError) -> Self {
+        use crate::NodeError::*;
+        match err {
+            NoSuchWorker(_) => Error::UnknownWorker,
+            WorkerExists(_) => Error::WorkerAddressTaken,
+            RouterExists => Error::InternalIOFailure,
+        }
+        .into()
     }
 }
 


### PR DESCRIPTION
This commit adds a check to not initialise & spawn workers that are being registered for addresses that are already in-use on the system.

Not all spawn errors are being caught yet, and the error types returned by `ockam_node` should be looked at again to make sure we can properly communicate to the user when things go wrong.