### PR TITLE
fix: bump ockam vers to pick up new ockam_core

### DIFF
--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.2 - 2021-04-05
+### Changed
+- Dependency updates.
+
 ## v0.4.1 - 2021-03-31
 ### Changed
 - Updated documentation.

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -778,7 +778,7 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "ockam"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arrayref",
  "bbs",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.4.1"
+version = "0.4.2"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
bump lock file