### PR TITLE
Move ockam-ffi crate to ockam_ffi

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Ockam Developers"]
-categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded-development"]
+categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded"]
 description = """Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 """
@@ -9,7 +9,7 @@ exclude = [
     "tests/**"
 ]
 homepage = "https://github.com/ockam-network/ockam"
-keywords = ["ockam", "crypto", "p2p", "encryption"]
+keywords = ["ockam", "crypto", "cryptography", "network-programming", "p2p", "encryption"]
 license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_core"
 readme = "README.md"
-categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded-development"]
+categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded"]
 keywords = ["ockam", "crypto", "p2p", "cryptography", "encryption"]
 description = """
 Core types of the Ockam library.

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# v0.1.0 - 2021-03-03
+# v0.1.0 - 2021-04-05
 
 - Initial release.

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -279,16 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
-name = "ockam-ffi"
-version = "0.1.0"
-dependencies = [
- "lazy_static",
- "ockam_core",
- "ockam_vault",
- "ockam_vault_core",
-]
-
-[[package]]
 name = "ockam_core"
 version = "0.7.0"
 dependencies = [
@@ -298,6 +288,16 @@ dependencies = [
  "rand 0.8.3",
  "serde",
  "serde_bare",
+]
+
+[[package]]
+name = "ockam_ffi"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "ockam_core",
+ "ockam_vault",
+ "ockam_vault_core",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ockam-ffi"
+name = "ockam_ffi"
 version = "0.1.0"
 authors = ["Ockam Developers"]
 edition = "2018"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -7,8 +7,8 @@ license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_core"
 readme = "README.md"
-categories = ["cryptography", "asynchronous", "authentication","peer-to-peer", "no-std"]
-keywords = ["ockam", "crypto", "p2p", "cryptography", "encryption"]
+categories = ["cryptography", "asynchronous", "authentication","embedded", "no-std"]
+keywords = ["ockam", "crypto", "kex", "cryptography", "encryption", "iot"]
 description = """The Ockam Key Exchange trait.
 """
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -7,8 +7,8 @@ license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_x3dh"
 readme = "README.md"
-categories = ["cryptography", "asynchronous", "authentication","peer-to-peer", "no-std"]
-keywords = ["ockam", "crypto", "cryptography", "iot"]
+categories = ["cryptography", "asynchronous", "authentication","embedded", "no-std"]
+keywords = ["ockam", "crypto", "x3dh", "cryptography", "encryption", "iot"]
 description = """The Ockam X3DH impementation.
 """
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -7,8 +7,8 @@ license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_xx"
 readme = "README.md"
-categories = ["cryptography", "asynchronous", "authentication","peer-to-peer", "no-std"]
-keywords = ["ockam", "crypto", "p2p", "xx"]
+categories = ["cryptography", "asynchronous", "authentication","embedded", "no-std"]
+keywords = ["ockam", "crypto", "xx", "cryptography", "encryption", "iot"]
 description = """The Ockam Noise XX impementation.
 """
 

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 authors = ["Ockam Developers"]
-categories = ["cryptography", "asynchronous", "authentication","peer-to-peer", "network-programming"]
+categories = ["cryptography", "asynchronous", "authentication","embedded", "network-programming"]
 description = "Ockam Node implementation crate"
 edition = "2018"
-keywords = ["ockam", "crypto", "p2p", "async", "distributed"]
+keywords = ["ockam", "crypto", "cryptography", "network-programming", "p2p", "encryption"]
 license = "Apache-2.0"
 name = "ockam_node"
 version = "0.5.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_transport_tcp"
 readme = "README.md"
 keywords = ["ockam", "crypto", "network", "networking", "tcp"]
-categories = ["cryptography", "asynchronous", "authentication","network-programming", "peer-to-peer"]
+categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded"]
 description = """
 TCP Transport for the Ockam Routing Protocol.
 """


### PR DESCRIPTION
Changes crate name to `ockam_ffi` instead of `ockam-ffi`