### PR TITLE
Add the standard crate lib header to ockam crate

### DIFF
--- a/implementations/rust/ockam/ockam/src/credential.rs
+++ b/implementations/rust/ockam/ockam/src/credential.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 mod attribute;
 mod attribute_schema;
 mod attribute_type;

--- a/implementations/rust/ockam/ockam/src/credential/issuer.rs
+++ b/implementations/rust/ockam/ockam/src/credential/issuer.rs
@@ -139,7 +139,7 @@ impl CredentialIssuer {
             atts.insert(name, att);
         }
 
-        let mut messages = Vec::<(usize, signature_core::lib::Message)>::new();
+        let mut messages = Vec::<(usize, Message)>::new();
         let mut remaining_atts = Vec::<(usize, CredentialAttribute)>::new();
 
         // Check if any blinded messages are allowed to be unknown

--- a/implementations/rust/ockam/ockam/src/credential/request.rs
+++ b/implementations/rust/ockam/ockam/src/credential/request.rs
@@ -4,6 +4,9 @@ use signature_bbs_plus::BlindSignatureContext;
 /// A request for a credential generated from a credential offer
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CredentialRequest {
+    /// Offer ID sent in the credential setup.
     pub offer_id: [u8; 32],
+
+    /// Context of the signature.
     pub(crate) context: BlindSignatureContext,
 }

--- a/implementations/rust/ockam/ockam/src/credential/verifier.rs
+++ b/implementations/rust/ockam/ockam/src/credential/verifier.rs
@@ -3,7 +3,9 @@ use rand::RngCore;
 use sha2::digest::{generic_array::GenericArray, Digest, FixedOutput};
 use signature_bbs_plus::{MessageGenerators, PublicKey};
 use signature_bls::ProofOfPossession;
-use signature_core::lib::*;
+use signature_core::lib::{*, Message};
+
+use ockam_core::lib::Result;
 
 /// Methods for verifying presentations
 #[derive(Debug)]
@@ -34,7 +36,7 @@ impl CredentialVerifier {
         presentations: &[CredentialPresentation],
         presentation_manifests: &[PresentationManifest],
         proof_request_id: [u8; 32],
-    ) -> ockam_core::lib::Result<(), CredentialError> {
+    ) -> Result<(), CredentialError> {
         if presentations.len() != presentation_manifests.len() || presentations.len() == 0 {
             return Err(CredentialError::MismatchedPresentationAndManifests);
         }
@@ -65,7 +67,7 @@ impl CredentialVerifier {
                 .iter()
                 .zip(prez.revealed_attributes.iter())
                 .map(|(i, r)| (*i, r.to_signature_message()))
-                .collect::<Vec<(usize, signature_core::lib::Message), U64>>();
+                .collect::<Vec<(usize, Message), U64>>();
 
             let mut hasher = sha2::Sha256::new();
             hasher.update(&bytes);

--- a/implementations/rust/ockam/ockam/src/credential/verifier.rs
+++ b/implementations/rust/ockam/ockam/src/credential/verifier.rs
@@ -3,7 +3,7 @@ use rand::RngCore;
 use sha2::digest::{generic_array::GenericArray, Digest, FixedOutput};
 use signature_bbs_plus::{MessageGenerators, PublicKey};
 use signature_bls::ProofOfPossession;
-use signature_core::lib::{*, Message};
+use signature_core::lib::{Message, *};
 
 use ockam_core::lib::Result;
 

--- a/implementations/rust/ockam/ockam/src/error.rs
+++ b/implementations/rust/ockam/ockam/src/error.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+#![allow(missing_docs)] // Contents are self describing for now.
 #[derive(Clone, Copy, Debug)]
 pub enum OckamError {
     None,

--- a/implementations/rust/ockam/ockam/src/lease.rs
+++ b/implementations/rust/ockam/ockam/src/lease.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use ockam_core::lib::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -11,7 +11,6 @@
 )]
 // ---
 // #![no_std] if the standard library is not present.
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -1,3 +1,14 @@
+//! Ockam is a library for building devices that communicate securely, privately
+//! and trustfully with cloud services and other devices.
+#![deny(
+  //  missing_docs, // not compatible with big_array
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unused_import_braces,
+    unused_qualifications,
+    warnings
+)]
 // ---
 // #![no_std] if the standard library is not present.
 

--- a/implementations/rust/ockam/ockam/src/remote_forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/remote_forwarder.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use crate::{Context, OckamError};
 use ockam_core::lib::net::SocketAddr;
 use ockam_core::{Address, Any, Result, Route, Routed, TransportMessage, Worker};
@@ -5,6 +7,7 @@ use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
+/// Information about a remotely forwarded worker.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct RemoteForwarderInfo {
     forwarding_route: Route,
@@ -13,12 +16,15 @@ pub struct RemoteForwarderInfo {
 }
 
 impl RemoteForwarderInfo {
+    /// Returns the forwarding route.
     pub fn forwarding_route(&self) -> &Route {
         &self.forwarding_route
     }
+    /// Returns the remote address.
     pub fn remote_address(&self) -> &str {
         &self.remote_address
     }
+    /// Returns the worker address.
     pub fn worker_address(&self) -> &Address {
         &self.worker_address
     }

--- a/implementations/rust/ockam/ockam/src/remote_forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/remote_forwarder.rs
@@ -79,7 +79,7 @@ impl Worker for RemoteForwarder {
     type Context = Context;
     type Message = Any;
 
-    async fn initialize(&mut self, ctx: &mut Self::Context) -> crate::Result<()> {
+    async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
         debug!("RemoteForwarder registering...");
         ctx.send(self.route.clone(), "register".to_string()).await?;
         let resp = ctx.receive::<String>().await?.take();


### PR DESCRIPTION
One of the serde dependencies precludes a crate-wide `missing_docs` attribute. That attribute was added on all sub-modules though.