### PR TITLE
feat(elixir): support address prefixes for random addresses

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/node.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/node.ex
@@ -46,6 +46,11 @@ defmodule Ockam.Node do
   defdelegate unregister_address(address), to: Registry, as: :unregister_name
 
   @doc """
+  Lists all registered addresses
+  """
+  defdelegate list_addresses(), to: Registry, as: :list_names
+
+  @doc """
   Send a message to the process registered with an address.
   """
   def send(address, message) do
@@ -59,12 +64,16 @@ defmodule Ockam.Node do
   @doc """
   Returns a random address that is currently not registed on the node.
   """
-  def get_random_unregistered_address(length_in_bytes \\ @default_address_length_in_bytes) do
-    candidate = length_in_bytes |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+  def get_random_unregistered_address(
+        prefix \\ "",
+        length_in_bytes \\ @default_address_length_in_bytes
+      ) do
+    random = length_in_bytes |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+    candidate = prefix <> random
 
     case whereis(candidate) do
       nil -> candidate
-      _pid -> get_random_unregistered_address(length_in_bytes)
+      _pid -> get_random_unregistered_address(prefix, length_in_bytes)
     end
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/listener.ex
@@ -6,6 +6,8 @@ defmodule Ockam.SecureChannel.Listener do
   alias Ockam.Message
   alias Ockam.SecureChannel.Channel
 
+  @channel_address_prefix "SC_"
+
   @doc false
   @impl true
   def setup(options, state) do
@@ -28,6 +30,7 @@ defmodule Ockam.SecureChannel.Listener do
       [role: :responder]
       |> Keyword.put(:vault, state.vault)
       |> Keyword.put(:identity_keypair, state.identity_keypair)
+      |> Keyword.put(:address_prefix, @channel_address_prefix)
 
     with {:ok, channel_options} <- update_routes(message, channel_options),
          {:ok, _address} <- Channel.create(channel_options) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
@@ -14,6 +14,8 @@ defmodule Ockam.Stream.Client.BiDirectional do
 
   @transport_message_encoder Ockam.Wire.Binary.V2
 
