### PR TITLE
feat(rust): support modular protocol parsing in ockam crate

### DIFF
--- a/implementations/rust/ockam/ockam/src/error.rs
+++ b/implementations/rust/ockam/ockam/src/error.rs
@@ -22,6 +22,7 @@ pub enum OckamError {
     InvalidParameter,
     SecureChannelVerificationFailed,
     SecureChannelCannotBeAuthenticated,
+    NoSuchParser,
 }
 
 impl OckamError {

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -16,6 +16,9 @@
 #[macro_use]
 extern crate serde_big_array;
 
+#[macro_use]
+extern crate tracing;
+
 big_array! { BigArray; 96 }
 
 // ---
@@ -46,9 +49,11 @@ mod remote_forwarder;
 pub use remote_forwarder::*;
 
 pub use ockam_core::worker;
+pub mod protocols;
+
 pub use ockam_core::{
-    Address, Any, Encoded, Error, Message, Result, Route, Routed, RouterMessage, TransportMessage,
-    Worker,
+    Address, Any, Encoded, Error, Message, ProtocolId, Result, Route, Routed, RouterMessage,
+    TransportMessage, Worker,
 };
 
 pub use ockam_channel::SecureChannel;

--- a/implementations/rust/ockam/ockam/src/protocols/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/mod.rs
@@ -1,0 +1,32 @@
+//! Advanced Ockam worker protocols
+
+use ockam_core::{Message, ProtocolId};
+use serde::{Deserialize, Serialize};
+
+mod parser;
+pub use parser::*;
+
+pub mod stream;
+
+/// A protocol payload wrapper for pre-parsing
+#[derive(Serialize, Deserialize)]
+pub struct ProtocolPayload {
+    pub protocol: ProtocolId,
+    pub data: Vec<u8>,
+}
+
+impl ProtocolPayload {
+    /// Take an encodable message type and wrap it into a protocol payload
+    ///
+    /// ## Decoding payloads
+    ///
+    /// In order to easily decode incoming `ProtocolPayload`s, it is
+    /// recommended to use the `ProtocolParser` abstraction, which handles
+    /// matching between different decoders based on the protocol ID.
+    pub fn new<P: Into<ProtocolId>, S: Message>(p: P, d: S) -> Self {
+        Self {
+            protocol: p.into(),
+            data: d.encode().expect("Failed to serialise protocol payload"),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam/src/protocols/parser.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/parser.rs
@@ -1,0 +1,123 @@
+use crate::{
+    error::OckamError, protocols::ProtocolPayload, Any, Message, ProtocolId, Result, Routed, Worker,
+};
+use std::{collections::BTreeMap, marker::PhantomData, ops::Deref, sync::Arc, sync::RwLock};
+
+/// A parser for a protocol fragment
+///
+/// **If you are not a protocol author, you may want to use
+/// [`UserParser`](UserParser) instead!**
+///
+/// Protocols are implemented as separate structures, wrapped in a
+/// carrier type.  Because Rust can't have a function return different
+/// types from a function, each protocol message (here called
+/// "Fragment") needs to be handled by a separate parser.
+pub trait ParserFragment<W>
+where
+    W: Worker,
+{
+    /// Return the set of `ProtocolID`s this parser can handle
+    fn ids(&self) -> Vec<ProtocolId>;
+
+    /// Parse an incoming message for a particular worker
+    fn parse(&self, _state: &mut W, _msg: ProtocolPayload) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// A user-closure to map protocol return values to worker state
+pub type UserParser<W, T> = Box<dyn Fn(&mut W, T) + Send + Sync + 'static>;
+
+/// An extensible protocol parser abstraction
+///
+/// ## The problem
+///
+/// In an Ockam worker system, a single worker can only ever accept
+/// _one_ strong message type, defined via its associated type.  This
+/// is very useful for input checking to a worker, but prevents it
+/// from being able to asynchronously handling multiple message types,
+/// and thus protocols.
+///
+/// The Ockam ProtocolParser exists to solve this problem.
+///
+/// ## How to use
+///
+/// Create a `ProtocolParser` and store it in your worker (as an
+/// `Arc<ProtocolParser>).  During your workers initialise function
+/// you should also initialise the protocol parser.  This is done by
+/// mapping a [`ProtocolId`] to a [`Parser`].  For any Ockam-internal
+/// protocol a Parser implementation is provided in the same module as
+/// the basic structure definitions.
+///
+/// [`ProtocolId]: ockam_core::ProtocolId
+/// [`ProtocolParselet]: ockam::protocol::Paser;
+#[derive(Default)]
+pub struct ProtocolParser<W: Worker>(Arc<ProtocolParserImpl<W>>);
+
+impl<W: Worker> ProtocolParser<W> {
+    /// Create a new `ProtocolParser`
+    pub fn new() -> Self {
+        Self(Arc::new(ProtocolParserImpl {
+            map: Default::default(),
+            _w: PhantomData,
+        }))
+    }
+
+    /// Prepare the state of the parser
+    ///
+    /// This is required to get around mutable borrowing rules in the
+    /// worker state, when passing the state to `parse()`.
+    pub fn prepare(&self) -> Arc<ProtocolParserImpl<W>> {
+        Arc::clone(&self.0)
+    }
+}
+
+impl<W: Worker> Deref for ProtocolParser<W> {
+    type Target = Arc<ProtocolParserImpl<W>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Default)]
+pub struct ProtocolParserImpl<W: Worker> {
+    map: RwLock<BTreeMap<ProtocolId, Arc<Box<dyn ParserFragment<W> + Send + Sync>>>>,
+    _w: PhantomData<W>,
+}
+
+impl<W: Worker> ProtocolParserImpl<W> {
+    /// Attach a new parser tree to this protocol parser
+    pub fn attach<P>(self: &Arc<Self>, parser: P)
+    where
+        P: ParserFragment<W> + Send + Sync + 'static,
+    {
+        let p: Arc<Box<dyn ParserFragment<W> + Send + Sync>> = Arc::new(Box::new(parser));
+
+        let mut map = self.map.write().unwrap();
+        p.ids().into_iter().for_each(|pid| {
+            map.insert(pid, Arc::clone(&p));
+        });
+    }
+
+    /// Parse a message based on its protocol
+    ///
+    /// You may want to call [`prepare()`](Self::prepare) before
+    /// calling this function.
+    pub fn parse(self: Arc<Self>, w: &mut W, msg: Routed<Any>) -> Result<()> {
+        let msg = msg.into_transport_message();
+
+        // Parse message as a ProtocolPayload to grab the ProtocolId
+        let proto_msg = ProtocolPayload::decode(&msg.payload).unwrap();
+        let proto = ProtocolId::from_str(proto_msg.protocol.as_str());
+
+        trace!("Parsing message for '{:?}' protocol", proto.as_str());
+
+        // Get the protocol specific parser
+        let map = self.map.read().unwrap();
+        let parser = map.get(&proto).ok_or(OckamError::NoSuchParser)?;
+
+        // Finally call the parser
+        parser.parse(w, proto_msg)
+    }
+}

--- a/implementations/rust/ockam/ockam/src/protocols/parser.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/parser.rs
@@ -25,9 +25,6 @@ where
     }
 }
 
-/// A user-closure to map protocol return values to worker state
-pub type UserParser<W, T> = Box<dyn Fn(&mut W, T) + Send + Sync + 'static>;
-
 /// An extensible protocol parser abstraction
 ///
 /// ## The problem

--- a/implementations/rust/ockam/ockam/src/protocols/stream/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/mod.rs
@@ -1,0 +1,2 @@
+pub mod requests;
+pub mod responses;

--- a/implementations/rust/ockam/ockam/src/protocols/stream/requests.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/requests.rs
@@ -1,0 +1,98 @@
+//! Stream protocol request payloads
+
+use crate::protocols::ProtocolPayload;
+use serde::{Deserialize, Serialize};
+
+/// Request a new mailbox to be created
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct CreateStreamRequest {
+    pub stream_name: Option<String>,
+}
+
+impl CreateStreamRequest {
+    pub fn new<'s, S: Into<Option<&'s str>>>(s: S) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_create",
+            Self {
+                stream_name: s.into().map(|s| s.to_string()),
+            },
+        )
+    }
+}
+
+/// Push a message into the mailbox
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct PushRequest {
+    pub request_id: usize, // uint
+    pub data: Vec<u8>,
+}
+
+impl PushRequest {
+    pub fn new<T: Into<Vec<u8>>>(request_id: usize, data: T) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_push",
+            Self {
+                request_id,
+                data: data.into(),
+            },
+        )
+    }
+}
+
+/// Pull messages from the mailbox
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct PullRequest {
+    pub request_id: usize,
+    pub index: usize,
+    pub limit: usize,
+}
+
+impl PullRequest {
+    pub fn new(request_id: usize, index: usize, limit: usize) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_pull",
+            Self {
+                request_id,
+                index,
+                limit,
+            },
+        )
+    }
+}
+
+/// Index request protocols to get and save indices
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum Index {
+    Get {
+        stream_name: String,
+        client_id: String,
+    },
+    Save {
+        stream_name: String,
+        client_id: String,
+        index: usize,
+    },
+}
+
+impl Index {
+    pub fn get<S: Into<String>>(stream_name: S, client_id: S) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_index",
+            Self::Get {
+                stream_name: stream_name.into(),
+                client_id: client_id.into(),
+            },
+        )
+    }
+
+    pub fn save<S: Into<String>>(stream_name: S, client_id: S, index: usize) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_index",
+            Self::Save {
+                stream_name: stream_name.into(),
+                client_id: client_id.into(),
+                index,
+            },
+        )
+    }
+}

