### PR TITLE
fix(rust): use local message in hop.rs

### DIFF
--- a/documentation/guides/rust/get-started/03-routing/README.md
+++ b/documentation/guides/rust/get-started/03-routing/README.md
@@ -53,10 +53,11 @@ impl Worker for Hop {
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
         println!("Address: {}, Received: {}", ctx.address(), msg);
 
-        let mut msg = msg.into_transport_message();
+        let mut local_msg = msg.into_local_message();
+        let msg = local_msg.transport_mut();
         msg.onward_route.step()?;
         msg.return_route.modify().prepend(ctx.address());
-        ctx.forward(msg).await
+        ctx.forward(local_msg).await
     }
 }
 ```


### PR DESCRIPTION
`ctx.forward()` expects a `local_message`, but got `transport_message`

<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
