### PR TITLE
Chore: add cargo audit to rust's lint task

### DIFF
--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -31,6 +31,9 @@ commands {
       'cargo clippy --all --all-targets -- --cap-lints=warn',
       'cargo audit',
     ],
+    audit_fix: [
+      'cargo audit fix',
+    ],
   ]
 
   directories = crates

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -29,6 +29,7 @@ commands {
       'cargo check',
       'cargo fmt --all -- --check',
       'cargo clippy --all --all-targets -- --cap-lints=warn',
+      'cargo audit',
     ],
   ]
 


### PR DESCRIPTION
## Changes
* Run `cargo audit` in the rust's lint tasks
* Add a new gradle task to run `cargo audit fix` automatically for all rust subcrates (not used in CI). Let me know if you think this can be helpful

## Related issues
* https://github.com/ockam-network/ockam/issues/1048

## Other
Note that no `Cargo.toml` changes are needed right now, as all the `cargo audit` warns/errors that it was complaining about a couple of weeks ago have been fixed in the past few PR's.

Also, since the `lint` stage is not required, is it okay to let it fail when `cargo audit` returns errors?