### PR TITLE
feat(elixir): Token Lease Manager Prototype 

### DIFF
--- a/implementations/elixir/ockam/ockam/mix.exs
+++ b/implementations/elixir/ockam/ockam/mix.exs
@@ -47,7 +47,6 @@ defmodule Ockam.MixProject do
     [
       {:bare, "~> 0.1.1"},
       {:gen_state_machine, "~> 3.0"},
-      {:httpoison, "~> 1.8"},
       {:ockam_vault_software, path: "../ockam_vault_software", optional: true},
       {:telemetry, "~> 0.4.2", optional: true},
       {:ranch, "~> 2.0", optional: true},

--- a/implementations/elixir/ockam/ockam/mix.exs
+++ b/implementations/elixir/ockam/ockam/mix.exs
@@ -47,6 +47,7 @@ defmodule Ockam.MixProject do
     [
       {:bare, "~> 0.1.1"},
       {:gen_state_machine, "~> 3.0"},
+      {:httpoison, "~> 1.8"},
       {:ockam_vault_software, path: "../ockam_vault_software", optional: true},
       {:telemetry, "~> 0.4.2", optional: true},
       {:ranch, "~> 2.0", optional: true},

--- a/implementations/elixir/ockam/ockam_hub/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/runtime.exs
@@ -20,6 +20,13 @@ config :telemetry_influxdb,
   org: System.get_env("INFLUXDB_ORG"),
   token: influx_token
 
+config :ockam_hub, :influxdb,
+  host: System.get_env("INFLUXDB_HOST"),
+  port: System.get_env("INFLUXDB_PORT"),
+  bucket: System.get_env("INFLUXDB_BUCKET"),
+  org: System.get_env("INFLUXDB_ORG"),
+  token: influx_token
+
 ui_auth_message =
   with true <- File.exists?("/mnt/secrets/auth/message"),
        {:ok, contents} <- File.read("/mnt/secrets/auth/message"),

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager.ex
@@ -1,0 +1,123 @@
+defmodule Ockam.TokenLeaseManager do
+  @moduledoc false
+  use Ockam.Worker
+
+  alias Ockam.TokenLeaseManager.Lease
+
+  @default_cloud_service :influxdb
+  @default_storate_service :storage
+
+  @impl true
+  # def setup(options, state) do
+  def init(options) do
+    cloud_service_name =
+      case get_from_options(:cloud_service, options) do
+        {:ok, cloud_service_name} -> cloud_service_name
+        _ -> @default_cloud_service
+      end
+    state = %{} # remove
+    storage_service_name =
+      case get_from_options(:storage_service, options) do
+        {:ok, storage_service_name} -> storage_service_name
+        _ -> @default_storate_service
+      end
+
+    state = Map.put(state, :cloud_service, get_cloud_service(cloud_service_name))
+    storage = Map.put(state, :storage_system, get_storage_service(storage_service_name))
+
+    #TODO: initialization for all expirations
+    # Process.send(self(), :set_all_expiration, [])
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_message({:create, options}, state) do
+    case create(state[:cloud_service], options) do
+      {:ok, _lease} -> {:ok, state}
+      error -> error
+    end
+  end
+
+  def handle_message({:revoke, token_id}, state) do
+    case revoke(state[:cloud_service], token_id) do
+      :ok -> {:ok, state}
+      error -> error
+    end
+  end
+
+  def handle_message({:set_expiration, token_id, expiration}, state) do
+    set_expiration(self(), token_id, expiration)
+    {:ok, state}
+  end
+
+  def handle_message(:set_all_expiration, state) do
+    lease_manager_pid = self()
+    Task.start(
+      fn ->
+        get_all_leases()
+        |> Enum.map(fn lease -> set_expiration(lease_manager_pid, lease[:token_id], lease[:expiration]) end)
+      end
+    )
+    {:ok, state}
+  end
+
+  def handle_message(_, state) do
+    {:ok, state}
+  end
+
+
+  defp get_cloud_service(name) do
+    case name do
+      :influxdb -> Ockam.TokenLeaseManager.CloudServiceInfluxdb
+      _ -> Ockam.TokenLeaseManager.CloudServiceInfluxdb
+    end
+  end
+
+  defp get_storage_service(name) do
+    # TODO: storage system
+    case name do
+      _ -> :storage
+    end
+  end
+
+  defp set_expiration(lease_manager_pid, token_id, expiration) do
+    Process.send_after(lease_manager_pid, {:revoke, token_id}, expiration)
+  end
+
+  defp save_lease(lease) do
+    # TODO
+  end
+
+  defp remove_lease(tokend_id) do
+    # TODO
+  end
+
+  defp get_all_leases() do
+    # TODO
+    []
+  end
+
+  defp create(cloud_service, options) do
+    {expiration, creation_opts} = Map.pop(options, "expiration")
+    case cloud_service.create(creation_opts) do
+      {:ok, lease} ->
+        save_lease(%Lease{lease | ttl: expiration})
+        set_expiration(self(), lease.id, expiration)
+        :ok
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp revoke(cloud_service, token_id) do
+    case cloud_service.revoke(token_id) do
+      :ok ->
+        remove_lease(token_id)
+        :ok
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager.ex
@@ -8,14 +8,13 @@ defmodule Ockam.TokenLeaseManager do
   @default_storate_service :storage
 
   @impl true
-  # def setup(options, state) do
-  def init(options) do
+  def setup(options, state) do
     cloud_service_name =
       case get_from_options(:cloud_service, options) do
         {:ok, cloud_service_name} -> cloud_service_name
         _ -> @default_cloud_service
       end
-    state = %{} # remove
+
     storage_service_name =
       case get_from_options(:storage_service, options) do
         {:ok, storage_service_name} -> storage_service_name

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/cloud_service.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/cloud_service.ex
@@ -1,0 +1,15 @@
+defmodule Ockam.TokenLeaseManager.CloudService do
+
+  @type lease :: map()
+  @type reason :: any()
+  @type token_id :: String.t()
+  @type options ::  Keyword.t()
+
+  @callback configuration() :: Keyword.t()
+  @callback create(options) :: {:ok, lease} | {:error, reason}
+  @callback revoke(token_id) :: :ok | {:error, reason}
+  @callback renew(token_id) :: :ok | {:error, reason}
+  @callback get(token_id) :: {:ok, lease} | {:error, reason}
+  @callback get_all() :: {:ok, [lease]} | {:error, reason}
+
+end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/cloud_service/influxdb_cloud_service.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/cloud_service/influxdb_cloud_service.ex
@@ -1,5 +1,5 @@
 defmodule Ockam.TokenLeaseManager.CloudServiceInfluxdb do
-  @behaviour Ockam.TokenLeaseManager.TokenCloudService
+  @behaviour Ockam.TokenLeaseManager.CloudService
 
   alias Ockam.TokenLeaseManager.Lease
 

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/cloud_service/influxdb_cloud_service.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/cloud_service/influxdb_cloud_service.ex
@@ -1,0 +1,124 @@
+defmodule Ockam.TokenLeaseManager.CloudServiceInfluxdb do
+  @behaviour Ockam.TokenLeaseManager.TokenCloudService
+
+  alias Ockam.TokenLeaseManager.Lease
+
+  @endpoint_autorizations "/api/v2/authorizations"
+  @http_ok 200
+  @http_created 201
+  @http_delete 204
+
+  def configuration() do
+    host = Application.get_env(:ockam_hub, :influxdb)[:host]
+    port = Application.get_env(:ockam_hub, :influxdb)[:port]
+    token = Application.get_env(:ockam_hub, :influxdb)[:token]
+    org = Application.get_env(:ockam_hub, :influxdb)[:org]
+    [host: host, port: port, token: token, endpoint: @endpoint_autorizations, org: org]
+  end
+
+  def create(options, cloud_service_config \\ []) do
+    config = get_service_configuration(cloud_service_config)
+    url = build_url(config)
+    headers = build_headers(config)
+    {:ok, body} = Poison.encode(options)
+    request(fn -> HTTPoison.post(url, body, headers) end, fn body -> decode_one(body) end, @http_created)
+  end
+
+  def revoke(token_id, cloud_service_config \\ []) do
+    config = get_service_configuration(cloud_service_config)
+    url = "#{build_url(config)}/#{token_id}"
+    headers = build_headers(config)
+    request(fn -> HTTPoison.delete(url, headers) end, nil, @http_delete)
+  end
+
+  def renew(token_id, cloud_service_config \\ []) do
+    config = get_service_configuration(cloud_service_config)
+    #TODO
+  end
+
+  def get(token_id, cloud_service_config \\ []) do
+    config = get_service_configuration(cloud_service_config)
+    url = "#{build_url(config)}/#{token_id}"
+    headers = build_headers(config)
+    request(fn -> HTTPoison.get(url, headers) end, fn body -> decode_one(body) end)
+  end
+
+  def get_all(cloud_service_config \\ []) do
+    config = get_service_configuration(cloud_service_config)
+    url = build_url(config)
+    headers = build_headers(config)
+    request(fn -> HTTPoison.get(url, headers) end, fn body -> decode_all(body) end)
+  end
+
+  defp request(req, decode \\ nil, right_status_code \\ @http_ok) do
+    case req.() do
+      {:ok, %HTTPoison.Response{status_code: ^right_status_code, body: body}} ->
+        if decode != nil do
+          decode.(body)
+        else
+          :ok
+        end
+
+      {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->
+        case Poison.Parser.parse(body) do
+          {:ok, %{"code" => code, "message" => message}} -> {:error, "#{status_code}: #{code} => #{message}"}
+          {:error, error} -> {:error, error}
+        end
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, reason}
+    end
+  end
+
+  defp decode_all(body) do
+    case Poison.Parser.parse(body) do
+      {:ok, %{"authorizations" => authorizations}} ->
+        {:ok, Enum.map(
+          authorizations,
+          fn auth ->
+            IO.inspect(auth)
+            %Lease{
+              id: auth["id"],
+              issued: auth["createdAt"], #TODO convert to datetime
+              value: auth["token"]
+            }
+          end
+        )
+        }
+      {:error, err} -> {:error, err}
+    end
+  end
+
+  defp decode_one(body) do
+    case Poison.Parser.parse(body) do
+      {:ok, auth} ->
+        {:ok,
+          %Lease{
+            id: auth["id"],
+            issued: auth["createdAt"], #TODO convert to datetime
+            value: auth["token"]
+          }
+        }
+      {:error, err} -> {:error, err}
+    end
+  end
+
+  defp get_service_configuration(config \\ []) do
+    case Enum.empty?(config) do
+      true -> configuration()
+      false -> config
+    end
+  end
+
+  defp build_url([host: host, port: port, token: token, endpoint: endpoint, org: _org]) do
+    "#{host}:#{port}#{endpoint}"
+  end
+
+  defp build_headers([host: _host, port: _port, token: token, endpoint: _endpoint, org: _org]) do
+    [
+      "Authorization": "Token #{token}",
+      "Content-Type": "application/json"
+    ]
+  end
+
+end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/lease.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/lease.ex
@@ -1,0 +1,12 @@
+defmodule Ockam.TokenLeaseManager.Lease do
+  
+  defstruct [
+    id: "",
+    issued: nil,
+    renewable: false,
+    tags: [],
+    ttl: 0,
+    value: ""
+  ]
+
+end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/storage_service.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/token_lease_manager/storage_service.ex
@@ -1,0 +1,13 @@
+defmodule Ockam.TokenLeaseManager.StorageService do
+
+  @type lease :: Ockam.TokenLeaseManager.Lease.t()
+  @type reason :: any()
+  @type lease_id :: String.t()
+  @type options ::  Keyword.t()
+
+  @callback save(lease) :: :ok |  {:error, reason}
+  @callback get(lease_id) :: {:ok, lease} |  {:error, reason}
+  @callback remove(lease_id) :: :ok |  {:error, reason}
+  @callback get_all(lease) :: {:ok, [lease]} |  {:error, reason}
+
+end

--- a/implementations/elixir/ockam/ockam_hub/mix.exs
+++ b/implementations/elixir/ockam/ockam_hub/mix.exs
@@ -51,6 +51,7 @@ defmodule Ockam.Hub.MixProject do
       {:httpoison, "~> 1.8"},
       {:ockam_vault_software, path: "../ockam_vault_software"},
       {:ockam, path: "../ockam"},
+      {:poison, "~> 4.0.1"},
       {:ranch, "~> 2.0"},
       {:telemetry, "~> 0.4.2"},
       {:telemetry_poller, "~> 0.5.1"},


### PR DESCRIPTION
<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes

The motivation of this PR is the possibility of including a Flexible Token Lease Manager which will interact with different Cloud APIs. This PR also includes an implementation for InfluxDB.

Token Lease Manager has been implemented as Ockam Worker, although it has been tested during development as GenServer.

Token Lease Manager will depend on two implementations:
* Cloud system: Where the actual tokens will be created and revoked
* Storage system: Where the Lease will be stored due to some lack of required information in the Cloud API, like expiration time or time-to-live.

Storage system has not been implemented in this PR.

Cloud system has been thought as a Behaviour and this one is like a CRUD (Creation, Read, Update and Deletion). Then, the implementation of this behaviour will depend on the actual Cloud API although there are several approaches. 
With the first approach, the process of the Manager will directly interact with the Cloud API through its implementation. Other approach could be to run the cloud system in a different process, which implies to communicate token manager and cloud system processes. The first approach, implies to store some configuration or state about the cloud system in the manager. The second approach implies to have another process and extra-comunication between processes.
The PR has been implemented with the first approach.

Token Lease Manager will choose its cloud system implementation using a factory pattern. 

Influxdb Cloud system calls have been implemented using http requests, thanks to httpoison library, instead of any influxdb client for elixir. The configuration/state of the cloud api implementation can be passed or it can be also generated "on the fly" if it is not, although the performance is worse.

Another two approaches came to my mind to revoke tokens. The first one was to use a cron-like system, but the storage system would receive too many requests if we want to have a decent accuracy. Other approach would be to take advantage of Elixir message system and send a delayed message to the Token Lease Manager. This approach is going to be very accurate and although the amount of messages would be proportional to the number of tokens, they should not consume too much memory. The main concern about this approach is that the expiration message will be in memory so, if the BEAM is restarted, the messages will be lost. In order to solve this issue, the manager should retrieve all the tokens from the storage system (maybe also from the cloud system and merge them) and create the expiration messages again at start time.


Examples of calls:
```elixir
# Token Lease Manager Creation
iex> send(manager, {:create, %{"expiration" => 120, "orgID" => "2dd6f18583c359d5","permissions" => [%{"action" => "read", "resource" => %{"type" => "authorizations"}}]}})
# Token Lease Manager Deletion
iex> send(manager, {:revoke, "076b91cb6b409000"})
```
