### PR TITLE
refactor(rust): rename context address functions

### DIFF
--- a/implementations/rust/ockam/ockam/src/remote_mailbox.rs
+++ b/implementations/rust/ockam/ockam/src/remote_mailbox.rs
@@ -56,7 +56,7 @@ impl<T: Message> RemoteMailbox<T> {
         hub_addr: SocketAddr,
         destination: A,
     ) -> Result<RemoteMailboxInfo> {
-        let remote_mailbox = Self::new(hub_addr, destination.into(), ctx.primary_address());
+        let remote_mailbox = Self::new(hub_addr, destination.into(), ctx.address());
 
         let worker_address: Address = random();
         ctx.start_worker(worker_address, remote_mailbox).await?;
@@ -95,7 +95,7 @@ impl<T: Message> Worker for RemoteMailbox<T> {
             RemoteMailboxInfo {
                 forwarding_route: route,
                 remote_address: address,
-                worker_address: ctx.primary_address(),
+                worker_address: ctx.address(),
             },
         )
         .await?;

--- a/implementations/rust/ockam/ockam_channel/src/key_exchange/initiator.rs
+++ b/implementations/rust/ockam/ockam_channel/src/key_exchange/initiator.rs
@@ -92,7 +92,7 @@ impl Worker for XInitiator {
                 .await?;
 
                 if should_stop {
-                    ctx.stop_worker(ctx.primary_address()).await?;
+                    ctx.stop_worker(ctx.address()).await?;
                 }
             }
         }

--- a/implementations/rust/ockam/ockam_channel/src/key_exchange/responder.rs
+++ b/implementations/rust/ockam/ockam_channel/src/key_exchange/responder.rs
@@ -82,7 +82,7 @@ impl Worker for XResponder {
                 .await?;
 
                 if should_stop {
-                    ctx.stop_worker(ctx.primary_address()).await?;
+                    ctx.stop_worker(ctx.address()).await?;
                 }
             }
         }

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -92,7 +92,7 @@ impl SecureChannel {
             route.into(),
             address_remote.clone(),
             address_local.clone(),
-            Some(Route::new().append(ctx.primary_address()).into()),
+            Some(Route::new().append(ctx.address()).into()),
         );
 
         ctx.start_worker(vec![address_remote, address_local.clone()], channel)

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -19,6 +19,11 @@ impl AddressSet {
         self.0.iter()
     }
 
