### PR TITLE
Select a version for `rand` in the examples.

### DIFF
--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 ockam = {path = "../../../implementations/rust/ockam/ockam", features = ["ockam_transport_tcp", "ockam_vault"]}
 
 [dev-dependencies]
-rand = { version = "*", features = ["std_rng"] }
+rand = { version = "0.8.4", features = ["std_rng"] }
 


### PR DESCRIPTION
### Proposed Changes

Explicitly specify the version of `rand` in the example crate.

---

Without this, when building the workspace I get the following error:

```
error: failed to select a version for `rand`.
    ... required by package `ockam_get_started v0.1.0 (/Users/thom/src/ockam/examples/rust/get_started)`
versions that meet the requirements `=0.7.3` are: 0.7.3

the package `ockam_get_started` depends on `rand`, with features: `std_rng` but `rand` does not have these features.

failed to select a version for `rand` which could resolve this conflict
```

Specifying the rand version fixes the error, and makes it clear which version of `rand` this is coded against. It also future-proofs it, in the case where `rand` has breaking changes in the 0.9 release (or some later semver-major release).