### PR TITLE
docs(rust): fix links to crate

### DIFF
--- a/implementations/rust/ockam/signature_bbs_plus/README.md
+++ b/implementations/rust/ockam/signature_bbs_plus/README.md
@@ -164,7 +164,7 @@ fn main() -> Result<(), Error> {
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
-[main-ockam-crate-link]: https://crates.io/crates/ocka
+[main-ockam-crate-link]: https://crates.io/crates/ockam
 [crate-image]: https://img.shields.io/crates/v/signature_bbs_plus.svg
 [crate-link]: https://crates.io/crates/signature_bbs_plus
 

--- a/implementations/rust/ockam/signature_ps/README.md
+++ b/implementations/rust/ockam/signature_ps/README.md
@@ -164,7 +164,7 @@ fn main() -> Result<(), Error> {
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
-[main-ockam-crate-link]: https://crates.io/crates/ocka
+[main-ockam-crate-link]: https://crates.io/crates/ockam
 [crate-image]: https://img.shields.io/crates/v/signature_ps.svg
 [crate-link]: https://crates.io/crates/signature_ps
 


### PR DESCRIPTION
this pr fixes a typo in the link back to crates.io
