### PR TITLE
chore: explicitly pass public ip in telemetry_forwarder

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/lib/hub.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub.ex
@@ -37,7 +37,22 @@ defmodule Ockam.Hub do
     # send some events to our UI to aid end-user development
     token = Application.get_env(:ockam_hub, :auth_message)
     host = Application.get_env(:ockam_hub, :auth_host)
-    TelemetryForwarder.attach_send_to_ui(host, token)
+
+    # I hate this but Azure seems to rewrite DNS sometimes.
+    # DNS shows public IP but when hitting nginx it shows
+    # 10.92.0.x
+    # additionally, not using azure's IP check because
+    # it outputs a bunch of html instead of plaintext
+    # or json.
+    {:ok, %{body: resp_body}} = HTTPoison.get("https://checkip.amazonaws.com")
+
+    public_ip = String.trim(resp_body)
+
+    # on app start, create the node if it does not exist
+    # we probably don't care if this errors.
+    TelemetryForwarder.create_node(host, token, public_ip)
+
+    TelemetryForwarder.attach_send_to_ui(host, token, public_ip)
 
     # Specifications of child processes that will be started and supervised.
     #

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/telemetry_forwarder.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/telemetry_forwarder.ex
@@ -1,6 +1,8 @@
 defmodule Ockam.Hub.TelemetryForwarder do
   @moduledoc false
 
+  require Logger
+
   @spec forward(any, [atom, ...], any, any) :: :ok | {:error, :already_exists}
   def forward(handler_name, event_name, node_name, process_name) do
     handler = fn ev, mes, met, opt ->
@@ -10,8 +12,8 @@ defmodule Ockam.Hub.TelemetryForwarder do
     :telemetry.attach(handler_name, event_name, handler, nil)
   end
 
-  @spec attach_send_to_ui(any, any) :: :ok | {:error, :already_exists}
-  def attach_send_to_ui(host, token) do
+  @spec attach_send_to_ui(any, any, any) :: :ok | {:error, :already_exists}
+  def attach_send_to_ui(host, token, public_ip) do
     event_name = [:ockam, Ockam.Node, :handle_routed_message, :start]
 
     handler = fn _event, _message, metadata, _options ->
@@ -24,11 +26,42 @@ defmodule Ockam.Hub.TelemetryForwarder do
       payload = Jason.encode!(metadata)
       token = URI.encode_www_form(token)
 
-      HTTPoison.post("#{host}/messages?token=#{token}", payload, [
+      HTTPoison.post("#{host}/messages?token=#{token}&public_ip=#{public_ip}", payload, [
         {"Content-Type", "application/json"}
       ])
     end
 
     :telemetry.attach(:send_to_ui, event_name, handler, nil)
+  end
+
+  @spec create_node(any, any, any) :: :ok
+  def create_node(host, token, public_ip) do
+    payload =
+      Jason.encode!(%{
+        node: %{
+          ip: public_ip,
+          hostname: "auto-added",
+          port: 4000
+        }
+      })
+
+    case HTTPoison.post("#{host}/nodes?token=#{token}&public_ip=#{public_ip}", payload, [
+           {"Content-Type", "application/json"}
+         ]) do
+      {:ok, %{status_code: 204}} ->
+        :ok
+
+      {:ok, %{status_code: 422}} ->
+        Logger.info("Node already created in UI")
+        :ok
+
+      {:error, %HTTPoison.Error{reason: :econnrefused}} ->
+        Logger.error("connection refused trying to create a node")
+        :ok
+    end
+
+    # we don't care if this fails,
+    # we'll see it in the nginx log
+    :ok
   end
 end


### PR DESCRIPTION
Azure seems to redirect public IP access to the internal networking.
We need to know the public IP so we can provide it to users.
This commit uses an external service to get it since asking Azure is surprisingly difficult.