### PR TITLE
ci: regenerate workflows for rust 1.51

### DIFF
--- a/.github/workflow_template.yml
+++ b/.github/workflow_template.yml
@@ -8,7 +8,7 @@ jobs:
   $name:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_.._.._examples_rust_get_started.yml
+++ b/.github/workflows/rust_build_.._.._examples_rust_get_started.yml
@@ -14,7 +14,7 @@ jobs:
   rust_build___examples_rust_get_started:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam.yml
+++ b/.github/workflows/rust_build_ockam_ockam.yml
@@ -27,7 +27,7 @@ jobs:
   rust_build_ockam_ockam:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_channel.yml
+++ b/.github/workflows/rust_build_ockam_ockam_channel.yml
@@ -21,7 +21,7 @@ jobs:
   rust_build_ockam_ockam_channel:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_channel.yml
+++ b/.github/workflows/rust_build_ockam_ockam_channel.yml
@@ -10,6 +10,7 @@ on:
       - 'implementations/rust/ockam/ockam_vault_core/**'
       - 'implementations/rust/ockam/ockam_vault_sync_core/**'
       - 'implementations/rust/ockam/ockam_vault/**'
+      - 'implementations/rust/ockam/ockam_key_exchange_x3dh/**'
       - 'build.gradle'
       - 'implementations/rust/build.gradle'
       - 'settings.gradle'

--- a/.github/workflows/rust_build_ockam_ockam_core.yml
+++ b/.github/workflows/rust_build_ockam_ockam_core.yml
@@ -13,7 +13,7 @@ jobs:
   rust_build_ockam_ockam_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_entity.yml
+++ b/.github/workflows/rust_build_ockam_ockam_entity.yml
@@ -20,7 +20,7 @@ jobs:
   rust_build_ockam_ockam_entity:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_examples.yml
+++ b/.github/workflows/rust_build_ockam_ockam_examples.yml
@@ -14,7 +14,7 @@ jobs:
   rust_build_ockam_ockam_examples:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_ffi.yml
+++ b/.github/workflows/rust_build_ockam_ockam_ffi.yml
@@ -16,7 +16,7 @@ jobs:
   rust_build_ockam_ockam_ffi:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_key_exchange_core.yml
+++ b/.github/workflows/rust_build_ockam_ockam_key_exchange_core.yml
@@ -15,7 +15,7 @@ jobs:
   rust_build_ockam_ockam_key_exchange_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_key_exchange_x3dh.yml
+++ b/.github/workflows/rust_build_ockam_ockam_key_exchange_x3dh.yml
@@ -18,7 +18,7 @@ jobs:
   rust_build_ockam_ockam_key_exchange_x3dh:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_key_exchange_xx.yml
+++ b/.github/workflows/rust_build_ockam_ockam_key_exchange_xx.yml
@@ -19,7 +19,7 @@ jobs:
   rust_build_ockam_ockam_key_exchange_xx:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_node.yml
+++ b/.github/workflows/rust_build_ockam_ockam_node.yml
@@ -14,7 +14,7 @@ jobs:
   rust_build_ockam_ockam_node:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_node_attribute.yml
+++ b/.github/workflows/rust_build_ockam_ockam_node_attribute.yml
@@ -13,7 +13,7 @@ jobs:
   rust_build_ockam_ockam_node_attribute:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_node_no_std.yml
+++ b/.github/workflows/rust_build_ockam_ockam_node_no_std.yml
@@ -13,7 +13,7 @@ jobs:
   rust_build_ockam_ockam_node_no_std:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_transport_tcp.yml
+++ b/.github/workflows/rust_build_ockam_ockam_transport_tcp.yml
@@ -15,7 +15,7 @@ jobs:
   rust_build_ockam_ockam_transport_tcp:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_transport_websocket.yml
+++ b/.github/workflows/rust_build_ockam_ockam_transport_websocket.yml
@@ -15,7 +15,7 @@ jobs:
   rust_build_ockam_ockam_transport_websocket:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_vault.yml
+++ b/.github/workflows/rust_build_ockam_ockam_vault.yml
@@ -17,7 +17,7 @@ jobs:
   rust_build_ockam_ockam_vault:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_vault_core.yml