+    /// Turn this set into an iterator
+    pub fn into_iter(self) -> impl Iterator<Item = Address> {
+        self.0.into_iter()
+    }
+
     /// Take the first address of the set.
     pub fn first(&self) -> Address {
         self.0.first().cloned().unwrap()

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/src/client_worker.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/src/client_worker.rs
@@ -47,7 +47,7 @@ impl Worker for Client {
                 .into(),
         );
 
-        ctx.send(ctx.primary_address(), "recursion".to_string())
+        ctx.send(ctx.address(), "recursion".to_string())
             .await?;
 
         Ok(())
@@ -63,7 +63,7 @@ impl Worker for Client {
                     .map(char::from)
                     .collect();
                 info!("Client sent message: {}", rand_string);
-                ctx.send(ctx.primary_address(), "recursion".to_string())
+                ctx.send(ctx.address(), "recursion".to_string())
                     .await?;
                 ctx.send(self.route.clone().unwrap(), rand_string).await?;
                 tokio::time::sleep(Duration::from_secs(2)).await;

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/issuer.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/issuer.rs
@@ -21,7 +21,7 @@ impl Worker for Issuer {
     type Context = Context;
 
     async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
-        println!("Issuer listening on {}.", ctx.primary_address());
+        println!("Issuer listening on {}.", ctx.address());
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/node/examples/create_ping_pong_node.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/node/examples/create_ping_pong_node.rs
@@ -34,7 +34,7 @@ impl Worker for Player {
     type Context = Context;
 
     async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
-        println!("Starting player {}", ctx.primary_address());
+        println!("Starting player {}", ctx.address());
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_local_routing.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_local_routing.rs
@@ -13,7 +13,7 @@ impl Worker for MyRouter {
         println!("Received: {}", msg);
         let mut msg = msg.into_transport_message();
         msg.onward_route.step()?;
-        msg.return_route.modify().prepend(ctx.primary_address());
+        msg.return_route.modify().prepend(ctx.address());
         ctx.forward(msg).await
     }
 }

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_multi_address.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_multi_address.rs
@@ -8,12 +8,12 @@ impl Worker for MultiAddressWorker {
     type Context = Context;
 
     async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
-        println!("Worker main address: '{}'", ctx.primary_address());
+        println!("Worker main address: '{}'", ctx.address());
         Ok(())
     }
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        println!("Addr '{}' received: '{}'", ctx.primary_address(), msg);
+        println!("Addr '{}' received: '{}'", ctx.address(), msg);
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_simple_router.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_simple_router.rs
@@ -75,7 +75,7 @@ impl Worker for Consumer {
     type Context = Context;
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
-        info!("Starting consumer '{}'...", ctx.primary_address());
+        info!("Starting consumer '{}'...", ctx.address());
 
         // Register this consumer with the router by its accept scope
         // (which is used in a look-up table in the router to forward
@@ -87,8 +87,8 @@ impl Worker for Consumer {
         ctx.send(
             "simple.router",
             RouterMessage::Register {
-                accepts: format!("10#proxy_me_{}", ctx.primary_address()).into(),
-                self_addr: ctx.primary_address(),
+                accepts: format!("10#proxy_me_{}", ctx.address()).into(),
+                self_addr: ctx.address(),
             },
         )
         .await?;

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -47,8 +47,18 @@ impl Context {
     }
 
     /// Return the primary worker address
-    pub fn primary_address(&self) -> Address {
+    pub fn address(&self) -> Address {
         self.address.first().clone()
+    }
+
+    /// Return all addresses of this worker
+    pub fn aliases(&self) -> AddressSet {
+        self.address
+            .clone()
+            .into_iter()
+            .skip(1)
+            .collect::<Vec<_>>()
+            .into()
     }
 
     /// Create a new context without spawning a full worker
@@ -154,8 +164,7 @@ impl Context {
         R: Into<Route>,
         M: Message + Send + 'static,
     {
-        self.send_from_address(route, msg, self.primary_address())
-            .await
+        self.send_from_address(route, msg, self.address()).await
     }
 
     /// Send a message via a fully qualified route using specific Worker address
@@ -197,7 +206,7 @@ impl Context {
         // Pack the payload into a TransportMessage
         let payload = msg.encode().unwrap();
         let mut data = TransportMessage::v1(route.clone(), payload);
-        data.return_route.modify().append(self.primary_address());
+        data.return_route.modify().append(self.address());
 
         // Pack transport message into relay message wrapper
         let msg = if needs_wrapping {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/listener.rs
@@ -65,6 +65,6 @@ impl Worker for TcpListenWorker {
             .await?;
         }
 
-        ctx.stop_worker(ctx.primary_address()).await
+        ctx.stop_worker(ctx.address()).await
     }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/receiver.rs
@@ -35,7 +35,7 @@ impl Worker for TcpRecvWorker {
     // Also: we must stop the TcpReceive loop when the worker gets
     // killed by the user or node.
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
-        let self_addr = ctx.primary_address();
+        let self_addr = ctx.address();
 
         // Run in a loop until TcpWorkerPair::stop() is called
         // FIXME: see ArcBool future note

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
@@ -51,7 +51,7 @@ impl Worker for TcpRouter {
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
         trace!("Registering TCP router for type = 1");
-        ctx.register(1, ctx.primary_address()).await?;
+        ctx.register(1, ctx.address()).await?;
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/sender.rs
@@ -56,7 +56,7 @@ impl Worker for TcpSendWorker {
 
         if let Err(_) = self.tx.write(msg.as_slice()).await {
             warn!("Failed to send message to peer {}", self.peer);
-            ctx.stop_worker(ctx.primary_address()).await?;
+            ctx.stop_worker(ctx.address()).await?;
         }
 
         Ok(())


### PR DESCRIPTION
* primary_address -> address
* add aliases which returns all secondary addresses

This was my suggestion from the miro board.  But may we should discuss how users should have access to their secondary functions.
