### PR TITLE
fix(elixir): remove deduplication from stream client

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
@@ -43,8 +43,8 @@ defmodule Ockam.Example.Stream.BiDirectional.SecureChannel do
       # hub_ip: "13.64.73.230",
       hub_ip: "127.0.0.1",
       hub_port: 4000,
-      service_address: "stream_service",
-      index_address: "stream_index_service"
+      service_address: "stream",
+      index_address: "stream_index"
     }
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
@@ -42,8 +42,8 @@ defmodule Ockam.Stream.Client.BiDirectional do
   Creates a return stream publisher id it doesn't exist
   Routes the message locally with return publisher address in return route
   """
-  def handle_message(data, consumer_stream, subscription_id, stream_options, state) do
-    with {:ok, %{return_stream: publisher_stream, message: message, message_id: message_id}} <-
+  def handle_message(data, consumer_stream, subscription_id, stream_options, _state) do
+    with {:ok, %{return_stream: publisher_stream, message: message}} <-
            decode_message(data) do
       {:ok, publisher_address} =
         ensure_publisher(
@@ -58,33 +58,9 @@ defmodule Ockam.Stream.Client.BiDirectional do
         | return_route: [publisher_address | Message.return_route(message)]
       }
 
-      case last_forwarded_message(state) do
-        last_message_id when last_message_id < message_id ->
-          Logger.debug(
-            "Consumer forward #{inspect(forwarded_message)} with id #{inspect(message_id)}"
-          )
-
-          Ockam.Router.route(forwarded_message)
-          {:ok, update_last_forwarded_message(state, message_id)}
-
-        other ->
-          Logger.debug(
-            "Consumer received duplicate message: #{inspect(message_id)} last processed: #{
-              inspect(other)
-            }"
-          )
-
-          :ok
-      end
+      Ockam.Router.route(forwarded_message)
+      :ok
     end
-  end
-
-  def last_forwarded_message(state) do
-    Map.get(state, :last_forwarded_message, 0)
-  end
-
-  def update_last_forwarded_message(state, message_id) do
-    Map.put(state, :last_forwarded_message, message_id)
   end
 
   @doc """
@@ -99,22 +75,28 @@ defmodule Ockam.Stream.Client.BiDirectional do
     PublisherRegistry.ensure_publisher(publisher_id, options)
   end
 
-  @bare_message {:struct, [return_stream: :string, message: :data, message_id: :uint]}
+  @bare_message {:struct, [return_stream: :string, message: :data]}
 
-  def encode_message(%{return_stream: stream, message: message, message_id: message_id}) do
-    {:ok, wire_message} = Ockam.Wire.encode(@transport_message_encoder, message)
-
-    :bare.encode(
-      %{return_stream: stream, message: wire_message, message_id: message_id},
-      @bare_message
-    )
+  def encode_message(%{return_stream: stream, message: message}) do
+    with {:ok, wire_message} <- Ockam.Wire.encode(@transport_message_encoder, message) do
+      {:ok,
+       :bare.encode(
+         %{return_stream: stream, message: wire_message},
+         @bare_message
+       )}
+    end
   end
 
   def decode_message(data) do
     case :bare.decode(data, @bare_message) do
-      {:ok, %{return_stream: stream, message: wire_message, message_id: message_id}, ""} ->
-        {:ok, message} = Ockam.Wire.decode(@transport_message_encoder, wire_message)
-        {:ok, %{return_stream: stream, message: message, message_id: message_id}}
+      {:ok, %{return_stream: stream, message: wire_message}, ""} ->
+        case Ockam.Wire.decode(@transport_message_encoder, wire_message) do
+          {:ok, message} ->
+            {:ok, %{return_stream: stream, message: message}}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
 
       other ->
         {:error, other}

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
@@ -39,15 +39,10 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
     [^self_address | onward_route] = Message.onward_route(message)
     forwarded_message = %{message | onward_route: onward_route}
 
-    {message_id, state} = next_message_id(state)
-
-    Logger.debug("Forward message #{inspect(forwarded_message)} with id #{inspect(message_id)}")
-
-    encoded_message =
+    {:ok, encoded_message} =
       Ockam.Stream.Client.BiDirectional.encode_message(%{
         message: forwarded_message,
-        return_stream: consumer_stream,
-        message_id: message_id
+        return_stream: consumer_stream
       })
 
     binary_message =
@@ -66,11 +61,5 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
     ## Delay message processing
     send(self(), message)
     {:ok, state}
-  end
-
-  def next_message_id(state) do
-    current = Map.get(state, :message_id, 0)
-    next = current + 1
-    {next, Map.put(state, :message_id, next)}
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/config/config.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/config.exs
@@ -2,6 +2,8 @@ import Config
 
 config :logger, level: :info
 
+config :ockam, Ockam.Wire, default: Ockam.Wire.Binary.V2
+
 config :logger, :console, metadata: [:module, :line, :pid]
 
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Deduplication in the stream client is not reliable enough.
Since secure channel do not require deduplication, it's not critically needed