+++ b/.github/workflows/rust_build_ockam_ockam_vault_core.yml
@@ -14,7 +14,7 @@ jobs:
   rust_build_ockam_ockam_vault_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_vault_sync_core.yml
+++ b/.github/workflows/rust_build_ockam_ockam_vault_sync_core.yml
@@ -19,7 +19,7 @@ jobs:
   rust_build_ockam_ockam_vault_sync_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_vault_test_attribute.yml
+++ b/.github/workflows/rust_build_ockam_ockam_vault_test_attribute.yml
@@ -13,7 +13,7 @@ jobs:
   rust_build_ockam_ockam_vault_test_attribute:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_ockam_vault_test_suite.yml
+++ b/.github/workflows/rust_build_ockam_ockam_vault_test_suite.yml
@@ -15,7 +15,7 @@ jobs:
   rust_build_ockam_ockam_vault_test_suite:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_signature_bbs_plus.yml
+++ b/.github/workflows/rust_build_ockam_signature_bbs_plus.yml
@@ -15,7 +15,7 @@ jobs:
   rust_build_ockam_signature_bbs_plus:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_signature_bls.yml
+++ b/.github/workflows/rust_build_ockam_signature_bls.yml
@@ -13,7 +13,7 @@ jobs:
   rust_build_ockam_signature_bls:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_signature_core.yml
+++ b/.github/workflows/rust_build_ockam_signature_core.yml
@@ -13,7 +13,7 @@ jobs:
   rust_build_ockam_signature_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_build_ockam_signature_ps.yml
+++ b/.github/workflows/rust_build_ockam_signature_ps.yml
@@ -15,7 +15,7 @@ jobs:
   rust_build_ockam_signature_ps:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_.._.._examples_rust_get_started.yml
+++ b/.github/workflows/rust_lint_.._.._examples_rust_get_started.yml
@@ -14,7 +14,7 @@ jobs:
   rust_lint___examples_rust_get_started:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam.yml
+++ b/.github/workflows/rust_lint_ockam_ockam.yml
@@ -27,7 +27,7 @@ jobs:
   rust_lint_ockam_ockam:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_channel.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_channel.yml
@@ -10,6 +10,7 @@ on:
       - 'implementations/rust/ockam/ockam_vault_core/**'
       - 'implementations/rust/ockam/ockam_vault_sync_core/**'
       - 'implementations/rust/ockam/ockam_vault/**'
+      - 'implementations/rust/ockam/ockam_key_exchange_x3dh/**'
       - 'build.gradle'
       - 'implementations/rust/build.gradle'
       - 'settings.gradle'

--- a/.github/workflows/rust_lint_ockam_ockam_channel.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_channel.yml
@@ -21,7 +21,7 @@ jobs:
   rust_lint_ockam_ockam_channel:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_core.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_core.yml
@@ -13,7 +13,7 @@ jobs:
   rust_lint_ockam_ockam_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_entity.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_entity.yml
@@ -20,7 +20,7 @@ jobs:
   rust_lint_ockam_ockam_entity:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_examples.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_examples.yml
@@ -14,7 +14,7 @@ jobs:
   rust_lint_ockam_ockam_examples:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_ffi.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_ffi.yml
@@ -16,7 +16,7 @@ jobs:
   rust_lint_ockam_ockam_ffi:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_key_exchange_core.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_key_exchange_core.yml
@@ -15,7 +15,7 @@ jobs:
   rust_lint_ockam_ockam_key_exchange_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_key_exchange_x3dh.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_key_exchange_x3dh.yml
@@ -18,7 +18,7 @@ jobs:
   rust_lint_ockam_ockam_key_exchange_x3dh:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_key_exchange_xx.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_key_exchange_xx.yml
@@ -19,7 +19,7 @@ jobs:
   rust_lint_ockam_ockam_key_exchange_xx:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_node.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_node.yml
@@ -14,7 +14,7 @@ jobs:
   rust_lint_ockam_ockam_node:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_node_attribute.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_node_attribute.yml
@@ -13,7 +13,7 @@ jobs:
   rust_lint_ockam_ockam_node_attribute:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_node_no_std.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_node_no_std.yml
