### PR TITLE
docs: fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ along the route of a message, may use a different transport protocol.
 
 It is possible to describe a route where the first hop is a TCP connection and
 the second hop is also a TCP connection. Or a different route where the first
-hop is bluetooth connection, the second hop is TCP connection, and the third
-hop is a UDP connection and so on.
+hop is a bluetooth connection, the second hop a TCP connection, and the third
+hop a UDP connection and so on.
 
 This enables end-to-end [Secure Channels](#secure-channels) over complex,
 multi-hop, multi-protocol routes. It also enables en-route encrypted messages

--- a/documentation/guides/rust/get-started/02-worker/README.md
+++ b/documentation/guides/rust/get-started/02-worker/README.md
@@ -27,7 +27,7 @@ This struct:
 * Must implement the `ockam::Worker` trait.
 * Must have the `#[ockam::async_worker]` attribute on the Worker trait implementation
 * Must define two associated types `Context` and `Message`
-  * The `Context` type is usually set to `ockam::Context` which is provide by the node implementation.
+  * The `Context` type is usually set to `ockam::Context` which is provided by the node implementation.
   * The `Message` type must be set to the type of message the worker wishes to handle.
 
 For a new `Echoer` worker, create a new file at `src/echoer.rs` in your

--- a/documentation/guides/rust/get-started/03-routing/README.md
+++ b/documentation/guides/rust/get-started/03-routing/README.md
@@ -12,7 +12,7 @@ application layer routing protocols allows us to send messages over multiple
 hops, within one node, or across many nodes.
 
 To achieve this, messages carry with them two meta fields: `onward_route`
-and `return_route`, where a route is list of addresses.
+and `return_route`, where a route is a list of addresses.
 
 To get a sense of how that works, let's route a message over two hops.
 
@@ -47,7 +47,7 @@ impl Worker for Hop {
     type Message = Any;
 
     /// This handle function takes any incoming message and forwards
-    /// it to the next hop in it's onward route
+    /// it to the next hop in its onward route
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
         println!("Address: {}, Received: {}", ctx.address(), msg);
 
@@ -60,7 +60,7 @@ impl Worker for Hop {
 ```
 
 To make this `Hop` type accessible to our main program, export it
-from `src/lib.rs` file by adding the following to it:
+from `src/lib.rs` by adding the following to it:
 
 ```rust
 // src/lib.rs


### PR DESCRIPTION
This PR fixes a few small typos in the documentation.