### PR TITLE
Getting tcp_transport working with multi-hop routes

### DIFF
--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-initiator.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-initiator.rs
@@ -1,0 +1,25 @@
+use ockam::{Context, Result, Route};
+use ockam_transport_tcp::{TcpTransport, TCP};
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    TcpTransport::create(&ctx, "127.0.0.1:4000").await?;
+
+    ctx.send(
+        Route::new()
+            // Send a message to node B
+            .append_t(TCP, "127.0.0.1:4000")
+            // Send a message to node C
+            .append_t(TCP, "127.0.0.1:6000")
+            // Echo worker on node C
+            .append("echoer"),
+        "Hello Ockam!".to_string(),
+    )
+    .await?;
+
+    // Wait to receive a reply and print it.
+    let reply = ctx.receive::<String>().await?;
+    println!("Initiator Received: {}", reply); // should print "Hello Ockam!"
+
+    ctx.stop().await
+}

--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-middle.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-middle.rs
@@ -1,0 +1,11 @@
+use ockam::{Context, Result};
+use ockam_transport_tcp::TcpTransport;
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    TcpTransport::create_listener(&ctx, "127.0.0.1:4000").await?;
+    TcpTransport::create(&ctx, "127.0.0.1:6000").await?;
+
+    // This node never shuts down.
+    Ok(())
+}

--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-responder.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-responder.rs
@@ -1,0 +1,14 @@
+use ockam::{Context, Result};
+use ockam_get_started::Echoer;
+use ockam_transport_tcp::TcpTransport;
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    TcpTransport::create_listener(&ctx, "127.0.0.1:6000").await?;
+
+    // Create an echoer worker
+    ctx.start_worker("echoer", Echoer).await?;
+
+    // This node never shuts down.
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -1,5 +1,5 @@
 use crate::lib::{
-    fmt::{self, Display},
+    fmt::{self, Debug, Display},
     str::from_utf8,
     String, ToString, Vec,
 };
@@ -72,7 +72,7 @@ impl<'a> From<&'a str> for AddressSet {
 /// string, the first `#` symbol is used to separate the type from the
 /// rest of the address.  If no `#` symbol is found, the address is
 /// assumed to be of `tt = 0` (local worker).
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Address {
     /// The address type
     pub tt: u8,
@@ -112,6 +112,13 @@ impl Address {
 }
 
 impl Display for Address {
+    fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
+        let inner: &'a str = from_utf8(&self.inner.as_slice()).unwrap_or("Invalid UTF-8");
+        write!(f, "{}#{}", self.tt, inner)
+    }
+}
+
+impl Debug for Address {
     fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
         let inner: &'a str = from_utf8(&self.inner.as_slice()).unwrap_or("Invalid UTF-8");
         write!(f, "{}#{}", self.tt, inner)

--- a/implementations/rust/ockam/ockam_node/src/router.rs
+++ b/implementations/rust/ockam/ockam_node/src/router.rs
@@ -132,6 +132,11 @@ impl Router {
         reply: &Sender<NodeReplyResult>,
     ) -> Result<()> {
         trace!("Starting new worker '{}'", addrs.first());
+
+        if std::env::var("OCKAM_DUMP_INTERNALS").is_ok() {
+            trace!("{:#?}", self.internal);
+        }
+
         let sender = Arc::new(sender);
         addrs.iter().for_each(|addr| {
             self.internal.insert(addr.clone(), Arc::clone(&sender));

--- a/implementations/rust/ockam/ockam_transport_tcp/src/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/receiver.rs
@@ -78,13 +78,7 @@ impl Worker for TcpRecvWorker {
             trace!("Message onward route: {}", msg.onward_route);
             trace!("Message return route: {}", msg.return_route);
 
-            // FIXME: if we need to re-route (i.e. send it to another
-            // domain specific router) the message here, use
-            // send_message, instead of forward.
-
-            // Forward the message to the final destination worker,
-            // which consumes the TransportMessage and yields the
-            // final message type
+            // Forward the message to the next hop in the route
             ctx.forward(msg).await?;
         }
 


### PR DESCRIPTION
To run the example:

1. cargo run --example 08-routing-over-transport-many-hops-responder
2. cargo run --example 08-routing-over-transport-many-hops-middle
3. cargo run --example 08-routing-over-transport-many-hops-initiator

To run this in a single binary the TcpTransport API needs to change slightly.


<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->