@@ -13,7 +13,7 @@ jobs:
   rust_lint_ockam_ockam_node_no_std:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_transport_tcp.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_transport_tcp.yml
@@ -15,7 +15,7 @@ jobs:
   rust_lint_ockam_ockam_transport_tcp:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_transport_websocket.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_transport_websocket.yml
@@ -15,7 +15,7 @@ jobs:
   rust_lint_ockam_ockam_transport_websocket:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_vault.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_vault.yml
@@ -17,7 +17,7 @@ jobs:
   rust_lint_ockam_ockam_vault:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_vault_core.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_vault_core.yml
@@ -14,7 +14,7 @@ jobs:
   rust_lint_ockam_ockam_vault_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_vault_sync_core.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_vault_sync_core.yml
@@ -19,7 +19,7 @@ jobs:
   rust_lint_ockam_ockam_vault_sync_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_vault_test_attribute.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_vault_test_attribute.yml
@@ -13,7 +13,7 @@ jobs:
   rust_lint_ockam_ockam_vault_test_attribute:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_ockam_vault_test_suite.yml
+++ b/.github/workflows/rust_lint_ockam_ockam_vault_test_suite.yml
@@ -15,7 +15,7 @@ jobs:
   rust_lint_ockam_ockam_vault_test_suite:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_signature_bbs_plus.yml
+++ b/.github/workflows/rust_lint_ockam_signature_bbs_plus.yml
@@ -15,7 +15,7 @@ jobs:
   rust_lint_ockam_signature_bbs_plus:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_signature_bls.yml
+++ b/.github/workflows/rust_lint_ockam_signature_bls.yml
@@ -13,7 +13,7 @@ jobs:
   rust_lint_ockam_signature_bls:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_signature_core.yml
+++ b/.github/workflows/rust_lint_ockam_signature_core.yml
@@ -13,7 +13,7 @@ jobs:
   rust_lint_ockam_signature_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_lint_ockam_signature_ps.yml
+++ b/.github/workflows/rust_lint_ockam_signature_ps.yml
@@ -15,7 +15,7 @@ jobs:
   rust_lint_ockam_signature_ps:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_.._.._examples_rust_get_started.yml
+++ b/.github/workflows/rust_test_.._.._examples_rust_get_started.yml
@@ -14,7 +14,7 @@ jobs:
   rust_test___examples_rust_get_started:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam.yml
+++ b/.github/workflows/rust_test_ockam_ockam.yml
@@ -27,7 +27,7 @@ jobs:
   rust_test_ockam_ockam:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_channel.yml
+++ b/.github/workflows/rust_test_ockam_ockam_channel.yml
@@ -21,7 +21,7 @@ jobs:
   rust_test_ockam_ockam_channel:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_channel.yml
+++ b/.github/workflows/rust_test_ockam_ockam_channel.yml
@@ -10,6 +10,7 @@ on:
       - 'implementations/rust/ockam/ockam_vault_core/**'
       - 'implementations/rust/ockam/ockam_vault_sync_core/**'
       - 'implementations/rust/ockam/ockam_vault/**'
+      - 'implementations/rust/ockam/ockam_key_exchange_x3dh/**'
       - 'build.gradle'
       - 'implementations/rust/build.gradle'
       - 'settings.gradle'

--- a/.github/workflows/rust_test_ockam_ockam_core.yml
+++ b/.github/workflows/rust_test_ockam_ockam_core.yml
@@ -13,7 +13,7 @@ jobs:
   rust_test_ockam_ockam_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_entity.yml
+++ b/.github/workflows/rust_test_ockam_ockam_entity.yml
@@ -20,7 +20,7 @@ jobs:
   rust_test_ockam_ockam_entity:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_examples.yml
+++ b/.github/workflows/rust_test_ockam_ockam_examples.yml
@@ -14,7 +14,7 @@ jobs:
   rust_test_ockam_ockam_examples:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_ffi.yml
+++ b/.github/workflows/rust_test_ockam_ockam_ffi.yml
@@ -16,7 +16,7 @@ jobs:
   rust_test_ockam_ockam_ffi:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_key_exchange_core.yml
