### PR TITLE
docs(rust): step 10 add a stop for easier testing

### DIFF
--- a/examples/rust/get_started/examples/10-routing-to-hub.rs
+++ b/examples/rust/get_started/examples/10-routing-to-hub.rs
@@ -16,5 +16,5 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     let msg = ctx.receive::<String>().await?;
     println!("Received return message: '{}'", msg);
-    Ok(())
+    ctx.stop().await
 }


### PR DESCRIPTION
Adds a `ctx.stop` to end of step 10, so it doesn't run forever. It's not a server, no need