### PR TITLE
chore(rust): simplify tcp init process

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -61,3 +61,13 @@ impl TcpTransport {
         TcpRouter::bind(ctx, socket_addr).await
     }
 }
+
+pub async fn establish_tcp_connection(
+    ctx: &mut Context,
+    remote_node: String,
+) -> Result<&mut Context> {
+    let router = TcpRouter::register(ctx).await?;
+    let connection = TcpTransport::create(ctx, remote_node.parse::<SocketAddr>().unwrap()).await?;
+    router.register(&connection).await?;
+    Ok(ctx)
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
Rust - Implement a higher level TCP registration and initialization process

In this PR I wanted to address [#1161](https://github.com/ockam-network/ockam/issues/1161).

@jared-s 
What do you think of such a function?
Is there ockam_transport_tcp lib.rs correct place to put such a function?
Were you thinking of something different than just wrapping initialization and registration code into a public function?
In here, I am just returning `Context` and then `send_message()` can be called on this context.
