### PR TITLE
feat: use env var to get node fqdn

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/lib/hub.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub.ex
@@ -38,16 +38,8 @@ defmodule Ockam.Hub do
     token = Application.get_env(:ockam_hub, :auth_message)
     host = Application.get_env(:ockam_hub, :auth_host)
 
-    # I hate this but Azure seems to rewrite DNS sometimes.
-    # DNS shows public IP but when hitting nginx it shows
-    # 10.92.0.x
-    # additionally, not using azure's IP check because
-    # it outputs a bunch of html instead of plaintext
-    # or json.
-    {:ok, %{body: resp_body}} = HTTPoison.get("https://checkip.amazonaws.com")
-
-    public_ip = String.trim(resp_body)
-
+    public_ip = Application.get_env(:ockam_hub, :node_ip)
+    public_ip = :inet.ntoa(public_ip)
     # on app start, create the node if it does not exist
     # we probably don't care if this errors.
     TelemetryForwarder.create_node(host, token, public_ip)


### PR DESCRIPTION
Setting an env var is the fastest way for a node to know its FQDN and external IP.