--- a/implementations/rust/ockam/ockam/src/protocols/stream/responses.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/responses.rs
@@ -1,0 +1,169 @@
+//! Stream protocol response payloads and parser
+
+use crate::{
+    protocols::{ParserFragment, ProtocolPayload, UserParser},
+    Message, ProtocolId, Result, Worker,
+};
+use serde::{Deserialize, Serialize};
+
+/// Response to a `CreateStreamRequest`
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Init {
+    pub stream_name: String,
+}
+
+impl Init {
+    pub fn new<S: Into<String>>(s: S) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_create",
+            Self {
+                stream_name: s.into(),
+            },
+        )
+    }
+}
+
+/// Confirm push operation on the mailbox
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct PushConfirm {
+    pub request_id: usize,
+    pub status: Status,
+    pub index: usize, // uint
+}
+
+impl PushConfirm {
+    pub fn new<S: Into<Status>>(request_id: usize, status: S, index: usize) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_push",
+            Self {
+                request_id,
+                index,
+                status: status.into(),
+            },
+        )
+    }
+}
+
+/// A simple status code
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum Status {
+    Ok,
+    Error,
+}
+
+impl From<bool> for Status {
+    fn from(b: bool) -> Self {
+        if b {
+            Self::Ok
+        } else {
+            Self::Error
+        }
+    }
+}
+
+impl From<Option<()>> for Status {
+    fn from(b: Option<()>) -> Self {
+        b.map(|_| Self::Ok).unwrap_or(Self::Error)
+    }
+}
+
+/// Response to a `PullRequest`
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct PullResponse {
+    pub request_id: usize,
+    pub messages: Vec<StreamMessage>,
+}
+
+impl PullResponse {
+    pub fn new<T: Into<Vec<StreamMessage>>>(request_id: usize, messages: T) -> ProtocolPayload {
+        ProtocolPayload::new(
+            "stream_pull",
+            Self {
+                request_id,
+                messages: messages.into(),
+            },
+        )
+    }
+}
+
+/// A stream message with a reference index
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct StreamMessage {
+    /// Index of the message in the stream
+    pub index: usize,
+    /// Encoded data of the message
+    pub data: Vec<u8>,
+}
+
+/// The index return payload
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Index {
+    pub stream_name: String,
+    pub client_id: String,
+    pub index: usize,
+}
+
+/// A convenience enum to wrap all possible response types
+///
+/// In your worker you will want to match this enum, given to you via
+/// the `ProtocolParser` abstraction.
+pub enum Response {
+    Init(Init),
+    PushConfirm(PushConfirm),
+    PullResponse(PullResponse),
+    Index(Index),
+}
+
+/// A stream protocol parser with user-provided receive hook
+pub struct ResponseParser<W: Worker> {
+    f: UserParser<W, Response>,
+}
+
+impl<W: Worker> ResponseParser<W> {
+    /// Create a new stream protocol parser with a response closure
+    ///
+    /// The provided function will be called for every incoming
+    /// response to the stream protocol.  You can use it, and the
+    /// mutable access to your worker state to map response messages
+    /// to the worker state.
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn(&mut W, Response) + Send + Sync + 'static,
+    {
+        Self { f: Box::new(f) }
+    }
+}
+
+impl<W: Worker> ParserFragment<W> for ResponseParser<W> {
+    fn ids(&self) -> Vec<ProtocolId> {
+        vec![
+            "stream_create",
+            "stream_push",
+            "stream_pull",
+            "stream_index",
+        ]
+        .into_iter()
+        .map(Into::into)
+        .collect()
+    }
+
+    fn parse(
+        &self,
+        state: &mut W,
+        ProtocolPayload { protocol, data }: ProtocolPayload,
+    ) -> Result<()> {
+        // Parse payload into a response
+        let resp = match protocol.as_str() {
+            "stream_create" => Response::Init(Init::decode(&data)?),
+            "stream_push" => Response::PushConfirm(PushConfirm::decode(&data)?),
+            "stream_pull" => Response::PullResponse(PullResponse::decode(&data)?),
+            "stream_index" => Response::Index(Index::decode(&data)?),
+            _ => unreachable!(),
+        };
+
+        // Call the user code
+        (*self.f)(state, resp);
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/hub_stream_protocol.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/examples/hub_stream_protocol.rs
@@ -1,0 +1,81 @@
+use ockam::{
+    async_worker,
+    protocols::{
+        stream::{requests::*, responses::*},
+        ProtocolParser,
+    },
+    Any, Context, Result, Route, Routed, Worker,
+};
+use ockam_transport_tcp::{TcpTransport, TCP};
+
+#[derive(Default)]
+struct MyWorker {
+    parser: ProtocolParser<MyWorker>,
+    stream: Option<String>,
+    peer: String,
+}
+
+impl MyWorker {
+    fn new(peer: String) -> Self {
+        Self {
+            peer,
+            ..Default::default()
+        }
+    }
+}
+
+/// Util function that maps stream-protocol responses to worker state
+fn handle_stream(w: &mut MyWorker, r: Response) {
+    match r {
+        Response::Init(Init { stream_name }) => w.stream = Some(stream_name),
+        _ => {}
+    }
+}
+
+#[async_worker]
+impl Worker for MyWorker {
+    type Context = Context;
+    type Message = Any;
+
+    async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        self.parser.attach(ResponseParser::new(handle_stream));
+
+        ctx.send(
+            Route::new()
+                .append_t(TCP, &self.peer)
+                .append("stream_service"),
+            CreateStreamRequest::new(None), // Generate a stream name for us please
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
+        self.parser.prepare().parse(self, msg)?;
+
+        println!("Stream name is now: `{:?}`", self.stream);
+        ctx.stop().await
+    }
+}
+
+fn get_peer_addr() -> String {
+    std::env::args()
+        .skip(1)
+        .take(1)
+        .next()
+        // This value can be used when running the ockam-hub locally
+        .unwrap_or(format!("127.0.0.1:4000"))
+}
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    let peer = get_peer_addr();
+
+    let tcp = TcpTransport::create(&ctx).await?;
+    tcp.connect(peer.clone()).await?;
+
+    ctx.start_worker("worker", MyWorker::new(peer)).await?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_protocols.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_protocols.rs
@@ -1,0 +1,49 @@
+use ockam::{
+    async_worker,
+    protocols::{stream::responses::*, ProtocolParser},
+    Any, Context, Result, Routed, Worker,
+};
+
+#[derive(Default)]
+struct MyWorker {
+    parser: ProtocolParser<MyWorker>,
+    stream: Option<String>,
+}
+
+/// Util function that maps stream-protocol responses to worker state
+fn handle_stream(w: &mut MyWorker, r: Response) {
+    match r {
+        Response::Init(Init { stream_name }) => w.stream = Some(stream_name),
+        _ => {}
+    }
+}
+
+#[async_worker]
+impl Worker for MyWorker {
+    type Context = Context;
+    type Message = Any;
+
+    async fn initialize(&mut self, _: &mut Context) -> Result<()> {
+        self.parser.attach(ResponseParser::new(handle_stream));
+
+        Ok(())
+    }
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
+        self.parser.prepare().parse(self, msg)?;
+
+        println!("Stream name is now: `{:?}`", self.stream);
+        ctx.stop().await
+    }
+}
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    ctx.start_worker("worker", MyWorker::default()).await?;
+
+    // Send an Init message to our worker -- this message would
+    // normally be sent from the Ockam Hub stream service
+    ctx.send("worker", Init::new("test-stream")).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
The general design of this protocol parsing approach is this:

- A worker that wants to parse many different protocols creates a `ProtocolParser<W>`. This type  is generic for the worker it is being implemented for
- Each protocol has a type that implements the `ParserFragment<W>` trait
  - This trait is used to let the main protocol parser know which protocol IDs it can handle
- There is a `UserParser<W, T>` closure type which MUST be used by any parser implementing `ParserFragment<W>`
  - `W` is the worker for which this parser type is implemented, and `T` is the response type given to the user to map to worker state
  - **Example**: `stream::ResponseParser` is generic over `W` but constrains `T: stream::responses::Response`
- Initialising the `ProtocolParser` SHOULD happen in the worker's `initialize` function.
  - Use `.attach(...)` to register a type implementing `ParserFragment<W>` with the `ProtocolParser`
- Parsing can then be handled by the `ProtocolParser` in the worker's `handle_message` function
  - Due to borrowing constraints a user must first call `.prepare()` on the parser
  - The parser then takes a mutable borrow of the worker state and the message being parsed
- The `UserParser<W, T>` closure gets access to the mutable worker state
  - This means no closure environment is being captured --> the closure is `Send` and `Sync` 
  - Each protocol-specific `UserParser` can then match on the incoming message type

## Example

There is a full example worker using this mechanism in the `ockam_examples` crate.

```rust
#[derive(Default)]
struct MyWorker {
    parser: ProtocolParser<MyWorker>,
    stream: Option<String>,
}

#[async_worker]
impl Worker for MyWorker {
    type Context = Context;
    type Message = Any;

    async fn initialize(&mut self, _: &mut Context) -> Result<()> {
        self.parser
            .attach(ResponseParser::new(|worker: &mut Self, msg| match msg {
                Response::Init(Init { stream_name }) => worker.stream = Some(stream_name),
                _ => { /* ignore messages */ }
            }));

        Ok(())
    }

    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
        self.parser.prepare().parse(self, msg)?;

        println!("Stream name is now: `{:?}`", self.stream);
        Ok(())
    }
}
```