### PR TITLE
fix user id env variable in ockam-builder docker run cmd

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -36,7 +36,7 @@ docker build \
 Run the builder:
 
 ```
-docker run --rm -it -e LOCAL_USER_ID=$(id -u) --volume $(pwd):/work ockam/builder:latest bash
+docker run --rm -it -e HOST_USER_ID=$(id -u) --volume $(pwd):/work ockam/builder:latest bash
 ```
 
 ## Hub


### PR DESCRIPTION
### Proposed Changes
This PR changes the env variable used in the Ockam-builder docker run command used for building the project.