### PR TITLE
feat(elixir): support hostnames in tcp addresses

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/local.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/local.ex
@@ -42,7 +42,7 @@ defmodule Ockam.Example.Stream.BiDirectional.Local do
     config = config()
 
     {:ok, hub_ip_n} = :inet.parse_address(to_charlist(config.hub_ip))
-    tcp_address = %Ockam.Transport.TCPAddress{ip: hub_ip_n, port: config.hub_port}
+    tcp_address = %Ockam.Transport.TCPAddress{host: hub_ip_n, port: config.hub_port}
 
     [
       service_route: [tcp_address, config.service_address],

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
@@ -178,7 +178,7 @@ defmodule Ockam.Example.Stream.BiDirectional.SecureChannel do
     config = config()
 
     {:ok, hub_ip_n} = :inet.parse_address(to_charlist(config.hub_ip))
-    tcp_address = %Ockam.Transport.TCPAddress{ip: hub_ip_n, port: config.hub_port}
+    tcp_address = %Ockam.Transport.TCPAddress{host: hub_ip_n, port: config.hub_port}
 
     udp_address = %Ockam.Transport.UDPAddress{ip: hub_ip_n, port: config.hub_port_udp}
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/index_api.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/index_api.ex
@@ -9,7 +9,7 @@ defmodule Ockam.Examples.Stream.IndexApi do
   @dialyzer :no_return
 
   def service_route() do
-    tcp_address = %Ockam.Transport.TCPAddress{ip: {127, 0, 0, 1}, port: 4000}
+    tcp_address = %Ockam.Transport.TCPAddress{host: {127, 0, 0, 1}, port: 4000}
     [tcp_address, "stream_kafka_index"]
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream.ex
@@ -32,7 +32,7 @@ defmodule Ockam.Examples.Stream do
     }
 
     {:ok, hub_ip_n} = :inet.parse_address(to_charlist(config.hub_ip))
