### PR TITLE
chore: add clippy on stable rust job

### DIFF
--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -14,8 +14,8 @@ commands {
     lint: [
       'cargo check',
       'cargo fmt --all -- --check',
-      // 'cargo +nightly clippy --all -- -D warnings',
-    ]
+      'cargo clippy --all --all-targets -- --cap-lints=warn',
+    ],
   ]
 
   directories = [


### PR DESCRIPTION
As a first step towards enabling clippy in CI, this PR adds the clippy as an additional step of the lint job, for both production and test code.

As I mentioned in the issue https://github.com/ockam-network/ockam/issues/1014, I think the best we can do for now is to set this step as optional (in this case, all clippy errors/warnings won't make the pipeline fail) until all clippy recommendations are applied, which could be done in small PR's across the different subcrates.

After that, we could then enable clippy in the nightly pipeline and use clippy as we'd normally do (`-D warnings`).

Let me know what you think!

-----

Note: the lint step fails because one of the examples is broken:

```rust
    Checking ockam_examples v0.1.0 (/__w/ockam/ockam/implementations/rust/ockam/ockam_examples)
error[E0432]: unresolved import `ockam::RemoteMailbox`
 --> examples/step-4-server.rs:1:36
  |
1 | use ockam::{async_worker, Context, RemoteMailbox, Result, Routed, Worker};
  |                                    ^^^^^^^^^^^^^ no `RemoteMailbox` in the root
```

 

