### PR TITLE
fix(rust): revert tcp router address to default static

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 - 2021-04-14
+### Changed
+- Temporarily reverted a change in router address association.
+
 ## v0.4.0 - 2021-04-14
 ### Added
 - Added dead_code lint.

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures",
  "hashbrown 0.9.1",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -58,10 +58,10 @@ impl<'ctx> TcpTransport<'ctx> {
         ctx: &'ctx Context,
         peer: S,
     ) -> Result<TcpTransport<'ctx>> {
-        let addr = Address::random(0);
+        let _addr = Address::random(0); // TODO
         let peer = parse_socket_addr(peer)?;
 
-        let router = TcpRouter::register(ctx, addr.clone()).await?;
+        let router = TcpRouter::register_or_get(ctx).await?;
         init::start_connection(ctx, &router, peer).await?;
 
         Ok(Self { ctx, router })

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
@@ -6,6 +6,8 @@ use crate::{
 use ockam::{async_worker, Address, Context, Result, Routed, RouterMessage, Worker};
 use std::{collections::BTreeMap, net::SocketAddr};
 
+/// A default worker address for the TCP Router.
+const DEFAULT_ADDRESS: &'static str = "io.ockam.router.tcp";
 /// A TCP address router and connection listener
 ///
 /// In order to create new TCP connection workers you need a router to
@@ -116,6 +118,14 @@ impl TcpRouter {
         Ok(TcpRouterHandle { ctx, addr })
     }
 
+    /// Either register a new router or return a handle to the existing one
+    pub(crate) async fn register_or_get<'c>(ctx: &'c Context) -> Result<TcpRouterHandle<'c>> {
+        let addr = Address::from(DEFAULT_ADDRESS);
+        Self::register(ctx, addr.clone()).await.or_else(|_| {
+            debug!("Using pre-existing TCP router...");
+            Ok(TcpRouterHandle { ctx, addr })
+        })
+    }
     /// Register a new TCP router and bind a connection listener
     ///
     ///  Use this function when your node is the server part of your


### PR DESCRIPTION
Temporary fix for https://github.com/ockam-network/ockam/issues/1259