### PR TITLE
fix(c): rename duplicated endpoint_buffer variable

### DIFF
--- a/implementations/c/ockam/codec/tests/endpoint_test.c
+++ b/implementations/c/ockam/codec/tests/endpoint_test.c
@@ -8,14 +8,14 @@
 #include "ockam/codec.h"
 #include "ockam/log.h"
 
-uint8_t* encoded_buffer;
+uint8_t* address_buffer;
 
 int _test_endpoints_setup(void** state)
 {
   int error = 0;
 
-  encoded_buffer = malloc(0xffff);
-  if (0 == encoded_buffer) {
+  address_buffer = malloc(0xffff);
+  if (0 == address_buffer) {
     error = -1;
     goto exit_block;
   }
@@ -32,12 +32,12 @@ void _test_endpoints(void** state)
 
   CodecEndpointType type;
 
-  uint8_t* encoded = encoded_buffer;
+  uint8_t* encoded = address_buffer;
 
   // IPV4
   encoded = encode_endpoint(encoded, kTcpIpv4, (uint8_t*) &ep_ipv4_in);
   assert_ptr_not_equal(0, encoded);
-  encoded = encoded_buffer;
+  encoded = address_buffer;
   encoded = decode_endpoint(encoded, &type, (uint8_t*) &ep_ipv4_out);
   assert_ptr_not_equal(0, encoded);
   assert_int_equal(type, kTcpIpv4);
@@ -48,6 +48,6 @@ int _test_endpoints_teardown(void** state)
 {
   int error = 0;
 
-  if (0 != encoded_buffer) free(encoded_buffer);
+  if (0 != address_buffer) free(address_buffer);
   return 0;
 }


### PR DESCRIPTION
### Proposed Changes

Compiling C tests fail due to a duplicated variable:

> ```
> [163/171] Linking C executable ockam/codec/tests/ockam_codec_tests
> FAILED: ockam/codec/tests/ockam_codec_tests
> : && /usr/lib64/ccache/gcc   ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/codec.c.o ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/variable_length_encoded_u2le_test.c.o ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/public_key_test.c.o ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/endpoint_local_test.c.o ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/endpoint_channel_test.c.o ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/endpoint_test.c.o ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/route_test.c.o -o ockam/codec/tests/ockam_codec_tests  -lcmocka-static  ockam/log/libockam_log.a  ockam/codec/libockam_codec.a  ockam/log/libockam_log.a && :
> /usr/bin/ld: ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/endpoint_test.c.o:(.bss+0x0): multiple definition of `encoded_buffer'; ockam/codec/tests/CMakeFiles/ockam_codec_tests.dir/endpoint_channel_test.c.o:(.bss+0x10): first defined here
> collect2: error: ld returned 1 exit status
> [165/171] Linking C static library ockam/transport/libockam_transport.a
> ninja: build stopped: subcommand failed.
> ```

This is duplicated between endpoint_test.c and endpoint_channel_test.c.

Rename the former to address_buffer as it seems like the most correct
next-choice name for the variable.

This seems to be a result of compiling many tests into a single binary.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

---

I'm not entirely sure this is the correct fix. Perhaps there's a way of splitting out the tests someone more familiar with the project can suggest? :) 