### PR TITLE
fix(rust): fix key size of ps key

### DIFF
--- a/implementations/rust/ockam/signature_ps/src/blind_signature.rs
+++ b/implementations/rust/ockam/signature_ps/src/blind_signature.rs
@@ -95,7 +95,7 @@ impl Default for BlindSignature {
 
 impl BlindSignature {
     /// The number of bytes in a signature
-    pub const BYTES: usize = 96;
+    pub const BYTES: usize = 128;
 
     /// Generate a new signature where all messages are known to the signer
     pub fn new(

--- a/implementations/rust/ockam/signature_ps/src/prover.rs
+++ b/implementations/rust/ockam/signature_ps/src/prover.rs
@@ -115,10 +115,10 @@ fn blind_signature_context_test() {
     let nonce = Nonce::random(&mut rng);
 
     // try with zero, just means a blinded signature but issuer knows all messages
-    let mut blind_messages = [];
+    let blind_messages = [];
 
     let res =
-        Prover::new_blind_signature_context(&mut blind_messages[..], &generators, nonce, &mut rng);
+        Prover::new_blind_signature_context(&blind_messages[..], &generators, nonce, &mut rng);
     assert!(res.is_ok());
 
     let (ctx, blinding) = res.unwrap();


### PR DESCRIPTION
Fixes https://github.com/ockam-network/ockam/issues/1435 by changing `BYTES` from 96 to 128.