### PR TITLE
Spacekookie/tcp api

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -109,6 +109,14 @@ impl Address {
 
         Self { tt, inner }
     }
+
+    /// Generate a random address with a specific type
+    pub fn random(tt: u8) -> Self {
+        let mut rng = rand::thread_rng();
+        let address: [u8; 16] = rng.gen();
+        let inner = hex::encode(address).as_bytes().into();
+        Self { tt, inner }
+    }
 }
 
 impl Display for Address {

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-ockam = { path = "../../../ockam", version = "0.5.0" }
-ockam_node = { path = "../../../ockam_node", version = "0.6.0" }
+ockam = { path = "../../../ockam", version = "*" }
+ockam_node = { path = "../../../ockam_node", version = "*" }
 tracing = "0.1"
-ockam_transport_tcp = { path = "../../../ockam_transport_tcp", version = "0.2.0" }
+ockam_transport_tcp = { path = "../../../ockam_transport_tcp", version = "*" }
 tokio = {version = "1.1.0", features = ["rt-multi-thread","sync","net","macros","time"]}
 rand = "0.8.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/verifier.rs
@@ -88,12 +88,10 @@ async fn main(ctx: Context) -> Result<()> {
 
     let local_tcp = format!("0.0.0.0:{}", port);
 
-    let router = TcpTransport::create_listener(&ctx, local_tcp).await?;
-
     let issuer = issuer_on_or_default(args.issuer);
-    let pair = TcpTransport::create(&ctx, &issuer).await?;
 
-    router.register(&pair).await?;
+    let tcp = TcpTransport::create_listener(&ctx, local_tcp).await?;
+    tcp.connect(&issuer).await?;
 
     ctx.start_worker(
         "verifier",

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-ockam = { path = "../../../ockam", version = "0.5.0" }
-ockam_node = { path = "../../../ockam_node", version = "0.6.0" }
-ockam_transport_tcp = { path = "../../../ockam_transport_tcp", version = "0.2.0" }
+ockam = { path = "../../../ockam", version = "*" }
+ockam_node = { path = "../../../ockam_node", version = "*" }
+ockam_transport_tcp = { path = "../../../ockam_transport_tcp", version = "*" }
 
 # TODO: this dependency here is required because rustc doesn't yet
 # support re-exporting attributes from crates.  Tracking issue:

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -56,6 +56,6 @@ impl Executor {
 
         // Block this task executing the primary message router,
         // returning any critical failures that it encounters.
-        rt.block_on(self.router.run())
+        crate::block_future(&rt, self.router.run())
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -1,12 +1,12 @@
 //! ockam_node - Ockam Node API
 #![deny(
     // missing_docs,
+    dead_code,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
     unused_import_braces,
     unused_qualifications,
-    // warnings
 )]
 
 #[macro_use]

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -48,11 +48,14 @@ pub fn start_node() -> (Context, Executor) {
 
 /// Utility to setup tracing-subscriber from the environment
 fn setup_tracing() {
-    fmt()
+    if let Err(_) = fmt()
         .with_env_filter(EnvFilter::try_from_env("OCKAM_LOG").unwrap_or_else(|_| {
             EnvFilter::default()
                 .add_directive(LevelFilter::INFO.into())
                 .add_directive("ockam_node=info".parse().unwrap())
         }))
-        .init();
+        .try_init()
+    {
+        debug!("Failed to initialise tracing_subscriber.  Is an instance already running?");
+    }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/init.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/init.rs
@@ -6,6 +6,7 @@ use ockam::{Address, Context, Result};
 use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
+#[derive(Debug)]
 pub struct WorkerPair {
     pub(crate) peer: SocketAddr,
     pub(crate) tx_addr: Address,
@@ -22,11 +23,11 @@ impl WorkerPair {
         Ok(())
     }
 
-    fn from_peer(addr: &SocketAddr) -> Self {
+    fn from_peer(peer: SocketAddr) -> Self {
         Self {
-            peer: addr.clone(),
-            tx_addr: format!("{}_tx", addr).into(),
-            rx_addr: format!("{}_rx", addr).into(),
+            peer,
+            tx_addr: Address::random(0),
+            rx_addr: Address::random(0),
             run: atomic::new(true),
         }
     }
@@ -43,7 +44,7 @@ impl WorkerPair {
             rx_addr,
             tx_addr,
             run,
-        } = WorkerPair::from_peer(&peer);
+        } = WorkerPair::from_peer(peer);
 
         trace!("Creating new worker pair from stream");
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/init.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/init.rs
@@ -1,6 +1,6 @@
 use crate::{
     atomic::{self, ArcBool},
-    TcpError, TcpRecvWorker, TcpRouter, TcpSendWorker,
+    TcpError, TcpRecvWorker, TcpRouterHandle, TcpSendWorker,
 };
 use ockam::{Address, Context, Result};
 use std::net::SocketAddr;
@@ -88,12 +88,14 @@ impl WorkerPair {
 /// One worker handles outgoing messages, while another handles
 /// incoming messages.  The local worker address is chosen based on
 /// the peer the worker is meant to be connected to.
-pub async fn start_connection<P>(ctx: &Context, peer: P) -> Result<WorkerPair>
+pub async fn start_connection<P>(
+    ctx: &Context,
+    router: &TcpRouterHandle<'_>,
+    peer: P,
+) -> Result<WorkerPair>
 where
     P: Into<SocketAddr>,
 {
-    let router = TcpRouter::register_or_get(ctx).await?;
-
     let peer = peer.into();
     let pair = WorkerPair::start(ctx, peer).await?;
     router.register(&pair).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![deny(
     // missing_docs,
+    dead_code,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -78,8 +78,9 @@ impl<'ctx> TcpTransport<'ctx> {
         ctx: &'ctx Context,
         bind_addr: S,
     ) -> Result<TcpTransport<'ctx>> {
-        let addr = parse_socket_addr(bind_addr)?;
-        let router = TcpRouter::bind(ctx, addr).await?;
+        let addr = Address::random(0);
+        let bind_addr = parse_socket_addr(bind_addr)?;
+        let router = TcpRouter::bind(ctx, addr, bind_addr).await?;
         Ok(Self { ctx, router })
     }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/listener.rs
@@ -19,7 +19,7 @@ impl TcpListenWorker {
         addr: SocketAddr,
         run: ArcBool,
     ) -> Result<()> {
-        let waddr = format!("{}_listener", addr);
+        let waddr = Address::random(0);
 
         debug!("Binding TcpListener to {}", addr);
         let inner = TcpListener::bind(addr)
@@ -31,7 +31,7 @@ impl TcpListenWorker {
             router_addr,
         };
 
-        ctx.start_worker(waddr.as_str(), worker).await?;
+        ctx.start_worker(waddr, worker).await?;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
@@ -109,28 +109,18 @@ impl TcpRouter {
         Ok(())
     }
 
-    /// Either register a new router or return a handle to the existing one
-    pub(crate) async fn register_or_get<'c>(ctx: &'c Context) -> Result<TcpRouterHandle<'c>> {
-        let addr = Address::from(DEFAULT_ADDRESS);
-        Self::register(ctx).await.or_else(|_| {
-            debug!("Using pre-existing TCP router...");
-            Ok(TcpRouterHandle { ctx, addr })
-        })
-    }
-
     /// Create and register a new TCP router with the node context
     ///
     /// To also handle incoming connections, use
     /// [`TcpRouter::bind`](TcpRouter::bind)
-    pub async fn register<'c>(ctx: &'c Context) -> Result<TcpRouterHandle<'c>> {
-        let addr = Address::from(DEFAULT_ADDRESS);
+    pub async fn register<'c>(ctx: &'c Context, addr: Address) -> Result<TcpRouterHandle<'c>> {
         Self::start(ctx, &addr, None).await?;
         Ok(TcpRouterHandle { ctx, addr })
     }
 
     /// Register a new TCP router and bind a connection listener
     ///
-    /// Use this function when your node is the server part of your
+    ///  Use this function when your node is the server part of your
     /// connection architecture.  For clients that shouldn't listen
     /// for connections themselves, use
     /// [`TcpRouter::register`](TcpRouter::register).

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
@@ -6,8 +6,6 @@ use crate::{
 use ockam::{async_worker, Address, Context, Result, Routed, RouterMessage, Worker};
 use std::{collections::BTreeMap, net::SocketAddr};
 
-const DEFAULT_ADDRESS: &'static str = "io.ockam.router.tcp";
-
 /// A TCP address router and connection listener
 ///
 /// In order to create new TCP connection workers you need a router to
@@ -126,10 +124,10 @@ impl TcpRouter {
     /// [`TcpRouter::register`](TcpRouter::register).
     pub async fn bind<'c, S: Into<SocketAddr>>(
         ctx: &'c Context,
+        addr: Address,
         socket_addr: S,
     ) -> Result<TcpRouterHandle<'c>> {
         let run = atomic::new(true);
-        let addr = Address::from(DEFAULT_ADDRESS);
 
         // Bind and start the connection listen worker
         TcpListenWorker::start(ctx, addr.clone(), socket_addr.into(), run.clone()).await?;


### PR DESCRIPTION
This commit makes it possible to start multiple TcpRouters with their respective connection workers.

There is a problem with this approach however, because Ockam Node internally associates a whole _address type_ with a router. This means that per node there _can't_ be more than one router per address type.