### PR TITLE
chore(rust): Make sure Cargo.lock file is updated.

### DIFF
--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -7,8 +7,8 @@ commands {
   group = 'ockam'
 
   list = [
-    build: 'cargo build',
-    test: 'cargo test',
+    build: 'cargo --locked build',
+    test: 'cargo --locked test',
     clean: 'cargo clean',
     veryClean: 'cargo clean',
     lint: [


### PR DESCRIPTION
Using the `--locked` option to `cargo build` and `cargo test`. If the
`Cargo.lock` file is not updated, the build fails.


Signed-off-by: Abhijit Gadgil <gabhijit@iitbombay.org>

<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes

Fixes issue #1012 
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
