### PR TITLE
WIP feat(rust): add no_std + alloc support to enable embedded device support for ockam

### DIFF
--- a/examples/rust/get_started/Cargo.lock
+++ b/examples/rust/get_started/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -309,8 +310,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -823,7 +822,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -845,7 +844,7 @@ dependencies = [
  "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
  "tracing",
 ]
 
@@ -858,7 +857,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
 ]
 
 [[package]]
@@ -881,7 +880,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -912,6 +911,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -950,7 +950,7 @@ dependencies = [
  "futures-util",
  "ockam_core",
  "ockam_node",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1323,6 +1323,14 @@ name = "serde_bare"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bare"
+version = "0.4.0"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -8,7 +8,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -55,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +78,31 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-embedded"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+ "cortex-m-semihosting",
+ "generic-array 0.14.4",
+ "heapless 0.5.3",
+ "pin-utils",
+ "typenum",
+]
 
 [[package]]
 name = "async-trait"
@@ -86,7 +121,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -145,7 +180,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -157,7 +192,7 @@ dependencies = [
  "digest",
  "ff",
  "group",
- "heapless",
+ "heapless 0.7.4",
  "pairing",
  "rand_core 0.6.3",
  "serde",
@@ -201,7 +236,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -214,6 +270,15 @@ dependencies = [
  "bitfield",
  "embedded-hal",
  "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -231,7 +296,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -241,7 +306,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -273,7 +338,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -299,8 +364,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -428,6 +491,24 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -488,6 +569,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
@@ -516,12 +606,22 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.5.3"
+source = "git+https://github.com/japaric/heapless?branch=slab#10e88349aef0957062f46700ccb2752485d3aa50"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+]
+
+[[package]]
+name = "heapless"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "stable_deref_trait",
 ]
 
@@ -577,7 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -745,7 +845,7 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json",
  "sha2",
  "signature_bbs_plus",
@@ -769,7 +869,7 @@ dependencies = [
  "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
  "tracing",
 ]
 
@@ -778,12 +878,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown 0.11.2",
- "heapless",
+ "heapless 0.7.4",
  "hex",
  "rand 0.8.4",
+ "rand_pcg",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
+ "spin",
 ]
 
 [[package]]
@@ -794,7 +897,7 @@ dependencies = [
  "bls12_381_plus",
  "cfg-if",
  "group",
- "heapless",
+ "heapless 0.7.4",
  "ockam_channel",
  "ockam_core",
  "ockam_key_exchange_core",
@@ -806,7 +909,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -837,7 +940,11 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
+ "cortex-m-semihosting",
+ "heapless 0.7.4",
  "ockam_core",
+ "ockam_node_no_std",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -849,6 +956,19 @@ version = "0.14.0-dev"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ockam_node_no_std"
+version = "0.13.0-dev"
+dependencies = [
+ "async-embedded",
+ "cortex-m 0.7.3",
+ "futures",
+ "heapless 0.7.4",
+ "ockam_core",
+ "panic-udf",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -932,6 +1052,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "panic-udf"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
 ]
 
 [[package]]
@@ -1107,6 +1235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bare"
+version = "0.4.0"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
+dependencies = [
+ "core2",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,7 +1474,7 @@ dependencies = [
  "ff",
  "group",
  "hashbrown 0.11.2",
- "heapless",
+ "heapless 0.7.4",
  "rand_core 0.6.3",
  "serde",
  "serde-big-array",
@@ -1347,6 +1493,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1555,7 +1707,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -18,13 +18,22 @@ version = "0.24.0-dev"
 default = ["std", "ockam_transport_tcp", "software_vault", "noise_xx"]
 software_vault = ["ockam_vault", "ockam_vault_sync_core", "ockam_vault_sync_core/software_vault", "ockam_channel/software_vault"]
 noise_xx = ["ockam_key_exchange_xx", "ockam_channel/noise_xx"]
-std = ["ockam_node", "serde/std"]
-alloc = ["ockam_core/alloc", "serde/alloc"]
-no_std = ["ockam_core/no_std", "serde"]
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_node/std", "serde/std", "ockam_node_attribute/std"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+alloc = ["ockam_core/alloc", "ockam_node/alloc", "serde/alloc", "ockam_node_attribute/no_std"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+no_std = ["ockam_core/no_std", "ockam_node/no_std", "serde"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"         }
-ockam_node = { path = "../ockam_node", version = "0.23.0-dev"        , optional = true }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default-features = false }
+ockam_node = { path = "../ockam_node", version = "0.23.0-dev", default-features = false, optional = true }
 ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.14.0-dev"         }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev"         }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.16.0-dev"        , optional = true }

--- a/implementations/rust/ockam/ockam/src/lease.rs
+++ b/implementations/rust/ockam/ockam/src/lease.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs)]
 
-use ockam_core::lib::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// A lease for managing secrets

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -10,7 +10,7 @@
     warnings
 )]
 // ---
-// #![no_std] if the standard library is not present.
+// #![cfg_attr(not(feature = "std"), no_std)] if the standard library is not present.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
@@ -26,11 +26,8 @@ pub use ockam_node_attribute::*;
 // ---
 
 // Export node implementation
-#[cfg(all(feature = "std", feature = "ockam_node"))]
 pub use ockam_node::*;
 
-#[cfg(all(not(feature = "std"), feature = "ockam_node_no_std"))]
-pub use ockam_node_no_std::*;
 // ---
 
 mod delay;
@@ -44,6 +41,7 @@ mod unique;
 pub use delay::*;
 pub use error::*;
 pub use lease::*;
+pub use ockam_core::compat;
 pub use ockam_core::worker;
 pub use ockam_entity::*;
 pub use protocols::*;

--- a/implementations/rust/ockam/ockam/src/remote_forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/remote_forwarder.rs
@@ -1,7 +1,10 @@
 #![deny(missing_docs)]
 
 use crate::{route, Context, OckamError};
+#[cfg(feature = "no_std")]
+use ockam_core::compat::rand::random;
 use ockam_core::{Address, Any, LocalMessage, Result, Route, Routed, TransportMessage, Worker};
+#[cfg(feature = "std")]
 use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};

--- a/implementations/rust/ockam/ockam/src/unique.rs
+++ b/implementations/rust/ockam/ockam/src/unique.rs
@@ -1,4 +1,4 @@
-use ockam_core::lib::String;
+use ockam_core::compat::string::String;
 use rand::{thread_rng, Rng};
 
 /// A simple generator for unique, human-readable identifiers suitable

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -8,7 +8,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+ "heapless 0.7.4",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -49,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +73,31 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-embedded"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+ "cortex-m-semihosting",
+ "generic-array 0.14.4",
+ "heapless 0.5.3",
+ "pin-utils",
+ "typenum",
+]
 
 [[package]]
 name = "async-trait"
@@ -80,7 +116,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -139,7 +175,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -151,7 +187,7 @@ dependencies = [
  "digest",
  "ff",
  "group",
- "heapless",
+ "heapless 0.7.4",
  "pairing",
  "rand_core 0.6.3",
  "serde",
@@ -195,7 +231,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -208,6 +265,15 @@ dependencies = [
  "bitfield",
  "embedded-hal",
  "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -225,7 +291,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -235,7 +301,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -267,7 +333,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -293,8 +359,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -325,6 +389,102 @@ name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "generic-array"
@@ -388,6 +548,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
@@ -407,12 +576,23 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.5.3"
+source = "git+https://github.com/japaric/heapless?branch=slab#10e88349aef0957062f46700ccb2752485d3aa50"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+]
+
+[[package]]
+name = "heapless"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -468,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -626,9 +806,10 @@ dependencies = [
  "ockam_vault",
  "ockam_vault_core",
  "ockam_vault_sync_core",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tracing",
  "trybuild",
 ]
@@ -638,11 +819,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless 0.7.4",
  "hex",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -679,10 +864,27 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
+ "cortex-m-semihosting",
+ "heapless 0.7.4",
  "ockam_core",
+ "ockam_node_no_std",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "ockam_node_no_std"
+version = "0.13.0-dev"
+dependencies = [
+ "async-embedded",
+ "cortex-m 0.7.3",
+ "futures",
+ "heapless 0.7.4",
+ "ockam_core",
+ "panic-udf",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -696,7 +898,8 @@ dependencies = [
  "hkdf",
  "ockam_core",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "sha2",
  "signature_bbs_plus",
  "tracing",
@@ -709,6 +912,7 @@ name = "ockam_vault_core"
 version = "0.19.0-dev"
 dependencies = [
  "cfg-if",
+ "heapless 0.7.4",
  "ockam_core",
  "serde",
  "serde-big-array",
@@ -724,7 +928,8 @@ dependencies = [
  "ockam_node",
  "ockam_vault",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
  "serde-big-array",
  "tracing",
@@ -750,6 +955,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "panic-udf"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
 ]
 
 [[package]]
@@ -784,6 +997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "polyval"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +1019,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -827,37 +1058,14 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -890,18 +1098,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -996,19 +1204,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1119,7 +1318,7 @@ dependencies = [
  "ff",
  "group",
  "hashbrown",
- "heapless",
+ "heapless 0.7.4",
  "rand_core 0.6.3",
  "serde",
  "serde-big-array",
@@ -1132,6 +1331,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1340,7 +1545,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -1379,7 +1584,7 @@ checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
 dependencies = [
  "ff",
  "group",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
  "serde",
  "zeroize",

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -17,21 +17,33 @@ in encrypted and authenticated way.
 default = ["std"]
 software_vault = ["ockam_vault", "ockam_vault_sync_core", "ockam_vault_sync_core/software_vault"]
 noise_xx = ["ockam_key_exchange_xx"]
-std = []
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_key_exchange_core/std", "ockam_key_exchange_xx/std", "ockam_node/std", "ockam_vault_core/std", "ockam_vault_sync_core/std", "ockam_vault/std",  "serde_bare/std", "rand/std", "rand/std_rng"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_key_exchange_xx/no_std", "ockam_node/no_std", "ockam_vault_core/no_std", "ockam_vault_sync_core/no_std", "ockam_vault/no_std", "rand_pcg"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc", "serde_bare/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                          }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.17.0-dev"                          }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.17.0-dev"                         , optional = true }
-ockam_node = { path = "../ockam_node", version = "0.23.0-dev"                          }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev"                          }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.16.0-dev"                         , optional = true }
-ockam_vault = {path = "../ockam_vault", version = "0.19.0-dev"                         , optional = true}
-serde_bare = "0.3.0"
-rand = "0.8"
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.17.0-dev", default_features = false }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.17.0-dev", default_features = false, optional = true }
+ockam_node = { path = "../ockam_node", version = "0.23.0-dev", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.16.0-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "0.19.0-dev", default_features = false, optional = true }
+serde_bare = { git = "https://github.com/antoinevg/serde_bare.git", branch = "antoinevg/no_std+alloc", default-features = false, optional = true }
+rand = { version = "0.8", default-features = false }
+rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 async-trait = "0.1"
-serde = {version = "1.0", features = ["derive"]}
-tracing = "0.1"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "0.19.0-dev"                       }

--- a/implementations/rust/ockam/ockam_channel/src/lib.rs
+++ b/implementations/rust/ockam/ockam_channel/src/lib.rs
@@ -5,6 +5,7 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,
@@ -14,6 +15,22 @@
     unused_qualifications,
     warnings
 )]
+
+#[cfg(feature = "std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "no_std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
+
 mod error;
 mod local_info;
 mod secure_channel;
