### PR TITLE
feat(rust|websocket transport): remove ctx borrowing

### DIFF
--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
@@ -258,15 +258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes 1.0.1",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +401,7 @@ dependencies = [
  "hex",
  "rand",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
 ]
 
 [[package]]
@@ -431,7 +422,7 @@ dependencies = [
  "futures-util",
  "ockam_core",
  "ockam_node",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -632,15 +623,6 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
@@ -812,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
@@ -900,16 +882,15 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
  "base64",
  "byteorder",
  "bytes 1.0.1",
  "http",
  "httparse",
- "input_buffer",
  "log",
  "rand",
  "sha-1",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -24,11 +24,11 @@ std = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures-channel = "0.3.15"
-futures-util = { version = "0.3.15", default-features = false, features = ["tokio-io"] }
+futures-channel = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
 ockam_core = { path = "../ockam_core", version = "0.20.0-dev"               }
 ockam_node = { path = "../ockam_node", version = "0.18.0-dev"               }
-serde_bare = "0.3.0"
+serde_bare = "0.4.0"
 tokio = {version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"]}
-tokio-tungstenite = "0.14.0"
+tokio-tungstenite = "0.15"
 tracing = "0.1"

--- a/implementations/rust/ockam/ockam_transport_websocket/examples/client.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/examples/client.rs
@@ -39,7 +39,7 @@ fn get_peer_addr() -> String {
         .skip(1)
         .take(1)
         .next()
-        .unwrap_or(format!("127.0.0.1:10222"))
+        .unwrap_or_else(|| "127.0.0.1:10222".to_string())
 }
 
 async fn read_stdin(tx: futures_channel::mpsc::UnboundedSender<Vec<u8>>) {

--- a/implementations/rust/ockam/ockam_transport_websocket/examples/server.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/examples/server.rs
@@ -50,5 +50,5 @@ fn get_bind_addr() -> String {
         .skip(1)
         .take(1)
         .next()
-        .unwrap_or(format!("127.0.0.1:10222"))
+        .unwrap_or_else(|| "127.0.0.1:10222".to_string())
 }

--- a/implementations/rust/ockam/ockam_transport_websocket/src/init.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/init.rs
@@ -89,7 +89,7 @@ impl WorkerPair {
 /// the peer the worker is meant to be connected to.
 pub async fn start_connection(
     ctx: &Context,
-    router: &WebSocketRouterHandle<'_>,
+    router: &WebSocketRouterHandle,
     peer: WebSocketAddr,
 ) -> Result<()> {
     let pair = WorkerPair::start(ctx, peer).await?;

--- a/implementations/rust/ockam/ockam_transport_websocket/src/init.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/init.rs
@@ -67,8 +67,8 @@ impl WorkerPair {
         // Return a handle to the worker pair
         Ok(WorkerPair {
             peer,
-            rx_addr,
             tx_addr,
+            rx_addr,
             run,
         })
     }


### PR DESCRIPTION
Issue: https://github.com/ockam-network/ockam/issues/1549

Other changes:
- fix order of WorkerPair's address parameters (they were passed in the wrong order, thanks clippy :pray: )
- update some dependencies