+  @consumer_address_prefix "STBC_"
+
   @doc """
   Create bidirectional consumer.
   Consumer will handle messages with handle_message/4
@@ -30,7 +32,8 @@ defmodule Ockam.Stream.Client.BiDirectional do
         stream_options,
         stream_name: stream_name,
         client_id: subscription_id,
-        message_handler: message_handler
+        message_handler: message_handler,
+        address_prefix: @consumer_address_prefix
       )
 
     {:ok, _consumer_address} = Consumer.create(consumer_options)

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
@@ -10,6 +10,8 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
 
   require Logger
 
+  @publisher_prefix "STBP_"
+
   @impl true
   def setup(options, state) do
     consumer_stream = Keyword.fetch!(options, :consumer_stream)
@@ -24,7 +26,12 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
   @impl true
   def handle_message({:init, publisher_stream, stream_options}, state) do
     {:ok, publisher_address} =
-      Publisher.create(Keyword.merge(stream_options, stream_name: publisher_stream))
+      Publisher.create(
+        Keyword.merge(stream_options,
+          stream_name: publisher_stream,
+          address_prefix: @publisher_prefix
+        )
+      )
 
     {:ok, Map.put(state, :publisher_address, publisher_address)}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/workers/service.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/workers/service.ex
@@ -17,6 +17,8 @@ defmodule Ockam.Stream.Workers.Service do
 
   @default_storage Ockam.Stream.Storage.Internal
 
+  @stream_worker_prefix "ST_W_"
+
   @protocol_mapping Ockam.Protocol.Mapping.mapping([
                       {:server, StreamProtocol.Create},
                       {:server, StreamProtocol.Partitioned.Create},
@@ -138,7 +140,8 @@ defmodule Ockam.Stream.Workers.Service do
           [
             reply_route: return_route,
             stream_name: name,
-            partition: partition
+            partition: partition,
+            address_prefix: @stream_worker_prefix
           ]
       )
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -34,7 +34,12 @@ defmodule Ockam.Worker do
 
       @doc false
       def create(options) when is_list(options) do
-        options = Keyword.put_new_lazy(options, :address, &Node.get_random_unregistered_address/0)
+        address_prefix = Keyword.get(options, :address_prefix, "")
+
+        options =
+          Keyword.put_new_lazy(options, :address, fn ->
+            Node.get_random_unregistered_address(address_prefix)
+          end)
 
         case Node.start_supervised(__MODULE__, options) do
           {:ok, pid, worker} ->

--- a/implementations/elixir/ockam/ockam/lib/ockam/workers/call.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/workers/call.ex
@@ -10,8 +10,12 @@ defmodule Ockam.Workers.Call do
 
   require Logger
 
+  @address_prefix "CALL_"
+
   def call(call, options \\ [], timeout \\ 10_000) do
-    {:ok, address} = __MODULE__.create(Keyword.put(options, :call, call))
+    {:ok, address} =
+      __MODULE__.create(Keyword.merge(options, call: call, address_prefix: @address_prefix))
+
     GenServer.call(Ockam.Node.whereis(address), :fetch, timeout)
   end
 

--- a/implementations/elixir/ockam/ockam/test/ockam/node_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/node_test.exs
@@ -12,14 +12,18 @@ defmodule Ockam.Node.Tests do
     end
   end
 
-  describe "#{Node}.get_random_unregistered_address/{0,1}" do
+  describe "#{Node}.get_random_unregistered_address/{0,1,2}" do
     test "keeps trying" do
       Enum.each(0..254, fn x ->
         x = Base.encode16(<<x>>, case: :lower)
         Node.register_address(x, self())
       end)
 
-      assert "ff" === Node.get_random_unregistered_address(1)
+      assert "ff" === Node.get_random_unregistered_address("", 1)
+    end
+
+    test "uses prefix" do
+      assert "prefix" <> _ = Node.get_random_unregistered_address("prefix_")
     end
   end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/worker_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/worker_test.exs
@@ -31,13 +31,27 @@ defmodule Ockam.Worker.Tests do
   use ExUnit.Case, async: false
   doctest Ockam.Worker
 
+  alias Ockam.Worker.Tests.InnerWorker
+  alias Ockam.Worker.Tests.OuterWorker
+
   require Logger
 
   describe "Ockam.Worker" do
     test "Can start inner worker on setup" do
-      {:ok, address} = Ockam.Worker.Tests.OuterWorker.create([])
+      {:ok, address} = OuterWorker.create([])
       pid = Ockam.Node.whereis(address)
       assert is_binary(GenServer.call(pid, :get_inner))
+    end
+
+    test "Can start a worker with address prefix" do
+      {:ok, address} = InnerWorker.create(address_prefix: "inner_")
+      assert "inner_" <> _ = address
+    end
+
+    test "Explicit address overrides address prefix" do
+      {:ok, address} = InnerWorker.create(address: "explicit_inner", address_prefix: "inner_")
+
+      assert "explicit_inner" == address
     end
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/alias.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/alias.ex
@@ -16,6 +16,8 @@ defmodule Ockam.Hub.Service.Alias do
 
   require Logger
 
+  @forwarder_address_prefix "FWD_"
+
   @impl true
   def handle_message(message, state) do
     Logger.info("ALIAS service\nMESSAGE: #{inspect(message)}")
@@ -25,7 +27,8 @@ defmodule Ockam.Hub.Service.Alias do
     {:ok, _alias_address} =
       __MODULE__.Forwarder.create(
         forward_route: forward_route,
-        registration_payload: payload
+        registration_payload: payload,
+        address_prefix: @forwarder_address_prefix
       )
 
     {:ok, state}


### PR DESCRIPTION
Add an option to `Ockam.Worker.create/1` option list: `:address_prefix` to use as a prefix in random address generation.
This can be used when debugging workers with random addresses and also for future operations integration (e.g. metrics)