### PR TITLE
feat(rust): allow duplicating context outside of worker lifecycle

### DIFF
--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -2629,6 +2629,7 @@ dependencies = [
  "ockam 0.4.2",
  "ockam_node 0.5.0",
  "serde",
+ "tokio",
  "tracing",
 ]
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
@@ -13,4 +13,5 @@ ockam_node = { path = "../../../ockam_node", version = "0.5.0" }
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
+tokio = { version = "1.0", features = ["full"] }
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_custom_context.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_custom_context.rs
@@ -1,0 +1,48 @@
+//! This example demonstrates how you can gain access to the worker
+//! context, without having to conform to a usual worker lifecycle.
+
+use ockam::{Context, Result};
+use std::time::Duration;
+use tracing::info;
+
+/// A custom runner with access to the node context
+struct Custom(Context);
+
+impl Custom {
+    fn run(self) {
+        let mut ctx = self.0;
+        tokio::spawn(async move {
+            ctx.send_message("app", "Hello 1".to_string())
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Wait for a reply
+            let reply = ctx.receive::<String>().await.unwrap();
+            info!("Ok: {}", reply);
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            ctx.send_message("app", "Hello 3".to_string())
+                .await
+                .unwrap();
+        });
+    }
+}
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    // Create and run our non-worker
+    let ctx2 = ctx.new_context("some.address").await?;
+    Custom(ctx2).run();
+
+    assert_eq!(ctx.receive::<String>().await?, "Hello 1".to_string());
+    info!("Ok");
+
+    ctx.send_message("some.address", "Hello 2".to_string())
+        .await?;
+
+    assert_eq!(ctx.receive::<String>().await?, "Hello 3".to_string());
+    info!("Ok");
+
+    ctx.stop().await
+}

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,5 +1,7 @@
 use crate::{
+    block_future,
     error::Error,
+    node::NullWorker,
     parser,
     relay::{self, RelayMessage},
     Cancel, Mailbox, NodeMessage,
@@ -17,6 +19,17 @@ pub struct Context {
     sender: Sender<NodeMessage>,
     rt: Arc<Runtime>,
     pub(crate) mailbox: Mailbox,
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        let addr = self.address.first();
+        trace!("Running Context::drop()");
+
+        if let Err(e) = block_future(self.rt.as_ref(), async { self.stop_worker(addr).await }) {
+            error!("Error occured during Context::drop(): {}", e);
+        };
+    }
 }
 
 impl Context {
@@ -50,6 +63,26 @@ impl Context {
             .clone()
             .or(Some(self.address.first().clone()))
             .unwrap()
+    }
+
+    /// Create a new context without spawning a full worker
+    pub async fn new_context<S: Into<Address>>(&self, addr: S) -> Result<Context> {
+        let addr = addr.into();
+        let ctx = NullWorker::new(Arc::clone(&self.rt), &addr, self.sender.clone());
+
+        // Create a small relay and register it with the internal router
+        let sender = relay::build_root::<NullWorker, _>(Arc::clone(&self.rt), &ctx.mailbox);
+        let (msg, mut rx) = NodeMessage::start_worker(addr.into(), sender);
+        self.sender
+            .send(msg)
+            .await
+            .map_err(|_| Error::FailedStartWorker)?;
+
+        Ok(rx
+            .recv()
+            .await
+            .ok_or(Error::InternalIOFailure)?
+            .map(|_| ctx)?)
     }
 
     /// Start a new worker handle at [`Address`](ockam_core::Address)

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -28,3 +28,27 @@ pub use mailbox::*;
 pub use messages::*;
 
 pub use node::start_node;
+
+use std::future::Future;
+use tokio::{runtime::Runtime, task};
+
+/// Execute a future without blocking the executor
+///
+/// This is a wrapper around two simple tokio functions to allow
+/// ockam_node to wait for a task to be completed in a non-async
+/// environment.
+///
+/// This function is not meant to be part of the ockam public API, but
+/// as an implementation utility for other ockam utilities that use
+/// tokio.
+#[doc(hidden)]
+pub fn block_future<'r, F>(rt: &'r Runtime, f: F) -> <F as Future>::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    task::block_in_place(move || {
+        let local = task::LocalSet::new();
+        local.block_on(&rt, f)
+    })
+}


### PR DESCRIPTION
This change allows the node Context to be used outside of the regular worker lifecycle, the same way that the root worker (so far called `App`, now renamed to `NullWorker`) has previously done.

The `Context` still has an address, and can wait for messages with `ctx.receive()`, but no longer runs its lifecycle loop (accepting messages) on its own.

This is a feature needed by @SanjoDeundiak to more easily implement wrapper types for the vault APIs. It also allows us to refactor the `ockam_transport_tcp` internals to be simplified.