-    tcp_address = %Ockam.Transport.TCPAddress{ip: hub_ip_n, port: config.hub_port}
+    tcp_address = %Ockam.Transport.TCPAddress{host: hub_ip_n, port: config.hub_port}
 
     %{
       service_route: [tcp_address, config.service_address],

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream_api.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream_api.ex
@@ -9,7 +9,7 @@ defmodule Ockam.Examples.Stream.StreamApi do
   @dialyzer :no_return
 
   def service_route() do
-    tcp_address = %Ockam.Transport.TCPAddress{ip: {127, 0, 0, 1}, port: 4000}
+    tcp_address = %Ockam.Transport.TCPAddress{host: {127, 0, 0, 1}, port: 4000}
     [tcp_address, "stream_kafka"]
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/address.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/address.ex
@@ -3,14 +3,56 @@ defmodule Ockam.Transport.TCPAddress do
 
   alias __MODULE__
 
-  defstruct [:ip, :port]
+  defstruct [:ip, :address, :port]
+
+  @ipv4_type {:data, 4}
+  @ipv6_type {:data, 16}
+  @host_type :string
+  ## type TCPAddress {
+  ##   address: ({:data, 4} | {:data, 16} | string) // host, ipv4 or ipv6
+  ##   port: u16
+  ## }
+  def bare_schema() do
+    {:struct, [ip: {:union, [@ipv4_type, @ipv6_type, @host_type]}, port: :u16]}
+  end
+
+  def decode(value) when is_binary(value) do
+    case Ockam.Bare.Extended.decode(value, bare_schema()) do
+      {:ok, %{port: port, ip: decoded_address}} ->
+        address = parse_address(decoded_address)
+
+        %TCPAddress{ip: address, port: port}
+      {:error, reason} ->
+        {:error, {:not_a_valid_serialized_tcp_address, reason}}
+    end
+  end
+
+  def encode(%TCPAddress{ip: address, port: port}) do
+    Ockam.Bare.Extended.encode(%{port: port, ip: format_address(address)}, bare_schema())
+  end
+
+  def format_address({a, b, c, d}) do
+    {@ipv4_type, <<a::8, b::8, c::8, d::8>>}
+  end
+  def format_address({a, b, c, d, e, f, g, h}) do
+    {@ipv6_type, <<a::unsigned-little-integer-16, b::unsigned-little-integer-16, c::unsigned-little-integer-16, d::unsigned-little-integer-16, e::unsigned-little-integer-16, f::unsigned-little-integer-16, g::unsigned-little-integer-16, h::unsigned-little-integer-16>>}
+  end
+  def format_address(string) when is_binary(string) do
+    {@host_type, string}
+  end
+
+  def parse_address({@host_type, host}) do
+    host
+  end
+  def parse_address({@ipv4_type, <<a::8, b::8, c::8, d::8>>}) do
+    {a, b, c, d}
+  end
+  def parse_address({@ipv6_type, <<a::unsigned-little-integer-16, b::unsigned-little-integer-16, c::unsigned-little-integer-16, d::unsigned-little-integer-16, e::unsigned-little-integer-16, f::unsigned-little-integer-16, g::unsigned-little-integer-16, h::unsigned-little-integer-16>>}) do
+    {a, b, c, d, e, f, g, h}
+  end
 
   # tcp address type
   @tcp 1
-
-  # ip address type tags
-  @ipv4 0
-  @ipv6 1
 
   @spec deserialize(any) ::
           {:error, {:not_a_valid_serialized_tcp_address, any}}
@@ -23,18 +65,9 @@ defmodule Ockam.Transport.TCPAddress do
 
   def deserialize(value) when is_list(value), do: deserialize(IO.iodata_to_binary(value))
 
-  def deserialize(<<@ipv4::8, a::8, b::8, c::8, d::8, port::unsigned-little-integer-16>>) do
-    %TCPAddress{ip: {a, b, c, d}, port: port}
+  def deserialize(data) do
+    decode(data)
   end
-
-  def deserialize(
-        <<@ipv6::8, a::8, b::8, c::8, d::8, e::8, f::8, g::8, h::8,
-          port::unsigned-little-integer-16>>
-      ) do
-    %TCPAddress{ip: {a, b, c, d, e, f, g, h}, port: port}
-  end
-
-  def deserialize(value), do: {:error, {:not_a_valid_serialized_tcp_address, value}}
 end
 
 defimpl Ockam.Address, for: Ockam.Transport.TCPAddress do
@@ -50,38 +83,7 @@ defimpl Ockam.Serializable, for: Ockam.Transport.TCPAddress do
   # tcp address type
   @tcp 1
 
-  # ip address type tags
-  @ipv4 0
-  @ipv6 1
-
-  def serialize(%TCPAddress{ip: ip, port: port}) do
-    with {:ok, serialized_ip} <- serialize_ip(ip),
-         {:ok, serialized_port} <- serialize_port(port) do
-      %{type: @tcp, value: :binary.list_to_bin([serialized_ip, serialized_port])}
-    end
+  def serialize(%TCPAddress{} = tcp_address) do
+    %{type: @tcp, value: Ockam.Transport.TCPAddress.encode(tcp_address)}
   end
-
-  # Turns and IP into a binary.
-
-  defp serialize_ip({a, b, c, d}) do
-    {:ok, <<@ipv4::8, a::8, b::8, c::8, d::8>>}
-  end
-
-  defp serialize_ip({a, b, c, d, e, f, g, h}) do
-    {:ok,
-     <<@ipv6::8, a::unsigned-little-integer-16, b::unsigned-little-integer-16,
-       c::unsigned-little-integer-16, d::unsigned-little-integer-16,
-       e::unsigned-little-integer-16, f::unsigned-little-integer-16,
-       g::unsigned-little-integer-16, h::unsigned-little-integer-16>>}
-  end
-
-  defp serialize_ip(value), do: {:error, {:not_a_valid_ip, value}}
-
-  # Turn a ports into a binary.
-
-  defp serialize_port(port) when port >= 0 and port <= 65_535 do
-    {:ok, <<port::unsigned-little-integer-16>>}
-  end
-
-  defp serialize_port(value), do: {:error, {:not_a_valid_port, value}}
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -13,8 +13,15 @@ defmodule Ockam.Transport.TCP.Client do
   @impl true
   def setup(options, state) do
     %{ip: ip, port: port} = Keyword.fetch!(options, :destination)
+
+    address = case ip do
+      string when is_binary(string) ->
+        String.to_charlist(string)
+      tuple when is_tuple(tuple) ->
+        tuple
+    end
     # TODO: connect/3 and controlling_process/2 should be in a callback.
-    case :gen_tcp.connect(ip, port, [:binary, :inet, active: true, packet: 2, nodelay: true]) do
+    case :gen_tcp.connect(address, port, [:binary, :inet, active: true, packet: 2, nodelay: true]) do
       {:ok, socket} ->
         :gen_tcp.controlling_process(socket, self())
         {:ok, Map.merge(state, %{socket: socket, ip: ip, port: port})}

--- a/implementations/elixir/ockam/ockam/test/ockam/message_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/message_test.exs
@@ -38,12 +38,12 @@ defmodule Ockam.Message.Tests do
     test "onward_route/1 does what I expect for TCP" do
       message = %{
         onward_route: [
-          %Ockam.Transport.TCPAddress{ip: {127, 0, 0, 1}, port: 3000}
+          %Ockam.Transport.TCPAddress{host: {127, 0, 0, 1}, port: 3000}
         ],
         payload: "hello"
       }
 
-      assert [%Ockam.Transport.TCPAddress{ip: {127, 0, 0, 1}, port: 3000}] ==
+      assert [%Ockam.Transport.TCPAddress{host: {127, 0, 0, 1}, port: 3000}] ==
                Message.onward_route(message)
     end
 
@@ -62,12 +62,12 @@ defmodule Ockam.Message.Tests do
     test "return_route/1 does what I expect for TCP" do
       message = %{
         return_route: [
-          %Ockam.Transport.TCPAddress{ip: {127, 0, 0, 1}, port: 3000}
+          %Ockam.Transport.TCPAddress{host: {127, 0, 0, 1}, port: 3000}
         ],
         payload: "hello"
       }
 
-      assert [%Ockam.Transport.TCPAddress{ip: {127, 0, 0, 1}, port: 3000}] =
+      assert [%Ockam.Transport.TCPAddress{host: {127, 0, 0, 1}, port: 3000}] =
                Message.return_route(message)
     end
   end

--- a/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
@@ -168,7 +168,7 @@ defmodule Ockam.Router.Tests do
     test "Simple TCP Test", %{printer_pid: printer} do
       message = %{
         onward_route: [
-          %TCPAddress{ip: {127, 0, 0, 1}, port: 4000},
+          %TCPAddress{host: {127, 0, 0, 1}, port: 4000},
           "printer"
         ],
         return_route: [],
@@ -208,7 +208,7 @@ defmodule Ockam.Router.Tests do
       request = %{
         onward_route: [
           "client_forwarder",
-          %TCPAddress{ip: {127, 0, 0, 1}, port: 5000},
+          %TCPAddress{host: {127, 0, 0, 1}, port: 5000},
           "echo"
         ],
         return_route: [],
@@ -232,7 +232,7 @@ defmodule Ockam.Router.Tests do
           %{
             onward_route: [
               "client_forwarder",
-              %TCPAddress{ip: {127, 0, 0, 1}, port: 5000},
+              %TCPAddress{host: {127, 0, 0, 1}, port: 5000},
               "echo"
             ],
             return_route: []
@@ -305,7 +305,7 @@ defmodule Ockam.Router.Tests do
       ## Initial request
       request = %{
         onward_route: [
-          %TCPAddress{ip: {127, 0, 0, 1}, port: 5001},
+          %TCPAddress{host: {127, 0, 0, 1}, port: 5001},
           "ping_pong_server"
         ],
         return_route: [

--- a/implementations/elixir/ockam/ockam/test/ockam/transport/tcp/address_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/transport/tcp/address_test.exs
@@ -11,12 +11,12 @@ defmodule Ockam.Transport.TCPAddress.Tests do
 
   describe "Ockam.Transport.TCPAddress" do
     test "1 is the TCP address type" do
-      address = %TCPAddress{ip: {127, 0, 0, 1}, port: 4000}
+      address = %TCPAddress{host: {127, 0, 0, 1}, port: 4000}
       assert 1 == Address.type(address)
     end
 
     test "can be serialized and then deserialized back to the original address" do
-      address = %TCPAddress{ip: {127, 0, 0, 1}, port: 4000}
+      address = %TCPAddress{host: {127, 0, 0, 1}, port: 4000}
 
       serialized = Ockam.Serializable.serialize(address)
       deserialized = TCPAddress.deserialize(serialized)
@@ -25,7 +25,7 @@ defmodule Ockam.Transport.TCPAddress.Tests do
     end
 
     test "Serializing an address produces expected binary" do
-      address = %TCPAddress{ip: {127, 0, 0, 1}, port: 4000}
+      address = %TCPAddress{host: {127, 0, 0, 1}, port: 4000}
 
       assert %{type: @tcp, value: <<0, 127, 0, 0, 1, 160, 15>>} ==
                Ockam.Serializable.serialize(address)
@@ -33,11 +33,11 @@ defmodule Ockam.Transport.TCPAddress.Tests do
 
     test "Deserializing an address produces expected struct" do
       serialized = [@localhost_binary, @four_thousand_encoded]
-      assert %TCPAddress{ip: {127, 0, 0, 1}, port: 4000} == TCPAddress.deserialize(serialized)
+      assert %TCPAddress{host: {127, 0, 0, 1}, port: 4000} == TCPAddress.deserialize(serialized)
     end
 
     test "Can serialize and deserialize string hostnames" do
-      address = %TCPAddress{ip: "hostname", port: 4000}
+      address = %TCPAddress{host: "hostname", port: 4000}
       serialized = Ockam.Serializable.serialize(address)
 
       assert %{type: @tcp, value: @hostname_binary} == serialized

--- a/implementations/elixir/ockam/ockam/test/ockam/transport/tcp/address_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/transport/tcp/address_test.exs
@@ -7,6 +7,7 @@ defmodule Ockam.Transport.TCPAddress.Tests do
   @tcp 1
   @four_thousand_encoded <<160, 15>>
   @localhost_binary <<0, 127, 0, 0, 1>>
+  @hostname_binary <<2, 8, 104, 111, 115, 116, 110, 97, 109, 101, 160, 15>>
 
   describe "Ockam.Transport.TCPAddress" do
     test "1 is the TCP address type" do
@@ -33,6 +34,17 @@ defmodule Ockam.Transport.TCPAddress.Tests do
     test "Deserializing an address produces expected struct" do
       serialized = [@localhost_binary, @four_thousand_encoded]
       assert %TCPAddress{ip: {127, 0, 0, 1}, port: 4000} == TCPAddress.deserialize(serialized)
+    end
+
+    test "Can serialize and deserialize string hostnames" do
+      address = %TCPAddress{ip: "hostname", port: 4000}
+      serialized = Ockam.Serializable.serialize(address)
+
+      assert %{type: @tcp, value: @hostname_binary} == serialized
+
+      deserialized = TCPAddress.deserialize(serialized)
+
+      assert address == deserialized
     end
   end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/wire/binary/v2_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/wire/binary/v2_test.exs
@@ -11,11 +11,11 @@ defmodule Ockam.Wire.Binary.V2.Tests do
 
       message = %{
         onward_route: [
-          %TCPAddress{ip: {a, b, c, d}, port: 4000},
+          %TCPAddress{host: {a, b, c, d}, port: 4000},
           "printer"
         ],
         return_route: [
-          %TCPAddress{ip: {a, b, c, d}, port: 3000}
+          %TCPAddress{host: {a, b, c, d}, port: 3000}
         ],
         payload: "hello"
       }
@@ -57,7 +57,7 @@ defmodule Ockam.Wire.Binary.V2.Tests do
 
       message = %{
         onward_route: [
-          %TCPAddress{ip: {a, b, c, d}, port: 4000}
+          %TCPAddress{host: {a, b, c, d}, port: 4000}
         ],
         return_route: [],
         payload: ""
@@ -117,7 +117,7 @@ defmodule Ockam.Wire.Binary.V2.Tests do
                 payload: payload
               }} = V2.decode(encoded)
 
-      assert [%Ockam.Transport.TCPAddress{ip: {^a, ^b, ^c, ^d}, port: 4000}] = onward_route
+      assert [%Ockam.Transport.TCPAddress{host: {^a, ^b, ^c, ^d}, port: 4000}] = onward_route
       assert [] = return_route
       assert "" = payload
     end


### PR DESCRIPTION
Implement serialization and connection using string hostnames in `TCPAddress`

The schema for address serialization if following:
```
type TCPAddress {
     host: ({:data, 4} | {:data, 16} | string) // ipv4, ipv6 or host
     port: :u16
}
```

This schema is compatible with the current format for TCP address serialization when using IP addresses.