### PR TITLE
Fix routing-transport-many-hops example

### DIFF
--- a/examples/rust/get_started/examples/07-routing-over-transport-initiator.rs
+++ b/examples/rust/get_started/examples/07-routing-over-transport-initiator.rs
@@ -3,7 +3,8 @@ use ockam_transport_tcp::{TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
-    TcpTransport::create(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect("127.0.0.1:4000").await?;
 
     // Send a message to the echoer worker, on a different node, over a tcp transport
     ctx.send(

--- a/examples/rust/get_started/examples/07-routing-over-transport-responder.rs
+++ b/examples/rust/get_started/examples/07-routing-over-transport-responder.rs
@@ -4,7 +4,8 @@ use ockam_transport_tcp::TcpTransport;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    TcpTransport::create_listener(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen("127.0.0.1:4000").await?;
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;

--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-initiator.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-initiator.rs
@@ -3,7 +3,8 @@ use ockam_transport_tcp::{TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
-    TcpTransport::create(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect("127.0.0.1:4000").await?;
 
     ctx.send(
         Route::new()

--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-middle.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-middle.rs
@@ -3,8 +3,8 @@ use ockam_transport_tcp::TcpTransport;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    TcpTransport::create_listener(&ctx, "127.0.0.1:4000").await?;
-    TcpTransport::create(&ctx, "127.0.0.1:6000").await?;
+    let tcp = TcpTransport::create_listener(&ctx, "127.0.0.1:4000").await?;
+    tcp.connect("127.0.0.1:6000").await?;
 
     // This node never shuts down.
     Ok(())

--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-middle.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-middle.rs
@@ -3,7 +3,8 @@ use ockam_transport_tcp::TcpTransport;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    let tcp = TcpTransport::create_listener(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen("127.0.0.1:4000").await?;
     tcp.connect("127.0.0.1:6000").await?;
 
     // This node never shuts down.

--- a/examples/rust/get_started/examples/08-routing-over-transport-many-hops-responder.rs
+++ b/examples/rust/get_started/examples/08-routing-over-transport-many-hops-responder.rs
@@ -4,7 +4,8 @@ use ockam_transport_tcp::TcpTransport;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    TcpTransport::create_listener(&ctx, "127.0.0.1:6000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen("127.0.0.1:6000").await?;
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;

--- a/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-initiator.rs
+++ b/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-initiator.rs
@@ -3,25 +3,23 @@ use ockam_transport_tcp::{TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
-    TcpTransport::create(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect("127.0.0.1:4000").await?;
 
-
-    let route_to_listener =
-        Route::new()
-            // Send a message to node B
-            .append_t(TCP, "127.0.0.1:4000")
-            // Send a message to node C
-            .append_t(TCP, "127.0.0.1:6000")
-            .append("secure_channel_listener");
+    let route_to_listener = Route::new()
+        // Send a message to node B
+        .append_t(TCP, "127.0.0.1:4000")
+        // Send a message to node C
+        .append_t(TCP, "127.0.0.1:6000")
+        .append("secure_channel_listener");
     let channel = SecureChannel::create(&mut ctx, route_to_listener).await?;
 
     // Send a message to the echoer worker via the channel.
     ctx.send(
-        Route::new()
-            .append(channel.address())
-            .append("echoer"),
-        "Hello Ockam!".to_string()
-    ).await?;
+        Route::new().append(channel.address()).append("echoer"),
+        "Hello Ockam!".to_string(),
+    )
+    .await?;
 
     // Wait to receive a reply and print it.
     let reply = ctx.receive::<String>().await?;

--- a/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-middle.rs
+++ b/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-middle.rs
@@ -3,8 +3,9 @@ use ockam_transport_tcp::TcpTransport;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    TcpTransport::create_listener(&ctx, "127.0.0.1:4000").await?;
-    TcpTransport::create(&ctx, "127.0.0.1:6000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen("127.0.0.1:4000").await?;
+    tcp.connect("127.0.0.1:6000").await?;
 
     // This node never shuts down.
     Ok(())

--- a/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-responder.rs
+++ b/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-responder.rs
@@ -4,7 +4,8 @@ use ockam_transport_tcp::TcpTransport;
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
-    TcpTransport::create_listener(&ctx, "127.0.0.1:6000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen("127.0.0.1:6000").await?;
 
     SecureChannel::create_listener(&mut ctx, "secure_channel_listener").await?;
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/src/bin/client.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/src/bin/client.rs
@@ -9,7 +9,8 @@ async fn main(ctx: ockam::Context) -> Result<()> {
     let hub_addr = SocketAddr::from_str("127.0.0.1:4000").unwrap();
 
     // Create and register a connection worker pair
-    TcpTransport::create(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect("127.0.0.1:4000").await?;
 
     let client = Client::new(hub_addr, "27164a70".to_string());
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/src/bin/server.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/src/bin/server.rs
@@ -14,7 +14,8 @@ async fn main(mut ctx: ockam::Context) -> Result<()> {
     let hub_addr = SocketAddr::from_str("127.0.0.1:4000").unwrap();
 
     // Create and register a connection worker pair
-    TcpTransport::create(&ctx, "127.0.0.1:4000").await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen("127.0.0.1:4000").await?;
 
     let server = Server {};
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/src/client_worker.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/src/client_worker.rs
@@ -47,8 +47,7 @@ impl Worker for Client {
                 .into(),
         );
 
-        ctx.send(ctx.address(), "recursion".to_string())
-            .await?;
+        ctx.send(ctx.address(), "recursion".to_string()).await?;
 
         Ok(())
     }
@@ -63,8 +62,7 @@ impl Worker for Client {
                     .map(char::from)
                     .collect();
                 info!("Client sent message: {}", rand_string);
-                ctx.send(ctx.address(), "recursion".to_string())
-                    .await?;
+                ctx.send(ctx.address(), "recursion".to_string()).await?;
                 ctx.send(self.route.clone().unwrap(), rand_string).await?;
                 tokio::time::sleep(Duration::from_secs(2)).await;
             }

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/holder.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/holder.rs
@@ -29,8 +29,9 @@ impl Worker for Holder {
         let issuer = &self.issuer;
         let verifier = &self.verifier;
 
-        let _issuer_pair = TcpTransport::create(&ctx, issuer).await?;
-        let _verifier_pair = TcpTransport::create(&ctx, verifier).await?;
+        let tcp = TcpTransport::create(&ctx).await?;
+        tcp.connect(issuer).await?;
+        tcp.connect(verifier).await?;
 
         // Send a New Credential Connection message
         ctx.send(

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/issuer.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/issuer.rs
@@ -1,10 +1,8 @@
-use std::net::SocketAddr;
-
 use ockam::{
-    async_worker, Context, CredentialAttribute, CredentialIssuer, CredentialSchema, OckamError,
-    Result, Routed, Worker,
+    async_worker, Context, CredentialAttribute, CredentialIssuer, CredentialSchema, Result, Routed,
+    Worker,
 };
-use ockam_transport_tcp::TcpRouter;
+use ockam_transport_tcp::TcpTransport;
 
 use credentials::CredentialMessage::{CredentialOffer, CredentialResponse};
 use credentials::{example_schema, CredentialMessage, DEFAULT_ISSUER_PORT};
@@ -82,11 +80,8 @@ async fn main(ctx: Context) -> Result<()> {
     let args: Args = Args::from_args();
     let port = args.port.unwrap_or(DEFAULT_ISSUER_PORT);
 
-    let local_tcp: SocketAddr = format!("0.0.0.0:{}", port)
-        .parse()
-        .map_err(|_| OckamError::InvalidInternalState)?;
-
-    let _router = TcpRouter::bind(&ctx, local_tcp).await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen(format!("0.0.0.0:{}", port)).await?;
 
     let credential_issuer = if let Some(signing_key) = args.signing_key {
         CredentialIssuer::with_signing_key_hex(signing_key).unwrap()

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/verifier.rs
@@ -90,7 +90,8 @@ async fn main(ctx: Context) -> Result<()> {
 
     let issuer = issuer_on_or_default(args.issuer);
 
-    let tcp = TcpTransport::create_listener(&ctx, local_tcp).await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen(local_tcp).await?;
     tcp.connect(&issuer).await?;
 
     ctx.start_worker(

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/network_echo_client.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/network_echo_client.rs
@@ -18,7 +18,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     let peer_addr = get_peer_addr();
 
     // Initialize the TCP stack by opening a connection to a the remote
-    TcpTransport::create(&ctx, &peer_addr).await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect(&peer_addr).await?;
 
     // Send a message to the remote
     ctx.send(

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/network_echo_server.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/network_echo_server.rs
@@ -36,7 +36,8 @@ async fn main(ctx: Context) -> Result<()> {
     // Get either the default socket address, or a user-input
     let bind_addr = get_bind_addr();
     debug!("Binding to: {}", bind_addr);
-    TcpTransport::create_listener(&ctx, bind_addr).await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.listen(bind_addr).await?;
 
     // Create the responder worker
     ctx.start_worker("echo_service", Responder).await?;

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/relay_echo_client.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/relay_echo_client.rs
@@ -20,7 +20,8 @@ async fn main(ctx: Context) -> Result<()> {
     let peer = get_peer_addr();
 
     // Initialize the TCP stack by opening a connection to a the remote
-    TcpTransport::create(&ctx, peer.clone()).await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect(peer.clone()).await?;
 
     // Get the forwarding route from user input
     let mut buffer = String::new();

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/relay_echo_server.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/relay_echo_server.rs
@@ -58,7 +58,8 @@ async fn main(ctx: Context) -> Result<()> {
     let peer = get_peer_addr();
 
     // Create and register a connection worker pair
-    TcpTransport::create(&ctx, peer.clone()).await?;
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect(peer.clone()).await?;
 
     // Start the worker we want to reach via proxy
     ctx.start_worker("worker", ProxiedWorker { peer }).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -39,7 +39,17 @@ pub use sender::TcpSendWorker;
 use ockam::{Address, Context, Result};
 use std::net::SocketAddr;
 
-/// An API layer object to control Ockam TCP transports
+/// High level management interface for TCP transports
+///
+/// Be aware that only one `TcpTransport` can exist per node, as it
+/// registers itself as a router for the `TCP` address type.  Multiple
+/// calls to [`TcpTransport::create`](crate::TcpTransport::create) or
+/// [`TcpTransport::create_listener`](crate::TcpTransport::create_listener)
+/// will fail.
+///
+/// To register additional connections on an already initialised
+/// `TcpTransport`, use
+/// [`tcp.connect()`](crate::TcpTransport::connect) instead!
 pub struct TcpTransport<'ctx> {
     ctx: &'ctx Context,
     router: TcpRouterHandle<'ctx>,


### PR DESCRIPTION
This PR fixes issue #1259 by updating the 08-routing-transport-many-hops-middle example to the new TcpTransport API.

It also adds some more explicit documentation pointing out this potential foot-gun.


<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->