+++ b/.github/workflows/rust_test_ockam_ockam_key_exchange_core.yml
@@ -15,7 +15,7 @@ jobs:
   rust_test_ockam_ockam_key_exchange_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_key_exchange_x3dh.yml
+++ b/.github/workflows/rust_test_ockam_ockam_key_exchange_x3dh.yml
@@ -18,7 +18,7 @@ jobs:
   rust_test_ockam_ockam_key_exchange_x3dh:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_key_exchange_xx.yml
+++ b/.github/workflows/rust_test_ockam_ockam_key_exchange_xx.yml
@@ -19,7 +19,7 @@ jobs:
   rust_test_ockam_ockam_key_exchange_xx:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_node.yml
+++ b/.github/workflows/rust_test_ockam_ockam_node.yml
@@ -14,7 +14,7 @@ jobs:
   rust_test_ockam_ockam_node:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_node_attribute.yml
+++ b/.github/workflows/rust_test_ockam_ockam_node_attribute.yml
@@ -13,7 +13,7 @@ jobs:
   rust_test_ockam_ockam_node_attribute:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_node_no_std.yml
+++ b/.github/workflows/rust_test_ockam_ockam_node_no_std.yml
@@ -13,7 +13,7 @@ jobs:
   rust_test_ockam_ockam_node_no_std:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_transport_tcp.yml
+++ b/.github/workflows/rust_test_ockam_ockam_transport_tcp.yml
@@ -15,7 +15,7 @@ jobs:
   rust_test_ockam_ockam_transport_tcp:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_transport_websocket.yml
+++ b/.github/workflows/rust_test_ockam_ockam_transport_websocket.yml
@@ -15,7 +15,7 @@ jobs:
   rust_test_ockam_ockam_transport_websocket:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_vault.yml
+++ b/.github/workflows/rust_test_ockam_ockam_vault.yml
@@ -17,7 +17,7 @@ jobs:
   rust_test_ockam_ockam_vault:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_vault_core.yml
+++ b/.github/workflows/rust_test_ockam_ockam_vault_core.yml
@@ -14,7 +14,7 @@ jobs:
   rust_test_ockam_ockam_vault_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_vault_sync_core.yml
+++ b/.github/workflows/rust_test_ockam_ockam_vault_sync_core.yml
@@ -19,7 +19,7 @@ jobs:
   rust_test_ockam_ockam_vault_sync_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_vault_test_attribute.yml
+++ b/.github/workflows/rust_test_ockam_ockam_vault_test_attribute.yml
@@ -13,7 +13,7 @@ jobs:
   rust_test_ockam_ockam_vault_test_attribute:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_ockam_vault_test_suite.yml
+++ b/.github/workflows/rust_test_ockam_ockam_vault_test_suite.yml
@@ -15,7 +15,7 @@ jobs:
   rust_test_ockam_ockam_vault_test_suite:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_signature_bbs_plus.yml
+++ b/.github/workflows/rust_test_ockam_signature_bbs_plus.yml
@@ -15,7 +15,7 @@ jobs:
   rust_test_ockam_signature_bbs_plus:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_signature_bls.yml
+++ b/.github/workflows/rust_test_ockam_signature_bls.yml
@@ -13,7 +13,7 @@ jobs:
   rust_test_ockam_signature_bls:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_signature_core.yml
+++ b/.github/workflows/rust_test_ockam_signature_core.yml
@@ -13,7 +13,7 @@ jobs:
   rust_test_ockam_signature_core:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/rust_test_ockam_signature_ps.yml
+++ b/.github/workflows/rust_test_ockam_signature_ps.yml
@@ -15,7 +15,7 @@ jobs:
   rust_test_ockam_signature_ps:
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:d70b384ff4d40e403f9b5b171eada3ed6746117a9267e98ae530336747895fe2
+      image: ghcr.io/ockam-network/ockam/builder@sha256:cbda96698696625b29da843da8c7d1b37b775d5767d14bbf0f8233174735dca8
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4


### PR DESCRIPTION
@mrinalwadhwa  the workflows are pinned to a specific docker image sha, so we need to regen to associate to the new rust 1.51 image