### PR TITLE
Implement sync and async node API split

### DIFF
--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -15,3 +15,8 @@ ockam_core = { path = "../ockam_core", version = "0.12.0"  }
 tokio = {version = "1.5.0", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"] }
+
+[features]
+default = ["sync-api"]
+async-api = []
+sync-api = []

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -399,16 +399,18 @@ impl Context {
     }
 
     /// Return a list of all available worker addresses on a node
-    pub async fn list_workers(&self) -> Result<Vec<Address>> {
-        let (msg, mut reply_rx) = NodeMessage::list_workers();
+    pub fn list_workers(&self) -> Result<Vec<Address>> {
+        block_future(&self.rt, async {
+            let (msg, mut reply_rx) = NodeMessage::list_workers();
 
-        self.sender.send(msg).await.map_err(|e| Error::from(e))?;
+            self.sender.send(msg).await.map_err(|e| Error::from(e))?;
 
-        Ok(reply_rx
-            .recv()
-            .await
-            .ok_or(Error::InternalIOFailure)??
-            .take_workers()?)
+            Ok(reply_rx
+                .recv()
+                .await
+                .ok_or(Error::InternalIOFailure)??
+                .take_workers()?)
+        })
     }
 
     /// Register a router for a specific address type

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -247,7 +247,22 @@ impl Context {
     ///
     /// [`Context::send`]: crate::Context::send
     /// [`TransportMessage`]: ockam_core::TransportMessage
+    #[cfg(feature = "sync-api")]
     pub async fn forward(&self, data: TransportMessage) -> Result<()> {
+        block_future(&self.rt, self.forward_impl(data))
+    }
+
+    /// Forward a transport message to its next routing destination
+    ///
+    /// See [forward](Self::forward) for more documentation.
+    #[cfg(feature = "async-api")]
+    pub async fn forward_async(&self, data: TransportMessage) -> Result<()> {
+        self.forward_impl(data).await
+    }
+
+    #[inline]
+    #[allow(unused)]
+    async fn forward_impl(&self, data: TransportMessage) -> Result<()> {
         // Resolve the sender for the next hop in the messages route
         let (reply_tx, mut reply_rx) = channel(1);
         let next = data.onward_route.next().unwrap(); // TODO: communicate bad routes

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router.rs
@@ -64,7 +64,7 @@ impl Worker for TcpRouter {
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
         trace!("Registering TCP router for type = {}", crate::TCP);
-        ctx.register(crate::TCP, ctx.address()).await?;
+        ctx.register(crate::TCP, ctx.address())?;
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -21,8 +21,7 @@ impl WorkerState {
 
     pub(crate) async fn receive_message(&mut self) -> Result<VaultResponseMessage> {
         self.ctx
-            .receive::<ResultMessage<VaultResponseMessage>>()
-            .await?
+            .receive::<ResultMessage<VaultResponseMessage>>()?
             .take()
             .body()
             .inner(self.error_domain)


### PR DESCRIPTION
This commit is mostly an experiment to investigate how we can split
the sync and async variants of functions with the least amount of code
duplication.  The approach taken in this commit comes with a bit of
overhead in terms of documentation, because functions SHOULD be
documented for both their sync and async variants.

It does come with the advantage that both sync and async APIs can be
made public via compile-options.