### PR TITLE
Initial Entity implementation

### DIFF
--- a/examples/rust/get_started/Cargo.lock
+++ b/examples/rust/get_started/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -772,6 +772,7 @@ name = "ockam_entity"
 version = "0.2.0-dev"
 dependencies = [
  "async-trait",
+ "cfg-if",
  "ockam_channel",
  "ockam_core",
  "ockam_key_exchange_xx",

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -869,6 +869,7 @@ name = "ockam_entity"
 version = "0.2.0-dev"
 dependencies = [
  "async-trait",
+ "cfg-if",
  "ockam_channel",
  "ockam_core",
  "ockam_key_exchange_xx",

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/implementations/rust/ockam/ockam_entity/Cargo.lock
+++ b/implementations/rust/ockam/ockam_entity/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -444,6 +444,7 @@ name = "ockam_entity"
 version = "0.2.0-dev"
 dependencies = [
  "async-trait",
+ "cfg-if",
  "ockam_channel",
  "ockam_core",
  "ockam_key_exchange_xx",

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -27,6 +27,7 @@ ockam_vault = {path = "../ockam_vault", version = "0.7.0-dev" , optional = true}
 ockam_channel = {path = "../ockam_channel", version = "0.8.0-dev" }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.5.0-dev" , optional = true}
 async-trait = "0.1.42"
+cfg-if = "1.0.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 serde_bare = "0.4"

--- a/implementations/rust/ockam/ockam_entity/README.md
+++ b/implementations/rust/ockam/ockam_entity/README.md
@@ -8,7 +8,7 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-INSERT DESCRIPTION HERE
+Entity is an abstraction over Profiles and Vaults, easing the use of these primitives in authentication and authorization APIs.
 
 ## Crate Features
 

--- a/implementations/rust/ockam/ockam_entity/src/change/ctype.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change/ctype.rs
@@ -8,6 +8,8 @@ pub use rotate_key::*;
 /// Possible types of [`crate::Profile`] changes
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ProfileChangeType {
+    /// Create key
     CreateKey(CreateKeyChange),
+    /// Rotate key
     RotateKey(RotateKeyChange),
 }

--- a/implementations/rust/ockam/ockam_entity/src/change/ctype/create_key.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change/ctype/create_key.rs
@@ -12,6 +12,7 @@ use serde_big_array::big_array;
 
 big_array! { BigArray; }
 
+/// Key change data creation
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CreateKeyChangeData {
     key_attributes: KeyAttributes,
@@ -19,15 +20,18 @@ pub struct CreateKeyChangeData {
 }
 
 impl CreateKeyChangeData {
+    /// Return key attributes
     pub fn key_attributes(&self) -> &KeyAttributes {
         &self.key_attributes
     }
+    /// Return public key
     pub fn public_key(&self) -> &[u8] {
         &self.public_key
     }
 }
 
 impl CreateKeyChangeData {
+    /// Create new CreateKeyChangeData
     pub fn new(key_attributes: KeyAttributes, public_key: Vec<u8>) -> Self {
         CreateKeyChangeData {
             key_attributes,
@@ -36,6 +40,7 @@ impl CreateKeyChangeData {
     }
 }
 
+/// Key change creation
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CreateKeyChange {
     data: CreateKeyChangeData,
@@ -44,15 +49,18 @@ pub struct CreateKeyChange {
 }
 
 impl CreateKeyChange {
+    /// Return data
     pub fn data(&self) -> &CreateKeyChangeData {
         &self.data
     }
+    /// Return self signature
     pub fn self_signature(&self) -> &[u8; 64] {
         &self.self_signature
     }
 }
 
 impl CreateKeyChange {
+    /// Create new CreateKeyChange
     pub fn new(data: CreateKeyChangeData, self_signature: [u8; 64]) -> Self {
         CreateKeyChange {
             data,
@@ -62,6 +70,7 @@ impl CreateKeyChange {
 }
 
 impl<V: ProfileVault> ProfileImpl<V> {
+    /// Create a new key event
     pub(crate) fn create_key_event_static(
         prev_id: EventIdentifier,
         key_attributes: KeyAttributes,
@@ -116,6 +125,7 @@ impl<V: ProfileVault> ProfileImpl<V> {
         Ok(signed_change_event)
     }
 
+    /// Create a new key event
     pub(crate) fn create_key_event(
         &mut self,
         key_attributes: KeyAttributes,

--- a/implementations/rust/ockam/ockam_entity/src/change/ctype/rotate_key.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change/ctype/rotate_key.rs
@@ -12,6 +12,7 @@ use serde_big_array::big_array;
 
 big_array! { BigArray; }
 
+/// RotateKeyChangeData
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RotateKeyChangeData {
     key_attributes: KeyAttributes,
@@ -19,15 +20,18 @@ pub struct RotateKeyChangeData {
 }
 
 impl RotateKeyChangeData {
+    /// Return key attributes
     pub fn key_attributes(&self) -> &KeyAttributes {
         &self.key_attributes
     }
+    /// Return public key
     pub fn public_key(&self) -> &[u8] {
         self.public_key.as_slice()
     }
 }
 
 impl RotateKeyChangeData {
+    /// Create RotateKeyChangeData
     pub fn new(key_attributes: KeyAttributes, public_key: Vec<u8>) -> Self {
         RotateKeyChangeData {
             key_attributes,
@@ -36,6 +40,7 @@ impl RotateKeyChangeData {
     }
 }
 
+/// RotateKeyChange
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RotateKeyChange {
     data: RotateKeyChangeData,
@@ -46,18 +51,22 @@ pub struct RotateKeyChange {
 }
 
 impl RotateKeyChange {
+    /// Return the data
     pub fn data(&self) -> &RotateKeyChangeData {
         &self.data
     }
+    /// Return the self signature
     pub fn self_signature(&self) -> &[u8; 64] {
         &self.self_signature
     }
+    /// Return the previous signature
     pub fn prev_signature(&self) -> &[u8; 64] {
         &self.prev_signature
     }
 }
 
 impl RotateKeyChange {
+    /// Create a new RotateKeyChange
     pub fn new(
         data: RotateKeyChangeData,
         self_signature: [u8; 64],
@@ -72,6 +81,7 @@ impl RotateKeyChange {
 }
 
 impl<V: ProfileVault> ProfileImpl<V> {
+    /// Rotate key event
     pub(crate) fn rotate_key_event(
         &mut self,
         key_attributes: KeyAttributes,

--- a/implementations/rust/ockam/ockam_entity/src/change/event.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change/event.rs
@@ -1,6 +1,7 @@
 use crate::{EventIdentifier, ProfileChange, ProfileChangeProof};
 use serde::{Deserialize, Serialize};
 
+/// Profile changes with a given event identifier
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Changes {
     prev_event_id: EventIdentifier,
@@ -19,6 +20,7 @@ impl Changes {
 }
 
 impl Changes {
+    /// Create new Changes
     pub fn new(prev_event_id: EventIdentifier, data: Vec<ProfileChange>) -> Self {
         Changes {
             prev_event_id,
@@ -54,6 +56,7 @@ impl ProfileChangeEvent {
 }
 
 impl ProfileChangeEvent {
+    /// Create a new profile change event
     pub fn new(identifier: EventIdentifier, changes: Changes, proof: ProfileChangeProof) -> Self {
         ProfileChangeEvent {
             identifier,

--- a/implementations/rust/ockam/ockam_entity/src/change/history.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change/history.rs
@@ -1,3 +1,4 @@
+//! Profile history
 use crate::ProfileChangeType::{CreateKey, RotateKey};
 use crate::{
     EntityError, EventIdentifier, KeyAttributes, Profile, ProfileChange, ProfileChangeEvent,

--- a/implementations/rust/ockam/ockam_entity/src/change/proof.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change/proof.rs
@@ -3,17 +3,21 @@ use serde_big_array::big_array;
 
 big_array! { BigArray; }
 
+/// Types of proof signatures.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SignatureType {
+    /// Root signature
     RootSign,
 }
 
 /// Variants of proofs that are allowed on a [`crate::Profile`] change
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ProfileChangeProof {
+    /// Signature change proof
     Signature(Signature),
 }
 
+/// Signature, its type and data
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Signature {
     stype: SignatureType,
@@ -22,15 +26,18 @@ pub struct Signature {
 }
 
 impl Signature {
+    /// Return the signature type
     pub fn stype(&self) -> &SignatureType {
         &self.stype
     }
+    /// Return signature data
     pub fn data(&self) -> &[u8; 64] {
         &self.data
     }
 }
 
 impl Signature {
+    /// Create a new signature
     pub fn new(stype: SignatureType, data: [u8; 64]) -> Self {
         Signature { stype, data }
     }

--- a/implementations/rust/ockam/ockam_entity/src/contact.rs
+++ b/implementations/rust/ockam/ockam_entity/src/contact.rs
@@ -1,3 +1,4 @@
+//! Profile contacts
 use crate::history::ProfileChangeHistory;
 use crate::{
     EntityError, EventIdentifier, KeyAttributes, ProfileChangeEvent, ProfileIdentifier,
@@ -91,6 +92,7 @@ impl Contact {
 }
 
 impl Contact {
+    /// Create a new Contact.
     pub fn new(identifier: ProfileIdentifier, change_events: Vec<ProfileChangeEvent>) -> Self {
         Contact {
             identifier,

--- a/implementations/rust/ockam/ockam_entity/src/entity.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity.rs
@@ -1,0 +1,190 @@
+use crate::{ProfileIdentifier, ProfileTrait};
+
+pub mod authentication;
+pub use authentication::*;
+pub mod change;
+pub use change::*;
+pub mod contacts;
+pub use contacts::*;
+pub mod identifiers;
+pub use identifiers::*;
+pub mod secrets;
+pub use secrets::*;
+
+/// An Entity represents an identity in various authentication contexts.
+#[derive(Clone)]
+pub struct Entity<P: ProfileTrait> {
+    default_profile_identifier: ProfileIdentifier,
+    profiles: Vec<P>,
+}
+
+impl<P: ProfileTrait> Entity<P> {
+    /// Create a new Entity with the given default profile.
+    pub fn new(default_profile: P) -> Self {
+        let idref = default_profile.identifier().unwrap();
+        let default_profile_identifier = ProfileIdentifier::from_key_id(idref.key_id().clone());
+        let profiles = vec![default_profile];
+        Entity {
+            default_profile_identifier,
+            profiles,
+        }
+    }
+
+    fn default_profile(&self) -> Option<&P> {
+        self.profiles
+            .iter()
+            .find(|profile| self.default_profile_identifier == profile.identifier().unwrap())
+    }
+
+    fn _add_profile(&mut self, profile: P) {
+        self.profiles.push(profile);
+    }
+}
+
+#[cfg(test)]
+#[allow(unreachable_code, unused_variables)]
+mod test {
+    use crate::{
+        Entity, KeyAttributes, Profile, ProfileAuth, ProfileContacts, ProfileIdentity,
+        ProfileSecrets, ProfileSync, ProfileTrait,
+    };
+    use ockam_node::Context;
+    use ockam_vault_sync_core::Vault;
+
+    async fn new_entity(ctx: &Context) -> ockam_core::Result<Entity<ProfileSync>> {
+        let vault = Vault::create(ctx)?;
+
+        let profile = Profile::create(&ctx, &vault).await;
+        assert!(profile.is_ok());
+
+        let profile = profile.unwrap();
+        Ok(Entity::new(profile))
+    }
+
+    #[test]
+    fn test_new_entity() {
+        let (mut ctx, mut executor) = ockam_node::start_node();
+        executor
+            .execute(async move {
+                let e = new_entity(&ctx).await.unwrap();
+                assert!(!e
+                    .default_profile_identifier
+                    .to_string_representation()
+                    .is_empty());
+                assert!(!e.profiles.is_empty());
+
+                let default = e.default_profile();
+
+                assert!(default.is_some());
+                ctx.stop().await.unwrap();
+            })
+            .unwrap();
+    }
+
+    fn entity_auth_tests<P: ProfileTrait>(mut e: Entity<P>) -> ockam_core::Result<()> {
+        let channel_state = "test".as_bytes();
+        let proof = e.generate_authentication_proof(channel_state);
+        assert!(proof.is_ok());
+
+        let proof = proof.unwrap();
+
+        // TODO WIP: Need Contacts for this test to be successful. This tests the delegation but not correct operation currently.
+        let default_id = e.default_profile_identifier.clone();
+        let valid = e.verify_authentication_proof(channel_state, &default_id, proof.as_slice());
+        // assert!(valid.is_ok());
+        Ok(())
+    }
+
+    fn entity_change_tests<P: ProfileTrait>(e: Entity<P>) -> ockam_core::Result<()> {
+        // TODO WIP: Need key ops and other event generating APIs to easily test this
+        // change_events update_no_verification verify
+        Ok(())
+    }
+
+    async fn entity_contacts_tests<P: ProfileTrait>(
+        ctx: &Context,
+        mut e: Entity<P>,
+    ) -> ockam_core::Result<()> {
+        //    verify_and_update_contact
+
+        let alice = new_entity(&ctx).await.unwrap();
+        let alice_id = alice.identifier()?.clone();
+
+        let alice_contact = alice.serialize_to_contact()?;
+        let alice_contact = Profile::deserialize_contact(alice_contact.as_slice())?;
+
+        let to_alice_contact = alice.to_contact()?;
+        assert_eq!(alice_contact.identifier(), to_alice_contact.identifier());
+
+        e.verify_contact(&alice_contact)?;
+
+        e.verify_and_add_contact(alice_contact)?;
+
+        assert_eq!(1, e.contacts()?.len());
+
+        let get_alice_contact = e.get_contact(&alice_id)?;
+        assert!(get_alice_contact.is_some());
+
+        let get_alice_contact = get_alice_contact.unwrap();
+        assert_eq!(&alice_id, get_alice_contact.identifier());
+
+        // TODO WIP: after change event emitting APIs are done, make this a non-trivial test
+        let change_events = vec![];
+        e.verify_and_update_contact(&alice_id, change_events)?;
+        Ok(())
+    }
+
+    fn entity_secrets_test<P: ProfileTrait>(mut e: Entity<P>) -> ockam_core::Result<()> {
+        //   get_secret_key  get_root_secret rotate_key
+
+        let key_attributes = KeyAttributes::new("label".to_string());
+        e.create_key(key_attributes.clone(), None)?;
+
+        let pubkey = e.get_public_key(&key_attributes)?;
+        let secret = e.get_secret_key(&key_attributes)?;
+        let root = e.get_root_secret()?;
+
+        let root_key_attributes = KeyAttributes::new(Profile::PROFILE_UPDATE.to_string());
+
+        e.rotate_key(root_key_attributes, None)?;
+
+        /* Uncomment once rotate_key is implemented
+        let new_pubkey = e.get_public_key(&key_attributes)?;
+
+        let new_secret = e.get_secret_key(&key_attributes)?;
+
+        assert_ne!(new_pubkey, pubkey);
+        assert_ne!(new_secret, secret);
+         */
+        Ok(())
+    }
+
+    async fn entity_profile_mgmt_test<P: ProfileTrait>(
+        ctx: &Context,
+        e: Entity<P>,
+    ) -> ockam_core::Result<()> {
+        let vault = Vault::create(ctx)?;
+        let bank_profile = Profile::create(ctx, &vault).await?;
+
+        //    e.add_profile(bank_profile);
+        Ok(())
+    }
+
+    async fn entity_all_tests(mut ctx: Context) -> ockam_core::Result<()> {
+        let e = new_entity(&ctx).await?;
+        entity_contacts_tests(&ctx, e.clone()).await?;
+        entity_auth_tests(e.clone())?;
+        entity_change_tests(e.clone())?;
+        entity_secrets_test(e.clone())?;
+        entity_profile_mgmt_test(&ctx, e).await?;
+        ctx.stop().await
+    }
+
+    #[test]
+    fn test_entity_default_profile_delegation() {
+        let (ctx, mut executor) = ockam_node::start_node();
+        executor
+            .execute(async move { entity_all_tests(ctx).await })
+            .unwrap();
+    }
+}

--- a/implementations/rust/ockam/ockam_entity/src/entity/authentication.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity/authentication.rs
@@ -1,0 +1,34 @@
+//! Entity auth
+
+use crate::EntityError::ProfileNotFound;
+use crate::{Entity, ProfileAuth, ProfileIdentifier, ProfileTrait};
+use ockam_core::Result;
+
+impl<P: ProfileTrait> ProfileAuth for Entity<P> {
+    fn generate_authentication_proof(&mut self, channel_state: &[u8]) -> Result<Vec<u8>> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.generate_authentication_proof(channel_state);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn verify_authentication_proof(
+        &mut self,
+        channel_state: &[u8],
+        responder_contact_id: &ProfileIdentifier,
+        proof: &[u8],
+    ) -> Result<bool> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.verify_authentication_proof(
+                    channel_state,
+                    responder_contact_id,
+                    proof,
+                );
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+}

--- a/implementations/rust/ockam/ockam_entity/src/entity/change.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity/change.rs
@@ -1,0 +1,33 @@
+//! Entity changes
+
+use crate::EntityError::ProfileNotFound;
+use crate::{Entity, ProfileChangeEvent, ProfileChanges, ProfileTrait};
+use ockam_core::Result;
+
+impl<P: ProfileTrait> ProfileChanges for Entity<P> {
+    fn change_events(&self) -> Result<Vec<ProfileChangeEvent>> {
+        if let Some(profile) = self.default_profile() {
+            profile.change_events()
+        } else {
+            Err(ProfileNotFound.into())
+        }
+    }
+
+    fn update_no_verification(&mut self, change_event: ProfileChangeEvent) -> Result<()> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.update_no_verification(change_event);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn verify(&mut self) -> Result<bool> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.verify();
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+}

--- a/implementations/rust/ockam/ockam_entity/src/entity/contacts.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity/contacts.rs
@@ -1,0 +1,73 @@
+//! Entity contacts
+//!
+use crate::EntityError::ProfileNotFound;
+use crate::{
+    Contact, ContactsDb, Entity, ProfileChangeEvent, ProfileContacts, ProfileIdentifier,
+    ProfileTrait,
+};
+use ockam_core::Result;
+
+impl<P: ProfileTrait> ProfileContacts for Entity<P> {
+    fn contacts(&self) -> Result<ContactsDb> {
+        if let Some(profile) = self.default_profile() {
+            profile.contacts()
+        } else {
+            Err(ProfileNotFound.into())
+        }
+    }
+
+    fn to_contact(&self) -> Result<Contact> {
+        if let Some(profile) = self.default_profile() {
+            profile.to_contact()
+        } else {
+            Err(ProfileNotFound.into())
+        }
+    }
+
+    fn serialize_to_contact(&self) -> Result<Vec<u8>> {
+        if let Some(profile) = self.default_profile() {
+            profile.serialize_to_contact()
+        } else {
+            Err(ProfileNotFound.into())
+        }
+    }
+
+    fn get_contact(&self, id: &ProfileIdentifier) -> Result<Option<Contact>> {
+        if let Some(profile) = self.default_profile() {
+            profile.get_contact(id)
+        } else {
+            Err(ProfileNotFound.into())
+        }
+    }
+
+    fn verify_contact(&mut self, contact: &Contact) -> Result<bool> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.verify_contact(contact);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn verify_and_add_contact(&mut self, contact: Contact) -> Result<bool> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.verify_and_add_contact(contact);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn verify_and_update_contact(
+        &mut self,
+        profile_id: &ProfileIdentifier,
+        change_events: Vec<ProfileChangeEvent>,
+    ) -> Result<bool> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.verify_and_update_contact(profile_id, change_events);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+}

--- a/implementations/rust/ockam/ockam_entity/src/entity/identifiers.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity/identifiers.rs
@@ -1,0 +1,10 @@
+//! Entity identifiers
+
+use crate::{Entity, ProfileIdentifier, ProfileIdentity, ProfileTrait};
+use ockam_core::Result;
+
+impl<P: ProfileTrait> ProfileIdentity for Entity<P> {
+    fn identifier(&self) -> Result<ProfileIdentifier> {
+        Ok(self.default_profile_identifier.clone())
+    }
+}

--- a/implementations/rust/ockam/ockam_entity/src/entity/secrets.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity/secrets.rs
@@ -1,0 +1,60 @@
+//! Entity secrets
+
+use crate::EntityError::ProfileNotFound;
+use crate::{Entity, KeyAttributes, ProfileEventAttributes, ProfileSecrets, ProfileTrait};
+use ockam_core::Result;
+use ockam_vault_core::{PublicKey, Secret};
+
+impl<P: ProfileTrait> ProfileSecrets for Entity<P> {
+    fn create_key(
+        &mut self,
+        key_attributes: KeyAttributes,
+        attributes: Option<ProfileEventAttributes>,
+    ) -> Result<()> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.create_key(key_attributes, attributes);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn rotate_key(
+        &mut self,
+        key_attributes: KeyAttributes,
+        attributes: Option<ProfileEventAttributes>,
+    ) -> Result<()> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.rotate_key(key_attributes, attributes);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn get_secret_key(&mut self, key_attributes: &KeyAttributes) -> Result<Secret> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.get_secret_key(key_attributes);
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+
+    fn get_public_key(&self, key_attributes: &KeyAttributes) -> Result<PublicKey> {
+        if let Some(profile) = self.default_profile() {
+            profile.get_public_key(key_attributes)
+        } else {
+            Err(ProfileNotFound.into())
+        }
+    }
+
+    fn get_root_secret(&mut self) -> Result<Secret> {
+        for profile in &mut self.profiles {
+            if self.default_profile_identifier == profile.identifier()? {
+                return profile.get_root_secret();
+            }
+        }
+        Err(ProfileNotFound.into())
+    }
+}

--- a/implementations/rust/ockam/ockam_entity/src/error.rs
+++ b/implementations/rust/ockam/ockam_entity/src/error.rs
@@ -21,6 +21,7 @@ pub enum EntityError {
     SecureChannelVerificationFailed,
     SecureChannelCannotBeAuthenticated,
     ProfileInvalidResponseType,
+    ProfileNotFound,
 }
 
 impl EntityError {

--- a/implementations/rust/ockam/ockam_entity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_entity/src/identifiers.rs
@@ -2,17 +2,24 @@ use ockam_core::hex::encode;
 use ockam_vault_core::KeyId;
 use serde::{Deserialize, Serialize};
 
+/// An identifier of a Profile.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ProfileIdentifier(KeyId);
 
 /// Unique [`crate::Profile`] identifier, computed as SHA256 of root public key
 impl ProfileIdentifier {
+    /// Create a ProfileIdentifier from a KeyId
     pub fn from_key_id(key_id: KeyId) -> Self {
         Self { 0: key_id }
     }
     /// Human-readable form of the id
     pub fn to_string_representation(&self) -> String {
         format!("P_ID.{}", &self.0)
+    }
+
+    /// Return the wrapped KeyId
+    pub fn key_id(&self) -> &KeyId {
+        &self.0
     }
 }
 
@@ -40,6 +47,13 @@ impl EventIdentifier {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rand::{thread_rng, RngCore};
+
+    impl ProfileIdentifier {
+        pub fn random() -> ProfileIdentifier {
+            ProfileIdentifier(format!("{:x}", thread_rng().next_u64()))
+        }
+    }
 
     #[test]
     fn test_new() {

--- a/implementations/rust/ockam/ockam_entity/src/imp.rs
+++ b/implementations/rust/ockam/ockam_entity/src/imp.rs
@@ -36,7 +36,6 @@ impl<V: ProfileVault> ProfileImpl<V> {
 }
 
 impl<V: ProfileVault> ProfileImpl<V> {
-    /// Return clone of Vault
     pub(crate) fn change_history(&self) -> &ProfileChangeHistory {
         &self.change_history
     }

--- a/implementations/rust/ockam/ockam_entity/src/key_attributes.rs
+++ b/implementations/rust/ockam/ockam_entity/src/key_attributes.rs
@@ -20,6 +20,7 @@ impl KeyAttributes {
 }
 
 impl KeyAttributes {
+    /// Create new key attributes
     pub fn new(label: String) -> Self {
         KeyAttributes { label }
     }

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -1,6 +1,8 @@
-//! Documentation should be here
+//! Entity is an abstraction over Profiles and Vaults, easing the use of these primitives in
+//! authentication and authorization APIs.
 #![deny(
-    // missing_docs,
+  // prevented by big_array
+  //  missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
@@ -32,11 +34,14 @@ mod change;
 pub use change::*;
 mod channel;
 pub(crate) use channel::*;
+mod entity;
+pub use entity::*;
 mod error;
 pub use error::*;
 mod worker;
 pub use worker::*;
 
+/// Traits required for a Vault implementation suitable for use in a Profile
 pub trait ProfileVault:
     SecretVault + SecureChannelVault + KeyIdVault + Hasher + Signer + Verifier + Clone + Send + 'static
 {
@@ -210,6 +215,7 @@ impl<D> ProfileVault for D where
 pub struct Profile;
 
 impl Profile {
+    /// Create a new Profile
     pub async fn create(ctx: &Context, vault: &Address) -> Result<ProfileSync> {
         let vault = VaultSync::create_with_worker(ctx, vault)?;
         let imp = ProfileImpl::<VaultSync>::create_internal(None, vault)?;
@@ -228,6 +234,7 @@ impl Profile {
     pub const CURRENT_CHANGE_VERSION: u8 = 1;
 }
 
+/// Profile event attributes
 pub type ProfileEventAttributes = HashMap<String, String>;
 /// Contacts Database
 pub type ContactsDb = HashMap<ProfileIdentifier, Contact>;
@@ -262,6 +269,7 @@ impl Profile {
 
 #[cfg(test)]
 mod test {
+
     use super::*;
     use ockam_vault_sync_core::Vault;
 

--- a/implementations/rust/ockam/ockam_entity/src/traits.rs
+++ b/implementations/rust/ockam/ockam_entity/src/traits.rs
@@ -7,11 +7,13 @@ use ockam_core::{Address, Result, Route};
 use ockam_node::Context;
 use ockam_vault_core::{PublicKey, Secret};
 
+/// Profile identity.
 pub trait ProfileIdentity {
     /// Return unique [`Profile`] identifier, which is equal to sha256 of the root public key
     fn identifier(&self) -> Result<ProfileIdentifier>;
 }
 
+/// Profile verified change history.
 pub trait ProfileChanges {
     /// Return change history chain
     fn change_events(&self) -> Result<Vec<ProfileChangeEvent>>;
@@ -21,6 +23,7 @@ pub trait ProfileChanges {
     fn verify(&mut self) -> Result<bool>;
 }
 
+/// Profile contact management.
 pub trait ProfileContacts {
     /// Return all known to this profile [`Contact`]s
     fn contacts(&self) -> Result<ContactsDb>;
@@ -42,8 +45,12 @@ pub trait ProfileContacts {
     ) -> Result<bool>;
 }
 
+/// Profile authentication support.
 pub trait ProfileAuth {
+    /// Generate an authentication proof based on the given channel_state
     fn generate_authentication_proof(&mut self, channel_state: &[u8]) -> Result<Vec<u8>>;
+
+    /// Verify an authentication proof based on the given channel state, proof and profile.
     fn verify_authentication_proof(
         &mut self,
         channel_state: &[u8],
@@ -52,6 +59,7 @@ pub trait ProfileAuth {
     ) -> Result<bool>;
 }
 
+/// Profile secret management.
 pub trait ProfileSecrets {
     /// Create new key. Key is uniquely identified by label in [`KeyAttributes`]
     fn create_key(
@@ -77,6 +85,7 @@ pub trait ProfileSecrets {
     fn get_root_secret(&mut self) -> Result<Secret>;
 }
 
+/// A trait that represents the two endpoints of a secure channel.
 #[async_trait]
 pub trait SecureChannelTrait {
     /// Create mutually authenticated secure channel

--- a/implementations/rust/ockam/ockam_entity/src/worker/profile_sync.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/profile_sync.rs
@@ -9,6 +9,7 @@ use ockam_vault_core::{PublicKey, Secret};
 use rand::random;
 use tracing::debug;
 
+/// Synchronous worker wrapper around a Profile
 pub struct ProfileSync {
     ctx: Context,
     profile_worker_address: Address,
@@ -69,6 +70,7 @@ impl ProfileSync {
         })
     }
 
+    /// Create a new Profile
     pub async fn create<P: ProfileTrait>(ctx: &Context, profile: P) -> Result<Self> {
         let profile_address = ProfileWorker::create_with_inner(ctx, profile).await?;
 

--- a/implementations/rust/ockam/ockam_entity/src/worker/worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/worker.rs
@@ -4,15 +4,18 @@ use ockam_core::{Address, Result, ResultMessage, Routed, Worker};
 use ockam_node::Context;
 use rand::random;
 
+/// A Worker wrapper for a Profile
 pub struct ProfileWorker<P: ProfileTrait> {
     inner: P,
 }
 
 impl<P: ProfileTrait> ProfileWorker<P> {
+    /// Create a new ProfileWorker
     fn new(inner: P) -> Self {
         Self { inner }
     }
 
+    /// Create and start a ProfileWorker
     pub async fn create_with_inner(ctx: &Context, inner: P) -> Result<Address> {
         let address: Address = random();
 

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -772,6 +772,7 @@ name = "ockam_entity"
 version = "0.2.0-dev"
 dependencies = [
  "async-trait",
+ "cfg-if",
  "ockam_channel",
  "ockam_core",
  "ockam_key_exchange_xx",

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
+checksum = "bbda1ffd586ec58bdbc3290f9243c1d05bec1abf49ec15e4bc3d60070b7d9d11"
 dependencies = [
  "cfg-if",
  "cipher",


### PR DESCRIPTION
This creates a delegating Entity. 

- Entity has a default Profile, and delegates all operations to it
- The Entity type implements `ProfileTrait` 
- ProfileTrait updated to add accessor for a Vault, as well as Clone, Send and static lifetime
- SecureChannel creation refactored to use generic Profile traits instead of `ProfileImpl`. This could move into `Entity` eventually but for now i broke it out into a `SecureChannel` builder. Having Profiles construct the Channels themselves was problematic to the design.