@@ -31,6 +48,7 @@ pub use traits::*;
 #[cfg(test)]
 mod tests {
     use crate::SecureChannel;
+    use ockam_core::compat::string::{String, ToString};
     use ockam_core::Route;
     use ockam_key_exchange_core::NewKeyExchanger;
     use ockam_key_exchange_xx::XXNewKeyExchanger;

--- a/implementations/rust/ockam/ockam_channel/src/local_info.rs
+++ b/implementations/rust/ockam/ockam_channel/src/local_info.rs
@@ -1,4 +1,5 @@
 use crate::SecureChannelError;
+use ockam_core::compat::string::{String, ToString};
 use ockam_core::{Encoded, Message, Result};
 use serde::{Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -2,9 +2,12 @@ use crate::{
     KeyExchangeCompleted, SecureChannelListener, SecureChannelNewKeyExchanger, SecureChannelVault,
     SecureChannelWorker,
 };
+#[cfg(feature = "no_std")]
+use ockam_core::compat::rand::random;
 use ockam_core::{Address, Result, Route};
 use ockam_key_exchange_core::KeyExchanger;
 use ockam_node::Context;
+#[cfg(feature = "std")]
 use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
@@ -1,7 +1,11 @@
 use crate::{SecureChannelNewKeyExchanger, SecureChannelVault, SecureChannelWorker};
 use async_trait::async_trait;
+#[cfg(feature = "no_std")]
+use ockam_core::compat::random;
+use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{Address, LocalMessage, Message, Result, Routed, TransportMessage, Worker};
 use ockam_node::Context;
+#[cfg(feature = "std")]
 use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::debug;

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_worker.rs
@@ -1,5 +1,6 @@
 use crate::{CreateResponderChannelMessage, LocalInfo, SecureChannelError, SecureChannelVault};
 use async_trait::async_trait;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{
     Address, Any, LocalMessage, Message, Result, Route, Routed, TransportMessage, Worker,
 };

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -61,6 +61,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,12 +169,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
  "heapless",
  "hex",
  "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -234,6 +251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,9 +295,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -285,6 +311,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -20,20 +20,26 @@ exclude = [
 [features]
 default = ["std"]
 
-# Requires the Rust Standard Library.
-std = ["serde_bare", "serde", "async-trait", "hex/std"]
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["hex/std", "rand/std", "rand/std_rng", "serde_bare/std"]
 
-# Requires the Rust alloc library
-alloc = []
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["core2", "hex", "rand_pcg", "serde_bare", "spin"]
 
-# No alloc and no standard library
-no_std = ["heapless"]
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc", "serde_bare/alloc"]
 
 [dependencies]
-async-trait =  { version = "0.1", optional = true }
-serde_bare = { version =  "0.4", optional = true }
-hashbrown =  { version = "0.11", features = ["serde"]}
-heapless = { version = "0.7", optional = true }
-hex = { version = "0.4", default-features = false }
-serde =  { version = "1.0", features = ["derive"], optional = true }
-rand = "0.8"
+async-trait = "0.1.42"
+serde_bare = { git = "https://github.com/antoinevg/serde_bare.git", branch = "antoinevg/no_std+alloc", default-features = false, optional = true }
+hashbrown =  { version = "0.11", features = ["serde"] }
+heapless = { version = "0.7.1", optional = true }
+hex = { version = "0.4", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+rand = { version = "0.8", default-features = false }
+rand_pcg = { version = "0.3.1", default-features = false, optional = true }
+core2 = { git = "https://github.com/antoinevg/core2.git", branch = "antoinevg/add-read-to-end", default-features = false, optional = true }
+spin = { version = "0.9.1", default-features = false, features = ["mutex", "spin_mutex"], optional = true }

--- a/implementations/rust/ockam/ockam_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_core/src/error.rs
@@ -1,6 +1,7 @@
 //! Error and Result types
 
-use crate::lib::{fmt::Formatter, Display, String};
+use crate::compat::string::String;
+use core::fmt::{self, Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 /// The type of errors returned by Ockam functions.
@@ -25,12 +26,12 @@ use serde::{Deserialize, Serialize};
 pub struct Error {
     code: u32,
 
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     domain: String,
 }
 
 /// The type returned by Ockam functions.
-pub type Result<T> = crate::lib::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// Produces Ok(false), which reads confusingly in auth code.
 pub fn deny() -> Result<bool> {
@@ -44,13 +45,13 @@ pub fn allow() -> Result<bool> {
 
 impl Error {
     /// Creates a new [`Error`].
-    #[cfg(not(feature = "std"))]
+    #[cfg(all(feature = "no_std", not(feature = "alloc")))]
     pub fn new(code: u32) -> Self {
         Self { code }
     }
 
     /// Creates a new [`Error`].
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     pub fn new<S: Into<String>>(code: u32, domain: S) -> Self {
         Self {
             code,
@@ -59,7 +60,7 @@ impl Error {
     }
 
     /// Returns an error's domain.
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     #[inline]
     pub fn domain(&self) -> &String {
         &self.domain
@@ -73,8 +74,8 @@ impl Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> crate::lib::fmt::Result {
-        #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        #[cfg(any(feature = "std", feature = "alloc"))]
         {
             write!(
                 f,
@@ -82,17 +83,16 @@ impl Display for Error {
                 self.code, self.domain
             )
         }
-        #[cfg(not(feature = "std"))]
+        #[cfg(all(feature = "no_std", not(feature = "alloc")))]
         {
             write!(f, "Error {{ code: {} }}", self.code)
         }
     }
 }
 
-#[cfg(feature = "std")]
-impl crate::lib::error::Error for Error {}
+impl crate::compat::error::Error for Error {}
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[cfg(test)]
 mod std_test {
     use super::*;
@@ -135,12 +135,13 @@ mod std_test {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "no_std", not(feature = "alloc")))]
 #[cfg(test)]
 mod no_std_test {
-    // These following tests are only run when the std feature in not enabled
-    // cargo test --no-default-features
-
+    // These following tests are run for no_std targets without
+    // support for heap allocation:
+    //
+    //     cargo test --no-default-features --features="no_std"
     use super::*;
 
     #[test]

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -5,7 +5,7 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,
@@ -16,14 +16,24 @@
     warnings
 )]
 
-#[cfg(all(feature = "no_std", feature = "alloc"))]
-compile_error!(r#"Cannot compile both features "alloc" and "no_std""#);
+#[cfg(all(feature = "std", feature = "alloc"))]
+compile_error!(r#"Cannot compile both features "std" and "alloc""#);
+
+#[cfg(all(feature = "no_std", not(feature = "alloc")))]
+compile_error!(r#"The "no_std" feature currently requires the "alloc" feature"#);
 
 #[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
 extern crate alloc;
+
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
+
+#[cfg(feature = "no_std")]
+#[macro_use]
+extern crate core;
 
 pub extern crate hashbrown;
 
@@ -38,6 +48,8 @@ pub use async_trait::async_trait as worker;
 
 mod error;
 mod message;
+#[cfg(feature = "no_std")]
+mod no_std_error;
 mod routing;
 mod worker;
 
@@ -46,69 +58,181 @@ pub use message::*;
 pub use routing::*;
 pub use worker::*;
 
+#[cfg(feature = "std")]
+pub use std::println;
+#[cfg(all(feature = "no_std", feature = "alloc"))]
+/// println! macro for no_std+alloc platforms
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        // TODO replace with defmt or similiar
+        //cortex_m_semihosting::hprintln!($($arg)*).unwrap();
+    }};
+}
+
 /// A facade around the various collections and primitives needed
-/// when using no alloc, alloc only, or std modes
-pub mod lib {
-    mod core {
-        #[cfg(not(feature = "std"))]
-        pub use core::*;
+/// when linking "std", "no_std + alloc" or "no_std" targets.
+pub mod compat {
+    #[cfg(all(feature = "no_std", feature = "alloc"))]
+    pub use alloc::borrow;
+    /// std::borrow
+    #[cfg(feature = "std")]
+    pub use std::borrow;
+
+    /// std::boxed
+    pub mod boxed {
+        #[cfg(all(feature = "no_std", feature = "alloc"))]
+        pub use alloc::boxed::Box;
         #[cfg(feature = "std")]
-        pub use std::*;
+        pub use std::boxed::Box;
     }
 
-    pub use self::core::cell::{Cell, RefCell};
-    pub use self::core::clone::{self, Clone};
-    pub use self::core::convert::{self, From, Into};
-    pub use self::core::default::{self, Default};
-    pub use self::core::fmt::{self, Debug, Display};
-    pub use self::core::marker::{self, PhantomData};
-    pub use self::core::num::Wrapping;
-    pub use self::core::ops::{Deref, DerefMut, Range};
-    pub use self::core::option::{self, Option};
-    pub use self::core::result::{self, Result};
-    pub use self::core::{cmp, iter, mem, num, slice, str};
-    pub use self::core::{f32, f64};
-    pub use self::core::{i16, i32, i64, i8, isize};
-    pub use self::core::{u16, u32, u64, u8, usize};
+    /// std::collections
+    pub mod collections {
+        #[cfg(all(feature = "no_std", feature = "alloc"))]
+        pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+        #[cfg(feature = "std")]
+        pub use std::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub use alloc::borrow::{Cow, ToOwned};
+        pub use hashbrown::{HashMap, HashSet};
+    }
+
+    /// std::error::Error trait
+    pub mod error {
+        #[cfg(feature = "no_std")]
+        pub use crate::no_std_error::Error;
+        #[cfg(feature = "std")]
+        pub use std::error::Error;
+    }
+
+    #[cfg(all(feature = "no_std", feature = "alloc"))]
+    pub use alloc::format;
+    /// std::format
     #[cfg(feature = "std")]
-    pub use std::borrow::{Cow, ToOwned};
+    pub use std::format;
 
-    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
-    pub use heapless::consts::*;
-
-    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
-    use heapless::String as ByteString;
-    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
-    pub type String = ByteString<U128>;
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub use alloc::string::{String, ToString};
+    #[cfg(feature = "no_std")]
+    pub use core2::io;
+    /// std::io
     #[cfg(feature = "std")]
-    pub use std::string::{String, ToString};
+    pub use std::io;
 
-    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
-    use heapless::Vec as InternalVec;
-    #[cfg(all(not(feature = "alloc"), feature = "no_std"))]
-    pub type Vec<T> = InternalVec<T, U64>;
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub use alloc::vec::Vec;
+    /// std::net
     #[cfg(feature = "std")]
-    pub use std::vec::Vec;
+    pub use std::net;
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub use alloc::boxed::Box;
-    #[cfg(feature = "std")]
-    pub use std::boxed::Box;
+    /// rand
+    pub mod rand {
+        pub use rand::distributions;
+        pub use rand::prelude;
+        pub use rand::CryptoRng;
+        pub use rand::Error;
+        pub use rand::Rng;
+        pub use rand::RngCore;
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
-    pub use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
-    #[cfg(feature = "std")]
-    pub use std::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+        #[cfg(feature = "no_std")]
+        pub use not_random::thread_rng;
+        #[cfg(feature = "std")]
+        pub use rand::thread_rng;
 
-    #[cfg(feature = "std")]
-    pub use std::{error, net};
+        #[cfg(feature = "no_std")]
+        pub use not_random::random;
+        #[cfg(feature = "std")]
+        pub use rand::random;
 
-    pub use hashbrown::{HashMap, HashSet};
+        #[cfg(feature = "std")]
+        pub use rand::rngs;
+        #[cfg(feature = "no_std")]
+        /// rngs
+        pub mod rngs {
+            pub use super::not_random::OsRng;
+        }
+
+        #[cfg(feature = "no_std")]
+        /// Placeholders for various features from 'rand' that are not
+        /// supported on no_std targets.
+        ///
+        /// WARNING: Thess implementations are NOT random, please do not
+        /// try to use these in production!
+        mod not_random {
+            use super::*;
+
+            /// rand::thread_rng()
+            /// WARNING: This implementation is neither random nor thread-local.
+            pub fn thread_rng() -> rand_pcg::Lcg64Xsh32 {
+                use rand::SeedableRng;
+                rand_pcg::Pcg32::seed_from_u64(1234)
+            }
+
+            /// rand::random()
+            pub fn random<T>() -> T
+            where
+                rand::distributions::Standard: rand::prelude::Distribution<T>,
+            {
+                let mut rng = thread_rng();
+                rng.gen()
+            }
+
+            /// rand::OsRng
+            pub struct OsRng;
+
+            impl CryptoRng for OsRng {}
+
+            impl RngCore for OsRng {
+                fn next_u32(&mut self) -> u32 {
+                    let mut rng = thread_rng();
+                    rng.gen()
+                }
+
+                fn next_u64(&mut self) -> u64 {
+                    let mut rng = thread_rng();
+                    rng.gen()
+                }
+
+                fn fill_bytes(&mut self, dest: &mut [u8]) {
+                    if let Err(e) = self.try_fill_bytes(dest) {
+                        panic!("Error: {}", e);
+                    }
+                }
+
+                fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+                    let mut rng = thread_rng();
+                    rng.try_fill(dest)
+                }
+            }
+        }
+    }
+
+    /// std::string
+    pub mod string {
+        #[cfg(all(feature = "no_std", feature = "alloc"))]
+        pub use alloc::string::{String, ToString};
+        #[cfg(all(feature = "no_std", not(feature = "alloc")))]
+        use heapless::String as ByteString;
+        #[cfg(feature = "std")]
+        pub use std::string::{String, ToString};
+    }
+
+    /// std::sync
+    pub mod sync {
+        #[cfg(all(feature = "no_std", feature = "alloc"))]
+        pub use alloc::sync::Arc;
+        #[cfg(feature = "std")]
+        pub use std::sync::Arc;
+
+        #[cfg(all(feature = "no_std", feature = "alloc"))]
+        pub use spin::Mutex;
+        #[cfg(feature = "std")]
+        pub use std::sync::Mutex;
+    }
+
+    /// std::vec
+    pub mod vec {
+        #[cfg(all(feature = "no_std", feature = "alloc"))]
+        pub use alloc::vec::Vec;
+        #[cfg(feature = "std")]
+        pub use std::vec::Vec;
+        #[cfg(all(feature = "no_std", not(feature = "alloc")))]
+        pub type Vec<T> = heapless::Vec<T, 64>;
+    }
 }

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -1,9 +1,13 @@
 use crate::{
-    lib::{
-        fmt::{self, Debug, Display, Formatter},
-        Deref, DerefMut, String, ToString, Vec,
+    compat::{
+        string::{String, ToString},
+        vec::Vec,
     },
     Address, LocalMessage, Result, Route, TransportMessage,
+};
+use core::{
+    fmt::{self, Debug, Display, Formatter},
+    ops::{Deref, DerefMut},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -72,7 +76,6 @@ where
     }
 }
 
-// TODO: see comment in Cargo.toml about this dependency
 impl From<serde_bare::Error> for crate::Error {
     fn from(_: serde_bare::Error) -> Self {
         Self::new(1, "serde_bare")

--- a/implementations/rust/ockam/ockam_core/src/no_std_error.rs
+++ b/implementations/rust/ockam/ockam_core/src/no_std_error.rs
@@ -1,0 +1,9 @@
+use core::fmt::{Debug, Display};
+
+/// Implementation of std::error::Error for no_std platforms.
+pub trait Error: Debug + Display {
+    /// The underlying cause of this error, if any.
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -1,10 +1,15 @@
-use crate::lib::{
-    fmt::{self, Debug, Display},
-    str::from_utf8,
-    String, ToString, Vec,
+use crate::compat::{
+    string::{String, ToString},
+    vec::Vec,
 };
+use core::fmt::{self, Debug, Display};
 use core::ops::Deref;
-use rand::{distributions::Standard, prelude::Distribution, random, Rng};
+use core::str::from_utf8;
+// TODO use rand::{distributions::Standard, prelude::Distribution, random, Rng};
+#[cfg(feature = "no_std")]
+use crate::compat::rand::{distributions::Standard, prelude::Distribution, thread_rng, Rng};
+#[cfg(feature = "std")]
+use rand::{distributions::Standard, prelude::Distribution, thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 
 /// A collection of Addresses
@@ -119,7 +124,11 @@ impl Address {
 
     /// Generate a random address with a specific type
     pub fn random(tt: u8) -> Self {
-        Self { tt, ..random() }
+        // TODO Self { tt, ..random() }
+        let mut rng = thread_rng();
+        let address: [u8; 16] = rng.gen();
+        let inner = hex::encode(address).as_bytes().into();
+        Self { tt, inner }
     }
 }
 

--- a/implementations/rust/ockam/ockam_core/src/routing/macros.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/macros.rs
@@ -22,8 +22,8 @@ macro_rules! route {
 
 #[cfg(test)]
 mod tests {
+    use crate::compat::rand::random;
     use crate::Address;
-    use rand::random;
 
     #[test]
     fn test1() {
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test2() {
-        use crate::std::string::ToString;
+        use crate::compat::string::ToString;
         let address: Address = random();
         let _route = route!["str", "STR2", "STR3".to_string(), address];
     }

--- a/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
@@ -1,4 +1,4 @@
-use crate::{lib::Vec, TransportMessage};
+use crate::{compat::vec::Vec, TransportMessage};
 use serde::{Deserialize, Serialize};
 
 /// LocalMessage is a message type that is routed locally within one node.

--- a/implementations/rust/ockam/ockam_core/src/routing/message/router_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/router_message.rs
@@ -1,4 +1,4 @@
-use crate::lib::Vec;
+use crate::compat::vec::Vec;
 use crate::{Address, LocalMessage};
 use serde::{Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam_core/src/routing/message/transport_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/transport_message.rs
@@ -1,10 +1,5 @@
-use crate::{
-    lib::{
-        fmt::{self, Display, Formatter},
-        Vec,
-    },
-    Route,
-};
+use crate::{compat::vec::Vec, Route};
+use core::fmt::{self, Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 /// A generic transport message

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -1,10 +1,8 @@
 use crate::{
-    lib::{
-        fmt::{self, Display},
-        String, Vec, VecDeque,
-    },
+    compat::{collections::VecDeque, string::String, vec::Vec},
     Address, Result, RouteError,
 };
+use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
 
 /// A full route to a peer

--- a/implementations/rust/ockam/ockam_core/src/worker.rs
+++ b/implementations/rust/ockam/ockam_core/src/worker.rs
@@ -1,4 +1,4 @@
-use crate::{lib::Box, Message, Result, Routed};
+use crate::{compat::boxed::Box, Message, Result, Routed};
 use async_trait::async_trait;
 
 /// Base ockam worker trait.

--- a/implementations/rust/ockam/ockam_entity/Cargo.lock
+++ b/implementations/rust/ockam/ockam_entity/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -293,8 +294,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -717,11 +716,14 @@ dependencies = [
  "async-trait",
  "ockam_core",
  "ockam_key_exchange_core",
+ "ockam_key_exchange_xx",
  "ockam_node",
+ "ockam_vault",
  "ockam_vault_core",
+ "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
  "tracing",
 ]
 
@@ -734,7 +736,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
 ]
 
 [[package]]
@@ -759,7 +761,7 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -790,6 +792,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -1162,6 +1165,14 @@ name = "serde_bare"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bare"
+version = "0.4.0"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_entity/src/credential/attribute.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/attribute.rs
@@ -1,6 +1,5 @@
 use super::CredentialAttributeType;
 use bls12_381_plus::Scalar;
-use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 use signature_core::lib::Message;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/attribute_schema.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/attribute_schema.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 /// An attribute describes a statement that the issuer of a credential is

--- a/implementations/rust/ockam/ockam_entity/src/credential/presentation.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/presentation.rs
@@ -1,6 +1,5 @@
 use super::CredentialAttribute;
 use crate::{ExtPokSignatureProof, PresentationIdBytes};
-use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 /// Indicates how to present a credential

--- a/implementations/rust/ockam/ockam_entity/src/credential/presentation_manifest.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/presentation_manifest.rs
@@ -1,6 +1,5 @@
 use super::CredentialSchema;
 use crate::SigningPublicKey;
-use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 use serde_big_array::big_array;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/schema.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/schema.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ockam_core::lib::*;
 use serde::{Deserialize, Serialize};
 
 /// A schema describes the data format of a credential.

--- a/implementations/rust/ockam/ockam_entity/src/credential/traits.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/traits.rs
@@ -4,9 +4,8 @@ use crate::{
     EntityIdentifier, OfferId, PresentationManifest, ProfileIdentifier, ProofBytes, ProofRequestId,
     SigningPublicKey, TrustPolicy,
 };
-use ockam_core::lib::convert::TryFrom;
-use ockam_core::lib::fmt::Formatter;
-use ockam_core::lib::Display;
+use core::convert::TryFrom;
+use core::fmt::{Display, Formatter};
 use ockam_core::{hex, Address, Error, Result, Route};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;

--- a/implementations/rust/ockam/ockam_entity/src/credential/util.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/util.rs
@@ -1,5 +1,5 @@
 use super::CredentialAttributeSchema;
-use ockam_core::lib::*;
+use core::fmt;
 
 use serde::{
     de::{Error as DError, SeqAccess, Visitor},

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/holder.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/holder.rs
@@ -4,7 +4,7 @@ use crate::{
     Profile, ProfileIdentifier, SigningPublicKey,
 };
 use async_trait::async_trait;
-use ockam_core::lib::convert::TryInto;
+use core::convert::TryInto;
 use ockam_core::{Address, Result, Route, Routed, Worker};
 use ockam_node::Context;
 use rand::random;

--- a/implementations/rust/ockam/ockam_entity/src/entity.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity.rs
@@ -9,7 +9,7 @@ use crate::{
     PresentationManifest, PresenterWorker, ProfileChangeEvent, ProfileIdentifier, ProofRequestId,
     SecureChannels, SigningPublicKey, TrustPolicy, TrustPolicyImpl, VerifierWorker,
 };
-use ockam_core::lib::convert::TryInto;
+use core::convert::TryInto;
 use ockam_core::{Address, Result, Route};
 use ockam_node::{block_future, Context};
 use ockam_vault::ockam_vault_core::{PublicKey, Secret};

--- a/implementations/rust/ockam/ockam_entity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_entity/src/identifiers.rs
@@ -1,9 +1,8 @@
 use crate::profile::Profile;
 use crate::EntityError;
+use core::convert::TryFrom;
+use core::fmt::{Display, Formatter};
 use ockam_core::hex::encode;
-use ockam_core::lib::convert::TryFrom;
-use ockam_core::lib::fmt::Formatter;
-use ockam_core::lib::Display;
 use ockam_core::{Error, Result};
 use ockam_vault_core::{Hasher, KeyId};
 use serde::{Deserialize, Serialize};
@@ -91,7 +90,7 @@ impl EventIdentifier {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ockam_core::lib::convert::TryInto;
+    use core::convert::TryInto;
     use rand::{thread_rng, RngCore};
 
     impl EntityIdentifier {

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -21,7 +21,7 @@ pub use error::*;
 pub use identifiers::*;
 pub use key_attributes::*;
 use ockam_channel::SecureChannelVault;
-use ockam_core::{lib::HashMap, Address, Message, Result};
+use ockam_core::{compat::collections::HashMap, Address, Message, Result};
 use ockam_node::{block_future, Context};
 use ockam_vault::{Hasher, KeyIdVault, SecretVault, Signer, Verifier};
 pub use profile::*;

--- a/implementations/rust/ockam/ockam_entity/src/profile_state.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile_state.rs
@@ -16,8 +16,8 @@ use crate::{
     PresentationManifest, ProfileChangeEvent, ProfileEventAttributes, ProfileIdentifier,
     ProfileVault, ProofBytes, ProofRequestId, SigningPublicKey,
 };
-use ockam_core::lib::convert::TryInto;
-use ockam_core::lib::{HashMap, HashSet};
+use core::convert::TryInto;
+use ockam_core::compat::collections::{HashMap, HashSet};
 use ockam_vault_core::{SecretPersistence, SecretType, SecretVault, CURVE25519_SECRET_LENGTH};
 use rand::{thread_rng, CryptoRng, RngCore};
 use sha2::digest::{generic_array::GenericArray, Digest, FixedOutput};

--- a/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
@@ -5,10 +5,8 @@ use crate::{
     ProfileIdentifier, ProfileState, SecureChannelTrait, TrustPolicyImpl,
 };
 use async_trait::async_trait;
-use ockam_core::{
-    lib::{result::Result::Ok, HashMap},
-    Address, Result, Routed, Worker,
-};
+use core::result::Result::Ok;
+use ockam_core::{compat::collections::HashMap, Address, Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_vault_sync_core::VaultSync;
 

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -293,8 +294,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -732,7 +731,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -754,7 +753,7 @@ dependencies = [
  "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
  "tracing",
 ]
 
@@ -767,7 +766,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
 ]
 
 [[package]]
@@ -790,7 +789,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -829,6 +828,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -1200,6 +1200,14 @@ name = "serde_bare"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bare"
+version = "0.4.0"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_examples/WIP/IOT/ARM/nRF52840/src/main.rs
+++ b/implementations/rust/ockam/ockam_examples/WIP/IOT/ARM/nRF52840/src/main.rs
@@ -1,6 +1,6 @@
 #![feature(default_alloc_error_handler)]
 #![no_main]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use log::LevelFilter;
 mod rttlogger;

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -248,8 +249,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -462,7 +461,7 @@ dependencies = [
  "async-trait",
  "hashbrown",
  "hex",
- "rand 0.8.4",
+ "rand",
  "serde",
  "serde_bare",
 ]
@@ -478,7 +477,7 @@ dependencies = [
  "hkdf",
  "ockam_core",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
  "sha2",
  "signature_bbs_plus",
  "tracing",
@@ -568,37 +567,14 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -627,15 +603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -693,8 +660,7 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]
@@ -915,7 +881,7 @@ checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
 dependencies = [
  "ff",
  "group",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
  "serde",
  "zeroize",

--- a/implementations/rust/ockam/ockam_ffi/src/vault.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault.rs
@@ -1,16 +1,16 @@
 use crate::vault_types::{FfiSecretAttributes, SecretKeyHandle};
 use crate::{check_buffer, FfiError, FfiObjectMutexStorage, FfiOckamError};
 use crate::{FfiVaultFatPointer, FfiVaultType};
+use core::convert::{TryFrom, TryInto};
+use core::ops::DerefMut;
+use core::slice;
 use lazy_static::lazy_static;
-use ockam_core::lib::convert::{TryFrom, TryInto};
-use ockam_core::lib::slice;
+use ockam_core::compat::sync::{Arc, Mutex};
 use ockam_vault::SoftwareVault;
 use ockam_vault_core::{
     AsymmetricVault, Hasher, PublicKey, Secret, SecretAttributes, SecretType, SecretVault,
     SymmetricVault,
 };
-use std::ops::DerefMut;
-use std::sync::{Arc, Mutex};
 
 /// FFI Vault trait. See documentation for individual sub-traits for details.
 pub trait FfiVault: SecretVault + Hasher + SymmetricVault + AsymmetricVault + Send {}

--- a/implementations/rust/ockam/ockam_ffi/src/vault_types.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault_types.rs
@@ -1,7 +1,7 @@
 #![allow(conflicting_repr_hints)]
 
 use crate::FfiError;
-use ockam_core::lib::convert::TryFrom;
+use core::convert::TryFrom;
 use ockam_vault_core::{SecretAttributes, SecretPersistence, SecretType};
 
 /// Represents a handle id for the secret key

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -25,10 +25,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
+dependencies = [
+ "cortex-m",
+]
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
 
 [[package]]
 name = "getrandom"
@@ -42,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +118,18 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
  "serde",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -64,15 +145,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
 name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless",
  "hex",
  "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -89,6 +195,7 @@ name = "ockam_vault_core"
 version = "0.19.0-dev"
 dependencies = [
  "cfg-if",
+ "heapless",
  "ockam_core",
  "serde",
  "serde-big-array",
@@ -166,6 +273,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,9 +327,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -203,6 +343,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -234,10 +386,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "wasi"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -12,7 +12,19 @@ keywords = ["ockam", "crypto", "kex", "cryptography", "encryption"]
 description = """The Ockam Key Exchange trait.
 """
 
+[features]
+default = ["std"]
+
+# Option (enabled by default): "std" enables functionality expected to be available on a standard platform.
+std = ["ockam_core/std", "ockam_vault_core/std"]
+
+# Option: "no_std" enables functionality required for platforms without the standard library.
+no_std = ["ockam_core/no_std", "ockam_vault_core/no_std"]
+
+# Option: "alloc" enables support for heap allocation on "no_std" platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_vault_core/alloc"]
+
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                           }
-ockam_vault_core = { path = "../ockam_vault_core" , version = "0.19.0-dev"                           }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev", default_features = false, optional = true }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_core/src/lib.rs
@@ -5,6 +5,7 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,
@@ -15,6 +16,22 @@
     warnings
 )]
 
+#[cfg(feature = "std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "no_std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
+
+use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::Result;
 use ockam_vault_core::Secret;
 use zeroize::Zeroize;

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -199,6 +200,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,8 +296,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -401,6 +408,7 @@ checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -606,11 +614,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless",
  "hex",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -639,6 +651,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -656,7 +669,7 @@ dependencies = [
  "hkdf",
  "ockam_core",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
  "sha2",
  "signature_bbs_plus",
  "tracing",
@@ -669,6 +682,7 @@ name = "ockam_vault_core"
 version = "0.19.0-dev"
 dependencies = [
  "cfg-if",
+ "heapless",
  "ockam_core",
  "serde",
  "serde-big-array",
@@ -682,8 +696,9 @@ dependencies = [
  "async-trait",
  "ockam_core",
  "ockam_node",
+ "ockam_vault",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
  "serde",
  "serde-big-array",
  "tracing",
@@ -786,37 +801,14 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -849,18 +841,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -956,9 +948,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1082,6 +1074,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1296,7 +1294,7 @@ checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
 dependencies = [
  "ff",
  "group",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
  "serde",
  "zeroize",

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -12,10 +12,25 @@ keywords = ["ockam", "crypto", "x3dh", "cryptography", "encryption"]
 description = """The Ockam X3DH impementation.
 """
 
+[features]
+default = ["std"]
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_vault_core/std", "ockam_key_exchange_core/std"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "ockam_key_exchange_core/no_std"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_key_exchange_core/alloc"]
+
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                           }
-ockam_vault_core = { path = "../ockam_vault_core" , version = "0.19.0-dev"                           }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "0.17.0-dev"                           }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core" , version = "0.19.0-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "0.17.0-dev", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
@@ -1,5 +1,9 @@
 use crate::{PreKeyBundle, X3DHError, X3dhVault, CSUITE};
-use ockam_core::lib::convert::TryFrom;
+use core::convert::TryFrom;
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::Result;
 use ockam_key_exchange_core::{CompletedKeyExchange, KeyExchanger};
 use ockam_vault_core::{
@@ -51,8 +55,8 @@ impl<V: X3dhVault> Initiator<V> {
     }
 }
 
-impl<V: X3dhVault> std::fmt::Debug for Initiator<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<V: X3dhVault> core::fmt::Debug for Initiator<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
             r#"X3dhInitiator {{ ephemeral_identity_key: {:?}, prekey_bundle: {:?}, state: {:?}, vault, completed_key_exchange: {:?}, identity_key: {:?} }}"#,

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -1,9 +1,26 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use arrayref::array_ref;
-use ockam_core::hex::encode;
-use ockam_core::lib::convert::TryFrom;
+use core::convert::TryFrom;
+use ockam_core::{compat::vec::Vec, hex::encode};
 use ockam_vault_core::{
     AsymmetricVault, Hasher, PublicKey, SecretVault, Signer, SymmetricVault, Verifier,
 };
+
+#[cfg(feature = "std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "no_std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
 
 mod error;
 pub use error::*;
@@ -38,8 +55,8 @@ impl From<&[u8; 64]> for Signature {
     }
 }
 
-impl std::fmt::Debug for Signature {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for Signature {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Signature {{ {} }}", encode(self.0.as_ref()))
     }
 }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/new_key_exchanger.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/new_key_exchanger.rs
@@ -7,8 +7,8 @@ pub struct X3dhNewKeyExchanger<V: X3dhVault> {
     vault: V,
 }
 
-impl<V: X3dhVault> std::fmt::Debug for X3dhNewKeyExchanger<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<V: X3dhVault> core::fmt::Debug for X3dhNewKeyExchanger<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "X3dhNewKeyExchanger {{ vault }}")
     }
 }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/responder.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/responder.rs
@@ -1,5 +1,9 @@
 use crate::{PreKeyBundle, Signature, X3DHError, X3dhVault, CSUITE};
 use arrayref::array_ref;
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::Result;
 use ockam_key_exchange_core::{CompletedKeyExchange, KeyExchanger};
 use ockam_vault_core::{
@@ -60,8 +64,8 @@ impl<V: X3dhVault> Responder<V> {
     }
 }
 
-impl<V: X3dhVault> std::fmt::Debug for Responder<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<V: X3dhVault> core::fmt::Debug for Responder<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
             r#"X3dhResponder {{ identity_key: {:?},

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -199,6 +200,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,8 +296,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -401,6 +408,7 @@ checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -606,11 +614,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless",
  "hex",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -639,6 +651,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -656,7 +669,7 @@ dependencies = [
  "hkdf",
  "ockam_core",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
  "sha2",
  "signature_bbs_plus",
  "tracing",
@@ -669,6 +682,7 @@ name = "ockam_vault_core"
 version = "0.19.0-dev"
 dependencies = [
  "cfg-if",
+ "heapless",
  "ockam_core",
  "serde",
  "serde-big-array",
@@ -682,8 +696,9 @@ dependencies = [
  "async-trait",
  "ockam_core",
  "ockam_node",
+ "ockam_vault",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
  "serde",
  "serde-big-array",
  "tracing",
@@ -786,37 +801,14 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -849,18 +841,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -956,9 +948,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1082,6 +1074,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1296,7 +1294,7 @@ checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
 dependencies = [
  "ff",
  "group",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
  "serde",
  "zeroize",

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -12,10 +12,25 @@ keywords = ["ockam", "crypto", "xx", "cryptography", "encryption"]
 description = """The Ockam Noise XX impementation.
 """
 
+[features]
+default = ["std"]
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_key_exchange_core/std", "ockam_vault_core/std"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_vault_core/no_std"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_vault_core/alloc"]
+
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                           }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev"                           }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.17.0-dev"                           }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev", default_features = false, optional = true }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.17.0-dev", default_features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/initiator.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/initiator.rs
@@ -1,5 +1,9 @@
 use crate::state::State;
 use crate::{XXError, XXVault};
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::Result;
 use ockam_key_exchange_core::{CompletedKeyExchange, KeyExchanger};
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -5,6 +5,7 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,
@@ -14,6 +15,21 @@
     unused_qualifications,
     warnings
 )]
+
+#[cfg(feature = "std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "no_std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
 
 mod error;
 pub use error::*;

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/responder.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/responder.rs
@@ -1,5 +1,9 @@
 use crate::state::State;
 use crate::{XXError, XXVault};
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::Result;
 use ockam_key_exchange_core::{CompletedKeyExchange, KeyExchanger};
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
@@ -1,4 +1,5 @@
 use crate::{XXError, XXVault, AES_GCM_TAGSIZE, SHA256_SIZE};
+use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 use ockam_key_exchange_core::CompletedKeyExchange;
 use ockam_vault_core::{
@@ -32,8 +33,8 @@ impl<V: XXVault> Zeroize for State<V> {
     }
 }
 
-impl<V: XXVault> std::fmt::Debug for State<V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<V: XXVault> core::fmt::Debug for State<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
             "SymmetricState {{ key: {:?}, nonce: {:?}, h: {:?}, ck: {:?} }}",

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -14,12 +14,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-embedded"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+ "cortex-m-semihosting",
+ "generic-array 0.14.4",
+ "heapless 0.5.3",
+ "pin-utils",
+ "typenum",
 ]
 
 [[package]]
@@ -34,16 +68,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -70,6 +134,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +303,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +328,27 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
  "serde",
+]
+
+[[package]]
+name = "heapless"
+version = "0.5.3"
+source = "git+https://github.com/japaric/heapless?branch=slab#10e88349aef0957062f46700ccb2752485d3aa50"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -188,6 +449,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,11 +506,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless 0.7.4",
  "hex",
  "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -242,10 +522,26 @@ name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
  "async-trait",
+ "cortex-m-semihosting",
+ "heapless 0.7.4",
  "ockam_core",
+ "ockam_node_no_std",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "ockam_node_no_std"
+version = "0.13.0-dev"
+dependencies = [
+ "async-embedded",
+ "cortex-m 0.7.3",
+ "futures",
+ "heapless 0.7.4",
+ "ockam_core",
+ "panic-udf",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -253,6 +549,14 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "panic-udf"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+]
 
 [[package]]
 name = "parking_lot"
@@ -286,10 +590,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -350,6 +672,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +714,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +733,21 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -406,9 +761,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -457,6 +812,18 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -517,19 +884,7 @@ checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -585,16 +940,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "wasi"

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -10,11 +10,32 @@ license = "Apache-2.0"
 name = "ockam_node"
 version = "0.23.0-dev"
 
-[dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                           }
-tokio = {version = "1.8", features = ["full"]}
-tracing = "0.1"
-tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"] }
+[features]
+default = ["std"]
 
-[dev-dependencies]
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "tokio", "tracing-subscriber"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_node_no_std/no_std", "heapless", "cortex-m-semihosting"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_node_no_std/alloc"]
+
+# Option: "dump_internals" when set, will dump the internal state of workers at startup via the trace! macro.
+dump_internals = []
+
+[dependencies]
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+tokio = {version = "1.8", features = ["full"], optional = true}
+tracing = { version = "0.1", default_features = false }
+tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"], optional = true }
+heapless = { version = "0.7", features = [ "mpmc_large" ], optional = true }
+ockam_node_no_std = { path = "../ockam_node_no_std", default-features = false, optional = true }
+cortex-m-semihosting = { version = "0.3.7", optional = true } # TODO replace with defmt or similiar
+
+# TODO [dev-dependencies]
 async-trait =  { version = "0.1" }

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,12 +1,12 @@
-use std::{sync::Arc, time::Duration};
-
-use ockam_core::{
-    Address, AddressSet, LocalMessage, Message, Result, Route, TransportMessage, Worker,
-};
-use tokio::{
+use crate::tokio::{
     runtime::Runtime,
     sync::mpsc::{channel, Sender},
     time::timeout,
+};
+use core::time::Duration;
+use ockam_core::compat::{sync::Arc, vec::Vec};
+use ockam_core::{
+    Address, AddressSet, LocalMessage, Message, Result, Route, TransportMessage, Worker,
 };
 
 use crate::{

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug;
-use tokio::sync::mpsc::error::SendError;
+use crate::tokio::{self, sync::mpsc::error::SendError};
+use core::fmt::Debug;
 
 /// Error declarations.
 #[derive(Clone, Copy, Debug)]

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -3,8 +3,9 @@
 use crate::{relay::RelayMessage, router::Router, NodeMessage};
 use ockam_core::{Address, Result};
 
-use std::{future::Future, sync::Arc};
-use tokio::{runtime::Runtime, sync::mpsc::Sender};
+use crate::tokio::{runtime::Runtime, sync::mpsc::Sender};
+use core::future::Future;
+use ockam_core::compat::sync::Arc;
 
 /// Ockam node and worker executor
 pub struct Executor {
@@ -59,6 +60,12 @@ impl Executor {
 
         // Block this task executing the primary message router,
         // returning any critical failures that it encounters.
-        crate::block_future(&rt, self.router.run())
+        #[cfg(feature = "std")]
+        return crate::block_future(&rt, self.router.run());
+        #[cfg(feature = "no_std")]
+        {
+            crate::execute(&rt, async move { self.router.run().await.unwrap() });
+            Ok(())
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -1,4 +1,6 @@
 //! ockam_node - Ockam Node API
+
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     dead_code,
@@ -9,8 +11,70 @@
     unused_qualifications
 )]
 
+#[cfg(all(feature = "std", feature = "alloc"))]
+compile_error!(r#"Cannot compile both features "std" and "alloc""#);
+
+#[cfg(all(feature = "no_std", not(feature = "alloc")))]
+compile_error!(r#"The "no_std" feature currently requires the "alloc" feature"#);
+
+#[cfg(feature = "no_std")]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate tracing;
+
+#[cfg(feature = "no_std")]
+pub use ockam_node_no_std::tokio;
+#[cfg(feature = "std")]
+pub use tokio;
+
+#[cfg(feature = "no_std")]
+pub use ockam_node_no_std::interrupt; // TODO replace with ockam_core::compat::sync::*
+
+#[cfg(feature = "no_std")]
+/// TODO replace with defmt
+#[macro_use]
+mod logging_no_std {
+    /// info!
+    #[macro_export]
+    macro_rules! info {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
+    /// trace!
+    #[macro_export]
+    macro_rules! trace {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
+    /// error!
+    #[macro_export]
+    macro_rules! error {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
+    /// debug!
+    #[macro_export]
+    macro_rules! debug {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
+}
 
 mod address_record;
 mod context;
@@ -32,8 +96,10 @@ pub use messages::*;
 
 pub use node::{start_node, NullWorker};
 
-use std::future::Future;
-use tokio::{runtime::Runtime, task};
+#[cfg(feature = "std")]
+use crate::tokio::{runtime::Runtime, task};
+#[cfg(feature = "std")]
+use core::future::Future;
 
 /// Execute a future without blocking the executor
 ///
@@ -45,6 +111,7 @@ use tokio::{runtime::Runtime, task};
 /// as an implementation utility for other ockam utilities that use
 /// tokio.
 #[doc(hidden)]
+#[cfg(feature = "std")]
 pub fn block_future<'r, F>(rt: &'r Runtime, f: F) -> <F as Future>::Output
 where
     F: Future + Send,
@@ -64,3 +131,6 @@ where
 {
     task::spawn(f);
 }
+
+#[cfg(feature = "no_std")]
+pub use crate::tokio::{block_future, execute};

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -1,7 +1,7 @@
+use crate::tokio::sync::mpsc::Receiver;
 use crate::{relay::RelayMessage, Context};
+use core::fmt::{self, Debug, Display, Formatter};
 use ockam_core::{Address, LocalMessage, Message, Routed};
-use std::fmt::{self, Debug, Display, Formatter};
-use tokio::sync::mpsc::Receiver;
 
 /// A mailbox for encoded messages
 ///
@@ -68,7 +68,7 @@ impl<'ctx, M: Message> Cancel<'ctx, M> {
     }
 }
 
-impl<'ctx, M: Message> std::ops::Deref for Cancel<'ctx, M> {
+impl<'ctx, M: Message> core::ops::Deref for Cancel<'ctx, M> {
     type Target = M;
 
     fn deref(&self) -> &Self::Target {

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -1,6 +1,7 @@
+use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{error::Error, relay::RelayMessage};
+use ockam_core::compat::vec::Vec;
 use ockam_core::{Address, AddressSet};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// Messages sent from the Node to the Executor
 #[derive(Debug)]

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -1,9 +1,10 @@
 use crate::relay::RelayMessage;
+use crate::tokio::runtime::Runtime;
+use crate::tokio::sync::mpsc::{channel, Sender};
 use crate::{relay, Context, Executor, Mailbox, NodeMessage};
+use ockam_core::compat::sync::Arc;
 use ockam_core::Address;
-use std::sync::Arc;
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc::{channel, Sender};
+#[cfg(feature = "std")]
 use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 /// A minimal worker implementation that does nothing
@@ -31,6 +32,7 @@ impl ockam_core::Worker for NullWorker {
 
 /// Start a node
 pub fn start_node() -> (Context, Executor) {
+    #[cfg(feature = "std")]
     setup_tracing();
 
     info!("Initializing ockam node");
@@ -52,6 +54,7 @@ pub fn start_node() -> (Context, Executor) {
 }
 
 /// Utility to setup tracing-subscriber from the environment
+#[cfg(feature = "std")]
 fn setup_tracing() {
     let filter = EnvFilter::try_from_env("OCKAM_LOG").unwrap_or_else(|_| {
         EnvFilter::default()

--- a/implementations/rust/ockam/ockam_node/src/parser.rs
+++ b/implementations/rust/ockam/ockam_node/src/parser.rs
@@ -1,3 +1,4 @@
+use ockam_core::compat::vec::Vec;
 use ockam_core::{Message, Result};
 
 // TODO: this function can not mutate the data vector it is given, and

--- a/implementations/rust/ockam/ockam_node/src/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay.rs
@@ -15,13 +15,14 @@
 //! The `Relay` is then responsible for turning the message back into
 //! a type and notifying the companion actor.
 
+use crate::tokio::runtime::Runtime;
+use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{parser, Context};
+use core::marker::PhantomData;
+use ockam_core::compat::{sync::Arc, vec::Vec};
 use ockam_core::{
     Address, LocalMessage, Message, Result, Route, Routed, RouterMessage, TransportMessage, Worker,
 };
-use std::{marker::PhantomData, sync::Arc};
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// A message addressed to a relay
 #[derive(Clone, Debug)]

--- a/implementations/rust/ockam/ockam_node/src/router.rs
+++ b/implementations/rust/ockam/ockam_node/src/router.rs
@@ -1,9 +1,9 @@
+use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{
     error::Error, relay::RelayMessage, AddressRecord, NodeMessage, NodeReply, NodeReplyResult,
 };
+use ockam_core::compat::collections::BTreeMap;
 use ockam_core::{Address, AddressSet, Result};
-use std::collections::BTreeMap;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// A combined address type and local worker router
 ///
@@ -130,6 +130,13 @@ impl Router {
         let address_record = AddressRecord::new(addrs.clone(), sender);
 
         self.internal.insert(primary_addr.clone(), address_record);
+
+        /* TODO #[cfg(feature = "std")]
+        if std::env::var("OCKAM_DUMP_INTERNALS").is_ok() {
+            trace!("{:#?}", self.internal);
+        }
+        #[cfg(feature = "dump_internals")]
+        trace!("{:#?}", self.internal);*/
 
         addrs.iter().for_each(|addr| {
             self.addr_map.insert(addr.clone(), primary_addr.clone());

--- a/implementations/rust/ockam/ockam_node/src/tests.rs
+++ b/implementations/rust/ockam/ockam_node/src/tests.rs
@@ -2,7 +2,12 @@
 mod test {
     use crate::{start_node, Context};
     use async_trait::async_trait;
+    use ockam_core::compat::{
+        boxed::Box,
+        string::{String, ToString},
+    };
     use ockam_core::{route, Routed, Worker};
+    // TODO
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::thread::sleep;

--- a/implementations/rust/ockam/ockam_node_attribute/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_attribute/Cargo.toml
@@ -20,6 +20,11 @@ exclude = [
 [lib]
 proc-macro = true
 
+[features]
+default = ["std"]
+std = []
+no_std = []
+
 [dependencies]
 quote = "1.0.9"
 syn = {version = "1.0", features = ["full", "extra-traits"]}

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -143,6 +143,7 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    #[cfg(feature = "std")]
     let output_function = quote! {
         #[inline(always)]
         #input_function
@@ -154,6 +155,21 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
             })
         }
     };
+
+    #[cfg(not(feature = "std"))]
+    let output_function = quote! {
+        #[inline(always)]
+        #input_function
+
+        fn main() -> ockam_core::Result<()> {
+            let (#ctx_ident, mut executor) = ockam_node::start_node();
+            executor.execute(async move {
+                #input_function_call
+            })
+        }
+        main().unwrap();
+    };
+
     // Create a token stream of the transformed output_function and return it.
     TokenStream::from(output_function)
 }

--- a/implementations/rust/ockam/ockam_node_no_std/.cargo/config
+++ b/implementations/rust/ockam/ockam_node_no_std/.cargo/config
@@ -1,0 +1,12 @@
+[build]
+target = "thumbv7em-none-eabihf"
+
+[target.thumbv7em-none-eabihf]
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+#runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+#runner = "probe-run -vv --chip ATSAME54P20A"
+runner = "qemu-system-arm -cpu cortex-m4 -machine netduinoplus2 -nographic -semihosting-config enable=on,target=native -kernel"

--- a/implementations/rust/ockam/ockam_node_no_std/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node_no_std/Cargo.lock
@@ -3,22 +3,55 @@
 version = 3
 
 [[package]]
-name = "executor"
-version = "0.7.0"
+name = "ahash"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc386acdbd994c2c2dc45829352eaff2bfc3b3191c220e4b61d1bcc44b56191"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
- "executor-macros",
- "lazy_static",
- "spin",
- "woke",
+ "getrandom",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
-name = "executor-macros"
-version = "0.1.1"
+name = "aligned"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76702ca666fb8b55aea1f5099cdbbdb42e50392de44ad60c86224e7d4236c401"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-embedded"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+ "cortex-m-semihosting",
+ "generic-array 0.14.4",
+ "heapless 0.5.3",
+ "pin-utils",
+ "typenum",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -26,11 +59,400 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "atomic-polyfill"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
 dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+ "serde",
+]
+
+[[package]]
+name = "heapless"
+version = "0.5.3"
+source = "git+https://github.com/japaric/heapless?branch=slab#10e88349aef0957062f46700ccb2752485d3aa50"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "instant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "ockam_core"
+version = "0.25.0-dev"
+dependencies = [
+ "async-trait",
+ "core2",
+ "hashbrown",
+ "heapless 0.7.4",
+ "hex",
+ "rand",
+ "rand_pcg",
+ "serde",
+ "serde_bare",
  "spin",
 ]
 
@@ -38,8 +460,78 @@ dependencies = [
 name = "ockam_node_no_std"
 version = "0.13.0-dev"
 dependencies = [
- "executor",
+ "async-embedded",
+ "cortex-m 0.7.3",
+ "futures",
+ "heapless 0.7.4",
+ "ockam_core",
+ "panic-udf",
+ "pin-project-lite",
+ "tokio",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "panic-udf"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -60,10 +552,123 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.5.2"
+name = "rand"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_bare"
+version = "0.4.0"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
+dependencies = [
+ "core2",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -77,13 +682,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "woke"
-version = "0.0.2"
+name = "vcell"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafdab77c9ee549298ca6585107832aa89d77b14ba13cda220fec6105b17dbb1"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/implementations/rust/ockam/ockam_node_no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_no_std/Cargo.toml
@@ -17,5 +17,36 @@ exclude = [
     "LICENSE"
 ]
 
+[lib]
+# TODO not setting arm target breaks build, setting arm target breaks tests
+test = false
+
+[features]
+default = ["no_std", "alloc"]
+cortexm = ["cortex-m"]
+riscv = []
+notests = []
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["tokio"]
+
+# Option: "no_std" enables functionality required for platforms without the
+# standard library.
+no_std = ["cortexm", "async-embedded", "panic-udf"]
+
+# Option: "alloc" enables support for heap allocation on "no_std" platforms,
+# requires nightly.
+alloc = ["ockam_core/alloc"]
+
 [dependencies]
-executor = "0.7.0"
+async-embedded = { git = "https://github.com/antoinevg/async-on-embedded.git", branch = "antoinevg/alloc", optional = true }
+cortex-m = { version = "0.7.2", optional = true }
+futures = { version = "0.3.15", default-features = false, features = [ "alloc", "async-await" ] }
+heapless = { version = "0.7", features = [ "mpmc_large", "cas" ] }
+ockam_core = { path = "../ockam_core", default-features = false, features = ["no_std"] }
+panic-udf      = { git = "https://github.com/antoinevg/async-on-embedded.git", branch = "antoinevg/alloc", optional = true }
+pin-project-lite = "0.2.6"
+
+# only used for running tests on std
+tokio = { version = "1.6.0", features = ["full", "test-util"], optional = true }

--- a/implementations/rust/ockam/ockam_node_no_std/rust-toolchain
+++ b/implementations/rust/ockam/ockam_node_no_std/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/implementations/rust/ockam/ockam_node_no_std/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_no_std/src/lib.rs
@@ -1,10 +1,26 @@
-#![no_std]
+//! no_std implementation for ockam_node
+//!
+//! This crate contains a first draft of the missing functionality
+//! from std which is required by ockam_node on no_std targets.
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unused_import_braces,
+    unused_qualifications,
+    warnings
+)]
 
-use core::future::Future;
+/// no_std implementation of tokio functionality required by ockam_node
+pub mod tokio;
 
-pub fn block_on<T>(future: impl Future<Output = T> + 'static + Send) -> T
-where
-    T: Send + 'static,
-{
-    executor::block_on(future)
+/// Placeholder Mutex implementation for use on cortex_m platforms
+///
+/// TODO Provide a std::sync::Mutex compatible mutex interface and
+/// abstract the implementations into the target specific crates.
+pub mod interrupt {
+    #[cfg(feature = "no_std")]
+    pub use cortex_m::interrupt::{free, Mutex};
 }

--- a/implementations/rust/ockam/ockam_node_no_std/src/tokio/mod.rs
+++ b/implementations/rust/ockam/ockam_node_no_std/src/tokio/mod.rs
@@ -1,0 +1,82 @@
+// TODO document modules once we've stabilized async execution
+#![allow(missing_docs)]
+#![allow(clippy::needless_lifetimes)]
+
+use async_embedded as async_cortex_m;
+use core::future::Future;
+
+pub mod sync;
+pub mod time;
+
+/// execute
+pub fn execute<'r, F>(_runtime: &'r runtime::Runtime, future: F) -> <F as Future>::Output
+where
+    F: Future<Output = ()> + Send,
+    F::Output: Send,
+{
+    async_cortex_m::task::block_on(future)
+}
+
+/// block_future
+pub fn block_future<'r, F>(_runtime: &'r runtime::Runtime, _future: F) -> <F as Future>::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    // task::block_in_place(move || {
+    //     let local = task::LocalSet::new();
+    //     local.block_on(rt, f)
+    // })
+    unimplemented!();
+}
+
+// - runtime ------------------------------------------------------------------
+
+/// runtime
+pub mod runtime {
+    use crate::tokio::task::JoinHandle;
+    use async_embedded as async_cortex_m;
+    use core::future::Future;
+    use ockam_core::compat::io;
+
+    pub struct Runtime {}
+
+    impl Runtime {
+        pub fn new() -> io::Result<Runtime> {
+            Ok(Self {})
+        }
+
+        pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+        where
+            F: Future + Send + 'static,
+            F::Output: Send + 'static,
+        {
+            async_cortex_m::task::spawn(future);
+            JoinHandle::new(23)
+        }
+    }
+}
+
+// - task ---------------------------------------------------------------------
+
+/// task
+pub mod task {
+    pub use super::block_future;
+
+    pub type RawTask = u32;
+
+    #[derive(Copy, Clone)]
+    pub struct JoinHandle<T> {
+        pub raw: Option<RawTask>,
+        _p: core::marker::PhantomData<T>,
+    }
+
+    impl<T> JoinHandle<T> {
+        pub(super) fn new(raw: RawTask) -> JoinHandle<T> {
+            JoinHandle {
+                raw: Some(raw),
+                _p: core::marker::PhantomData,
+            }
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_node_no_std/src/tokio/sync.rs
+++ b/implementations/rust/ockam/ockam_node_no_std/src/tokio/sync.rs
@@ -1,0 +1,353 @@
+/// multiple producer, single consumer async channel
+pub mod mpsc {
+
+    // make println! available for tests
+    #[cfg(all(feature = "std", test))]
+    #[macro_use]
+    extern crate ockam_core;
+
+    use core::sync::atomic::{
+        AtomicBool, AtomicUsize,
+        Ordering::{AcqRel, Relaxed},
+    };
+    use core::task::Poll;
+    use futures::future::poll_fn;
+    use futures::task::AtomicWaker;
+    use heapless::mpmc::MpMcQueue;
+    use ockam_core::compat::sync::Arc;
+
+    pub type QueueN<T, const N: usize> = MpMcQueue<T, N>;
+    pub type Queue<T> = QueueN<T, 32>;
+
+    /// channel constructor
+    ///
+    /// TODO currently allocates a channel with a fixed size of 32
+    /// irrespective of the size provided
+    pub fn channel<T>(_size: usize) -> (Sender<T>, Receiver<T>) {
+        let queue = QueueN::<T, 32>::new();
+        channel_with_queue(queue)
+    }
+
+    fn channel_with_queue<T>(queue: Queue<T>) -> (Sender<T>, Receiver<T>) {
+        let sender = Arc::new(Inner {
+            queue,
+            wake_sender: AtomicWaker::new(),
+            wake_receiver: AtomicWaker::new(),
+            sender_count: AtomicUsize::new(1),
+            is_sender_closed: AtomicBool::new(false),
+        });
+        let receiver = Arc::clone(&sender);
+        (Sender(sender), Receiver(receiver))
+    }
+
+    struct Inner<T> {
+        queue: Queue<T>,
+        wake_sender: AtomicWaker,
+        wake_receiver: AtomicWaker,
+        sender_count: AtomicUsize,
+        is_sender_closed: AtomicBool,
+    }
+
+    /// Sender
+    pub struct Sender<T>(Arc<Inner<T>>);
+
+    impl<T> Sender<T> {
+        pub async fn send(&self, value: T) -> Result<(), error::SendError<T>> {
+            let mut value = Some(value);
+            poll_fn(|context| {
+                match self.0.queue.enqueue(value.take().unwrap()) {
+                    Ok(()) => {
+                        self.0.wake_receiver.wake();
+                        Poll::Ready(Ok(()))
+                    }
+                    Err(_e) => {
+                        // queue is full
+
+                        // TODO how do tokio chan's behave in overflow?
+                        {
+                            self.0.is_sender_closed.swap(true, AcqRel);
+                            self.0.wake_receiver.wake();
+                        }
+
+                        self.0.wake_sender.register(context.waker());
+                        Poll::Pending
+                    }
+                }
+            })
+            .await
+        }
+
+        pub async fn closed(&self) {
+            // nop
+        }
+    }
+
+    impl<T> Clone for Sender<T> {
+        fn clone(&self) -> Self {
+            self.0.sender_count.fetch_add(1, Relaxed);
+            Sender(self.0.clone())
+        }
+    }
+
+    impl<T> Drop for Sender<T> {
+        fn drop(&mut self) {
+            let sender_count = self.0.sender_count.fetch_sub(1, AcqRel);
+            if sender_count != 1 {
+                return;
+            }
+            self.0.is_sender_closed.swap(true, AcqRel);
+            self.0.wake_receiver.wake();
+        }
+    }
+
+    impl<T> core::fmt::Debug for Sender<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            write!(f, "Sender")
+        }
+    }
+
+    /// Receiver
+    pub struct Receiver<T>(Arc<Inner<T>>);
+
+    impl<T: core::fmt::Debug> Receiver<T> {
+        pub async fn recv(&mut self) -> Option<T> {
+            poll_fn(|context| match self.0.queue.dequeue() {
+                Some(value) => {
+                    self.0.wake_sender.wake();
+                    Poll::Ready(Some(value))
+                }
+                None => {
+                    self.0.wake_receiver.register(context.waker());
+                    if self.0.is_sender_closed.load(Relaxed) {
+                        Poll::Ready(None)
+                    } else {
+                        Poll::Pending
+                    }
+                }
+            })
+            .await
+        }
+    }
+
+    impl<T> core::fmt::Debug for Receiver<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            write!(f, "[Receiver]")
+        }
+    }
+
+    /// mpsc::error::SendError
+    pub mod error {
+        use core::fmt;
+        use ockam_core::compat::error;
+
+        #[derive(Debug)]
+        pub struct SendError<T>(pub T);
+
+        impl<T> fmt::Display for SendError<T> {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(fmt, "SendError -> channel closed")
+            }
+        }
+
+        impl<T: fmt::Debug> error::Error for SendError<T> {}
+    }
+
+    #[cfg(all(feature = "std", test))]
+    mod tests {
+        use crate::tokio::sync::mpsc::{
+            channel, channel_n, channel_with_queue, channel_with_queue_n, Queue, QueueN, Receiver,
+            ReceiverN, Sender, SenderN,
+        };
+        use async_cortex_m::task::block_on;
+        use async_cortex_m::task::spawn;
+        use async_embedded as async_cortex_m;
+        use ockam_core::compat::format;
+
+        #[test]
+        fn test_send_receive() {
+            async {
+                let queue = Queue::<u32>::new();
+                let (tx, mut rx): (Sender<u32>, Receiver<u32>) = channel_with_queue(queue);
+
+                let _result = tx.send(23).await;
+                let x = rx.recv().await;
+            };
+        }
+
+        #[test]
+        fn test_spawn_one_sender() {
+            async {
+                let queue = heapless::mpmc::MpMcQueue::<u32, 32>::new();
+                let (mut tx, mut rx) = channel_with_queue(queue);
+
+                spawn(async move {
+                    for i in 0..10 {
+                        if let Err(_) = tx.send(i).await {
+                            println!("receiver dropped");
+                            return;
+                        }
+                    }
+                });
+
+                block_on(async move {
+                    while let Some(i) = rx.recv().await {
+                        println!("got = {}", i);
+                    }
+                });
+            };
+        }
+
+        #[test]
+        fn test_spawn_many_senders() {
+            async {
+                let (tx, mut rx) = channel(32);
+                for n in 0..10 {
+                    let tx2 = tx.clone();
+                    spawn(async move {
+                        tx2.send(format!("sent from: {}", n)).await.unwrap();
+                    });
+                }
+
+                spawn(async move {
+                    tx.send(format!("closing last tx")).await.unwrap();
+                });
+
+                block_on(async move {
+                    while let Some(message) = rx.recv().await {
+                        println!("GOT = {}", message);
+                    }
+                });
+            };
+        }
+
+        #[test]
+        fn test_queue_sizes() {
+            let queue = QueueN::<u32, 32>::new();
+            let (tx, mut rx) = channel_with_queue_n(queue);
+            let (tx, mut rx): (SenderN<u32, 1>, ReceiverN<u32, 1>) = channel_n();
+            let (tx, mut rx): (SenderN<u32, 32>, ReceiverN<u32, 32>) = channel_n();
+
+            let queue = Queue::<u32>::new();
+            let (tx, mut rx) = channel_with_queue(queue);
+            let (tx, mut rx): (Sender<u32>, Receiver<u32>) = channel(1);
+            let (tx, mut rx): (Sender<u32>, Receiver<u32>) = channel(32);
+        }
+
+        #[tokio::test]
+        async fn test_tokio_spawn_one_sender() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+            tokio::spawn(async move {
+                for n in 0..10 {
+                    tx.send(format!("sent from: {}", n)).await.unwrap();
+                }
+            });
+
+            while let Some(message) = rx.recv().await {
+                println!("test_tokio_spawn_one_sender got: {}", message);
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+        async fn test_tokio_spawn_many_senders() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+            for n in 0..10 {
+                let tx2 = tx.clone();
+                tokio::spawn(async move {
+                    tx2.send(format!("sent from: {}", n)).await.unwrap();
+                });
+            }
+
+            tokio::spawn(async move {
+                tx.send(format!("closing last tx")).await.unwrap();
+            });
+
+            while let Some(message) = rx.recv().await {
+                println!("test_tokio_spawn_many_senders got: {}", message);
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_tokio_overflow_queue() {
+            let (tx, mut rx) = crate::tokio::sync::mpsc::channel(32);
+
+            let tx2 = tx.clone();
+            tokio::spawn(async move {
+                for n in 0..100 {
+                    let tx3 = tx2.clone();
+                    tokio::spawn(async move {
+                        tx3.send(format!("sent from: {}", n)).await.unwrap();
+                    });
+                }
+            });
+
+            tokio::spawn(async move {
+                tx.send(format!("closing last tx")).await.unwrap();
+            });
+
+            while let Some(message) = rx.recv().await {
+                println!("test_tokio_overflow_queue got: {}", message);
+            }
+        }
+    }
+
+    /// initial draft of statically sized channel implementation
+    pub fn channel_n<T, const N: usize>() -> (SenderN<T, N>, ReceiverN<T, N>) {
+        let queue = QueueN::<T, N>::new();
+        channel_with_queue_n(queue)
+    }
+
+    fn channel_with_queue_n<T, const N: usize>(
+        queue: QueueN<T, N>,
+    ) -> (SenderN<T, N>, ReceiverN<T, N>) {
+        let sender = Arc::new(queue);
+        let receiver = Arc::clone(&sender);
+        (SenderN(sender), ReceiverN(receiver))
+    }
+
+    /// SenderN
+    pub struct SenderN<T, const N: usize>(Arc<QueueN<T, N>>);
+
+    impl<T, const N: usize> SenderN<T, N> {
+        pub async fn send(&self, value: T) -> Result<(), error::SendError<T>> {
+            match self.0.enqueue(value) {
+                Ok(()) => Ok(()),
+                Err(e) => Err(error::SendError(e)),
+            }
+        }
+
+        pub async fn closed(&self) {
+            unimplemented!();
+        }
+    }
+
+    impl<T, const N: usize> Clone for SenderN<T, N> {
+        fn clone(&self) -> Self {
+            unimplemented!();
+        }
+    }
+
+    impl<T, const N: usize> core::fmt::Debug for SenderN<T, N> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            write!(f, "SenderN")
+        }
+    }
+
+    /// ReceiverN
+    pub struct ReceiverN<T, const N: usize>(Arc<QueueN<T, N>>);
+
+    impl<T, const N: usize> ReceiverN<T, N> {
+        pub async fn recv(&mut self) -> Option<T> {
+            poll_fn(|_context| match self.0.dequeue() {
+                Some(item) => core::task::Poll::Ready(Some(item)),
+                None => core::task::Poll::Pending,
+            })
+            .await
+        }
+    }
+
+    impl<T, const N: usize> core::fmt::Debug for ReceiverN<T, N> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            write!(f, "Receiver")
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_node_no_std/src/tokio/time.rs
+++ b/implementations/rust/ockam/ockam_node_no_std/src/tokio/time.rs
@@ -1,0 +1,76 @@
+use super::*;
+pub use core::time::Duration;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct Timeout<F> {
+        #[pin]
+        duration: Duration,
+        #[pin]
+        future: F,
+    }
+}
+
+pub fn timeout<F>(duration: Duration, future: F) -> Timeout<F>
+where
+    F: Future,
+{
+    Timeout { duration, future }
+}
+
+impl<F> Future for Timeout<F>
+where
+    F: Future,
+{
+    type Output = Result<F::Output, error::Elapsed>;
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Self::Output> {
+        let me = self.project();
+
+        // First, try polling the future
+        if let core::task::Poll::Ready(v) = me.future.poll(cx) {
+            return core::task::Poll::Ready(Ok(v));
+        }
+
+        // TODO Then check the timer
+        /*match me.delay.poll(cx) {
+            Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
+            Poll::Pending => Poll::Pending,
+        }*/
+
+        core::task::Poll::Pending
+    }
+}
+
+pub mod error {
+    use core::fmt;
+    use ockam_core::compat::{error, io};
+
+    #[derive(Debug, PartialEq)]
+    pub struct Elapsed(());
+
+    impl Elapsed {
+        #![allow(dead_code)]
+        pub(crate) fn new() -> Self {
+            Elapsed(())
+        }
+    }
+
+    impl fmt::Display for Elapsed {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            "deadline has elapsed".fmt(fmt)
+        }
+    }
+
+    impl error::Error for Elapsed {}
+
+    impl From<Elapsed> for io::Error {
+        fn from(_err: Elapsed) -> io::Error {
+            io::ErrorKind::TimedOut.into()
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -622,8 +623,7 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -33,7 +33,7 @@ mod transport;
 pub use error::*;
 pub use transport::*;
 
-use ockam_core::lib::net::SocketAddr;
+use ockam_core::compat::net::SocketAddr;
 use ockam_core::Result;
 
 /// TCP address type constant

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -1,6 +1,6 @@
 use crate::atomic::ArcBool;
 use crate::{parse_socket_addr, TcpError, TcpListenWorker, WorkerPair, TCP};
-use ockam_core::lib::net::{SocketAddr, ToSocketAddrs};
+use ockam_core::compat::net::{SocketAddr, ToSocketAddrs};
 use ockam_core::{Address, Result, RouterMessage};
 use ockam_node::{block_future, Context};
 use std::sync::Arc;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/router.rs
@@ -4,7 +4,7 @@ use crate::{
     TcpError, TCP,
 };
 use async_trait::async_trait;
-use ockam_core::lib::Deref;
+use core::ops::Deref;
 use ockam_core::{Address, LocalMessage, Result, Routed, RouterMessage, Worker};
 use ockam_node::Context;
 use std::{collections::BTreeMap, sync::Arc};

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -309,8 +310,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -814,7 +813,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -836,7 +835,7 @@ dependencies = [
  "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
  "tracing",
 ]
 
@@ -849,7 +848,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc)",
 ]
 
 [[package]]
@@ -872,7 +871,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -903,6 +902,7 @@ dependencies = [
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
  "ockam_core",
  "tokio",
  "tracing",
@@ -942,7 +942,7 @@ dependencies = [
  "ockam",
  "ockam_core",
  "ockam_node",
- "serde_bare 0.4.0",
+ "serde_bare 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1315,6 +1315,14 @@ name = "serde_bare"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bare"
+version = "0.4.0"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -9,6 +9,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
+ "heapless",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -160,6 +162,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,8 +258,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -432,6 +440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,11 +465,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless",
  "hex",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -471,7 +489,8 @@ dependencies = [
  "ockam_vault_core",
  "ockam_vault_test_attribute",
  "ockam_vault_test_suite",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "sha2",
  "signature_bbs_plus",
  "tracing",
@@ -578,37 +597,14 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -641,18 +637,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -703,9 +699,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -794,6 +790,12 @@ dependencies = [
  "subtle",
  "typenum",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -925,7 +927,7 @@ checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
 dependencies = [
  "ff",
  "group",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
  "serde",
  "zeroize",

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -17,20 +17,31 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = ["std"]
-std = ["ockam_core/std"]
-no_std = ["ockam_vault_core/heapless"]
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_vault_core/std", "aes-gcm/alloc", "aes-gcm/std", "rand/std", "rand/std_rng", "tracing/std", "x25519-dalek/std", "x25519-dalek/u64_backend"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "rand_pcg", "x25519-dalek/u32_backend", "aes-gcm/heapless", "aes-gcm/force-soft", "aes-gcm/stream"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_vault_core/alloc",  "aes-gcm/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                           }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev"                           }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev", default_features = false }
 arrayref = "0.3"
-aes-gcm = "0.9"
-curve25519-dalek = "3.1"
-ed25519-dalek = "1.0"
-hkdf = "0.11"
-rand = "0.8"
-sha2 = "0.9"
-x25519-dalek = "1.1"
+aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }
+curve25519-dalek = { version = "3.1", default-features = false }
+ed25519-dalek = { version = "1.0", default-features = false }
+hkdf = { version = "0.11", default-features = false }
+rand = { version = "0.8", default-features = false }
+rand_pcg = { version = "0.3.1", default-features = false, optional = true }
+sha2 = { version = "0.9", default-features = false }
+x25519-dalek = { version = "1.0", default_features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 tracing = "0.1.26"
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "0.17.0-dev"              }

--- a/implementations/rust/ockam/ockam_vault/src/hasher_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/hasher_impl.rs
@@ -1,6 +1,7 @@
 use crate::software_vault::SoftwareVault;
 use crate::VaultError;
 use arrayref::array_ref;
+use ockam_core::compat::vec::Vec;
 use ockam_vault_core::{
     Hasher, Secret, SecretAttributes, SecretType, SecretVault, AES128_SECRET_LENGTH,
     AES256_SECRET_LENGTH,

--- a/implementations/rust/ockam/ockam_vault/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate contains one of the possible implementation of the vault traits
 //! which you can use with Ockam library.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,
@@ -12,6 +13,19 @@
     unused_qualifications,
     warnings
 )]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "no_std")]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
 
 pub extern crate ockam_vault_core;
 

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -1,7 +1,7 @@
 use crate::software_vault::{SoftwareVault, VaultEntry};
 use crate::VaultError;
 use arrayref::array_ref;
-use ockam_core::lib::convert::TryInto;
+use core::convert::TryInto;
 use ockam_vault_core::{
     KeyId, KeyIdVault, PublicKey, Secret, SecretAttributes, SecretKey, SecretPersistence,
     SecretType, SecretVault, AES128_SECRET_LENGTH, AES256_SECRET_LENGTH, CURVE25519_SECRET_LENGTH,

--- a/implementations/rust/ockam/ockam_vault/src/signer_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/signer_impl.rs
@@ -2,7 +2,10 @@ use crate::software_vault::SoftwareVault;
 use crate::xeddsa::XEddsaSigner;
 use crate::VaultError;
 use arrayref::array_ref;
+#[cfg(feature = "no_std")]
+use ockam_core::compat::rand::{thread_rng, RngCore};
 use ockam_vault_core::{Secret, SecretType, Signer, CURVE25519_SECRET_LENGTH};
+#[cfg(feature = "std")]
 use rand::{thread_rng, RngCore};
 
 impl Signer for SoftwareVault {

--- a/implementations/rust/ockam/ockam_vault/src/software_vault.rs
+++ b/implementations/rust/ockam/ockam_vault/src/software_vault.rs
@@ -1,7 +1,7 @@
 use crate::VaultError;
+use ockam_core::compat::{collections::BTreeMap, string::String};
 use ockam_vault_core::zdrop_impl;
 use ockam_vault_core::{Secret, SecretAttributes, SecretKey};
-use std::collections::BTreeMap;
 use tracing::info;
 use zeroize::Zeroize;
 

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -61,6 +61,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,11 +170,15 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless",
  "hex",
  "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
@@ -246,6 +264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,9 +318,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -307,6 +334,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -14,13 +14,23 @@ description = """The Ockam Vault trait.
 
 [features]
 default = ["std"]
+
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
 std = ["ockam_core/std"]
-no_std = ["heapless"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "heapless"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "serde/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"        }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
 heapless = { version = "0.7", features = ["serde"], optional = true }
-serde = {version = "1.0", features = ["derive"]}
+serde = {version = "1.0", default-features = false,features = ["derive"]}
 serde-big-array = "0.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 cfg-if = "1.0"

--- a/implementations/rust/ockam/ockam_vault_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault_core/src/lib.rs
@@ -4,7 +4,7 @@
 //! for use by other crates that either provide implementations for those traits,
 //! or use traits and types as an abstract dependency.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,

--- a/implementations/rust/ockam/ockam_vault_core/src/types.rs
+++ b/implementations/rust/ockam/ockam_vault_core/src/types.rs
@@ -17,7 +17,7 @@ pub const AES256_SECRET_LENGTH: usize = 32;
 pub const AES128_SECRET_LENGTH: usize = 16;
 
 cfg_if! {
-    if #[cfg(feature = "no_std")] {
+    if #[cfg(all(feature = "no_std", not(feature = "alloc")))] {
         /// Secret Key Vector
         pub type SecretKeyVec = heapless::Vec<u8, 32>;
         /// Public Key Vector
@@ -26,8 +26,13 @@ cfg_if! {
         pub type SmallBuffer<T> = heapless::Vec<T, 4>;
         /// Buffer for large binaries (e.g. encrypted data). Max size - 512
         pub type Buffer<T> = heapless::Vec<T, 512>;
-        /// ID of a Key
         pub type KeyId = heapless::String<64>;
+
+        impl From<&str> for KeyId {
+            fn from(s: &str) -> Self {
+                heapless::String::from(s)
+            }
+        }
     }
     else {
         extern crate alloc;

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
@@ -8,7 +8,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+ "heapless 0.7.4",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -49,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +73,31 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "async-embedded"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+ "cortex-m-semihosting",
+ "generic-array 0.14.4",
+ "heapless 0.5.3",
+ "pin-utils",
+ "typenum",
+]
 
 [[package]]
 name = "async-trait"
@@ -80,7 +116,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -139,7 +175,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -151,7 +187,7 @@ dependencies = [
  "digest",
  "ff",
  "group",
- "heapless",
+ "heapless 0.7.4",
  "pairing",
  "rand_core 0.6.3",
  "serde",
@@ -195,7 +231,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/antoinevg/core2.git?branch=antoinevg/add-read-to-end#3310b6fbcc7b7c9d2c48841006fb2118289390dc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -208,6 +265,15 @@ dependencies = [
  "bitfield",
  "embedded-hal",
  "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -225,7 +291,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -235,7 +301,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -267,7 +333,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -287,8 +353,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
  "sha2",
  "zeroize",
 ]
@@ -319,6 +383,102 @@ name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "generic-array"
@@ -376,6 +536,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
@@ -395,12 +564,23 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.5.3"
+source = "git+https://github.com/japaric/heapless?branch=slab#10e88349aef0957062f46700ccb2752485d3aa50"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+]
+
+[[package]]
+name = "heapless"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767c746c1943728fb6f2cdb24b2cbe292dd4d6976640758060adf4bb9855a7ca"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -456,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -606,21 +786,42 @@ name = "ockam_core"
 version = "0.25.0-dev"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown",
+ "heapless 0.7.4",
  "hex",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
  "serde_bare",
+ "spin",
 ]
 
 [[package]]
 name = "ockam_node"
 version = "0.23.0-dev"
 dependencies = [
+ "async-trait",
+ "cortex-m-semihosting",
+ "heapless 0.7.4",
  "ockam_core",
+ "ockam_node_no_std",
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "ockam_node_no_std"
+version = "0.13.0-dev"
+dependencies = [
+ "async-embedded",
+ "cortex-m 0.7.3",
+ "futures",
+ "heapless 0.7.4",
+ "ockam_core",
+ "panic-udf",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -634,7 +835,8 @@ dependencies = [
  "hkdf",
  "ockam_core",
  "ockam_vault_core",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "sha2",
  "signature_bbs_plus",
  "tracing",
@@ -647,6 +849,7 @@ name = "ockam_vault_core"
 version = "0.19.0-dev"
 dependencies = [
  "cfg-if",
+ "heapless 0.7.4",
  "ockam_core",
  "serde",
  "serde-big-array",
@@ -664,7 +867,8 @@ dependencies = [
  "ockam_vault_core",
  "ockam_vault_test_attribute",
  "ockam_vault_test_suite",
- "rand 0.8.4",
+ "rand",
+ "rand_pcg",
  "serde",
  "serde-big-array",
  "tracing",
@@ -709,6 +913,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "panic-udf"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/antoinevg/async-on-embedded.git?branch=antoinevg/alloc#cb7eb7fb670e5cfb7be7ea76436025180fa9d9ed"
+dependencies = [
+ "cortex-m 0.6.7",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +952,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "polyval"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +974,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -783,37 +1013,14 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -846,18 +1053,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -953,9 +1160,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1066,7 +1273,7 @@ dependencies = [
  "ff",
  "group",
  "hashbrown",
- "heapless",
+ "heapless 0.7.4",
  "rand_core 0.6.3",
  "serde",
  "serde-big-array",
@@ -1079,6 +1286,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1254,7 +1467,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -1293,7 +1506,7 @@ checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
 dependencies = [
  "ff",
  "group",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
  "serde",
  "zeroize",

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -14,20 +14,33 @@ that talk to the same Vault implementation without need for synchronization prim
 """
 
 [features]
-default = []
+default = ["std"]
 software_vault = ["ockam_vault"]
 
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_vault_core/std", "ockam_vault/std", "ockam_node/std", "rand/std", "rand/std_rng"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "ockam_vault/no_std", "ockam_node/no_std", "rand_pcg"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/alloc"]
+
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.25.0-dev"                           }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev"                           }
-ockam_vault = { path = "../ockam_vault", version = "0.19.0-dev"                          , optional = true }
-ockam_node = {path = "../ockam_node", version = "0.23.0-dev"                          }
+ockam_core = { path = "../ockam_core", version = "0.25.0-dev", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.19.0-dev", default_features = false }
+ockam_vault = { path = "../ockam_vault", version = "0.19.0-dev", default_features = false, optional = true }
+ockam_node = { path = "../ockam_node", version = "0.23.0-dev", default_features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
-tracing = "0.1"
+tracing = { version = "0.1", default_features = false }
 async-trait = "0.1"
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
+rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "0.19.0-dev"                           }

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/lib.rs
@@ -4,6 +4,7 @@
 //! for use by other crates that either provide implementations for those traits,
 //! or use traits and types as an abstract dependency.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,
@@ -13,6 +14,19 @@
     unused_qualifications,
     warnings
 )]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "no_std")]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
 
 mod error;
 mod vault;

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex/key_id_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex/key_id_vault.rs
@@ -4,14 +4,35 @@ use ockam_vault_core::{KeyId, KeyIdVault, PublicKey, Secret};
 
 impl<V: KeyIdVault> KeyIdVault for VaultMutex<V> {
     fn get_secret_by_key_id(&mut self, key_id: &str) -> Result<Secret> {
-        self.0.lock().unwrap().get_secret_by_key_id(key_id)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().get_secret_by_key_id(key_id);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .get_secret_by_key_id(key_id)
+        });
     }
 
     fn compute_key_id_for_public_key(&mut self, public_key: &PublicKey) -> Result<KeyId> {
-        self.0
+        #[cfg(feature = "std")]
+        return self
+            .0
             .lock()
             .unwrap()
-            .compute_key_id_for_public_key(public_key)
+            .compute_key_id_for_public_key(public_key);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .compute_key_id_for_public_key(public_key)
+        });
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex/secret_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex/secret_vault.rs
@@ -4,27 +4,87 @@ use ockam_vault_core::{PublicKey, Secret, SecretAttributes, SecretKey, SecretVau
 
 impl<V: SecretVault> SecretVault for VaultMutex<V> {
     fn secret_generate(&mut self, attributes: SecretAttributes) -> Result<Secret> {
-        self.0.lock().unwrap().secret_generate(attributes)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().secret_generate(attributes);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .secret_generate(attributes)
+        });
     }
 
     fn secret_import(&mut self, secret: &[u8], attributes: SecretAttributes) -> Result<Secret> {
-        self.0.lock().unwrap().secret_import(secret, attributes)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().secret_import(secret, attributes);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .secret_import(secret, attributes)
+        });
     }
 
     fn secret_export(&mut self, context: &Secret) -> Result<SecretKey> {
-        self.0.lock().unwrap().secret_export(context)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().secret_export(context);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .secret_export(context)
+        });
     }
 
     fn secret_attributes_get(&mut self, context: &Secret) -> Result<SecretAttributes> {
-        self.0.lock().unwrap().secret_attributes_get(context)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().secret_attributes_get(context);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .secret_attributes_get(context)
+        });
     }
 
     fn secret_public_key_get(&mut self, context: &Secret) -> Result<PublicKey> {
-        self.0.lock().unwrap().secret_public_key_get(context)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().secret_public_key_get(context);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .secret_public_key_get(context)
+        });
     }
 
     fn secret_destroy(&mut self, context: Secret) -> Result<()> {
-        self.0.lock().unwrap().secret_destroy(context)
+        #[cfg(feature = "std")]
+        return self.0.lock().unwrap().secret_destroy(context);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .secret_destroy(context)
+        });
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex/symmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex/symmetric_vault.rs
@@ -10,10 +10,21 @@ impl<V: SymmetricVault> SymmetricVault for VaultMutex<V> {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Buffer<u8>> {
-        self.0
+        #[cfg(feature = "std")]
+        return self
+            .0
             .lock()
             .unwrap()
-            .aead_aes_gcm_encrypt(context, plaintext, nonce, aad)
+            .aead_aes_gcm_encrypt(context, plaintext, nonce, aad);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .aead_aes_gcm_encrypt(context, plaintext, nonce, aad)
+        });
     }
 
     fn aead_aes_gcm_decrypt(
@@ -23,10 +34,21 @@ impl<V: SymmetricVault> SymmetricVault for VaultMutex<V> {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Buffer<u8>> {
-        self.0
+        #[cfg(feature = "std")]
+        return self
+            .0
             .lock()
             .unwrap()
-            .aead_aes_gcm_decrypt(context, cipher_text, nonce, aad)
+            .aead_aes_gcm_decrypt(context, cipher_text, nonce, aad);
+        #[cfg(feature = "no_std")]
+        return ockam_node::interrupt::free(|cs| {
+            self.0
+                .borrow(cs)
+                .borrow_mut()
+                .as_mut()
+                .unwrap()
+                .aead_aes_gcm_decrypt(context, cipher_text, nonce, aad)
+        });
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -1,6 +1,9 @@
 use crate::{Vault, VaultRequestMessage, VaultResponseMessage, VaultTrait};
+#[cfg(feature = "no_std")]
+use ockam_core::compat::rand::random;
 use ockam_core::{Address, Result, ResultMessage, Route};
 use ockam_node::{block_future, Context};
+#[cfg(feature = "std")]
 use rand::random;
 use tracing::debug;
 use zeroize::Zeroize;

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/key_id_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/key_id_vault.rs
@@ -1,4 +1,5 @@
 use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
+use ockam_core::compat::string::ToString;
 use ockam_core::Result;
 use ockam_node::block_future;
 use ockam_vault_core::{KeyId, KeyIdVault, PublicKey, Secret};

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_worker.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_worker.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
+use ockam_core::compat::{boxed::Box, rand::random};
 use ockam_core::{Address, Result, ResultMessage, Routed, Worker};
 use ockam_node::Context;
 use ockam_vault_core::{
     AsymmetricVault, Hasher, KeyIdVault, SecretVault, Signer, SymmetricVault, Verifier,
 };
-use rand::random;
 use zeroize::Zeroize;
 
 /// Super-trait of traits required for a Vault Worker.

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_worker/request_message.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_worker/request_message.rs
@@ -1,3 +1,4 @@
+use ockam_core::compat::string::String;
 use ockam_vault_core::{Buffer, PublicKey, Secret, SecretAttributes, SmallBuffer};
 use serde::{Deserialize, Serialize};
 use serde_big_array::big_array;

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
@@ -186,8 +186,7 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/antoinevg/serde_bare.git?branch=antoinevg/no_std+alloc#34fa8b1230c1d48af003035e53ba32997c82082b"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/signature_bbs_plus/src/lib.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/lib.rs
@@ -1,5 +1,5 @@
 //!
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     // TODO restore missing_docs,
     trivial_casts,

--- a/implementations/rust/ockam/signature_bls/src/lib.rs
+++ b/implementations/rust/ockam/signature_bls/src/lib.rs
@@ -13,7 +13,7 @@
 //! but provides some optimizations when an allocator exists for verifying
 //! aggregated signatures.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -28,7 +28,7 @@ hashbrown = { version = "0.11", features = ["serde"] }
 heapless = "0.7"
 rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
-subtle = "2.4"
+subtle = { version = "2.4", default_features = false }
 typenum = "1.13"
 serde-big-array = "0.3"
 

--- a/implementations/rust/ockam/signature_core/src/lib.rs
+++ b/implementations/rust/ockam/signature_core/src/lib.rs
@@ -1,6 +1,6 @@
 //! A crate for common methods used by short group signatures
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     trivial_casts,
     trivial_numeric_casts,

--- a/implementations/rust/ockam/signature_ps/src/lib.rs
+++ b/implementations/rust/ockam/signature_ps/src/lib.rs
@@ -2,7 +2,7 @@
 //! as described in <https://eprint.iacr.org/2015/525.pdf>
 //! and <https://eprint.iacr.org/2017/1197.pdf>
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,
     trivial_casts,


### PR DESCRIPTION
### Proposed Changes

* rework `ockam::lib` to `ockam::compat`
  - mirror `std::` and `alloc::` module structures
  - add `no_std` versions of missing `rand::` functionality
  - remove references to items that live in `core::`
* update all ockam modules to use `ockam::compat` instead of `ockam::lib`
* add `no_std` and `alloc` features to all ockam crates
  - populate all crate dependencies to `std`, `no_std` and `alloc`
  - update all crate `#[cfg(feature=...)]` attributes
* implementa `no_std` version of `ockam_node_attribute`
* add placeholder semihosting logging macros for embedded targets
* add placeholder `no_std` embedded `Mutex` implementation for `ockam_vault_sync`
* implement `no_std` versions of tokio functionality used by `ockam_node`:
  - `tokio::sync::mpsc`
  - `tokio::runtime`
  - `tokio::task`
  - `tokio::time`

### Notes

With this commit the first four examples from the rust getting started guide should compile and run on the Microchip ATSAME54-XPRO board and under emulation with `qemu-system-arm`.

1. **My handling of `rand::` is a bit clumsy:**
  * There are issues with multiple included versions of the `rand` crate conflicting with each other.
  * I've special cased the inclusion of `no_std` implementations of functionality missing from the `rand` crate.

2. **Tests are disabled for `ockam_node_no_std`**
  * If we don't set an embedded target the crate can't build.
  * If we set an embedded target the tests can't run.
  * In the medium term I want to set the tests up to be able to run under `qemu-system-arch` which will resolve this.

3. **Some of the crypto modules are currently broken with `no_std`**
  * I see there's been some major refactoring happening here over the last few days.
  * I think it's probably better if I hold off on fixing this again until things have stabilized.



