### PR TITLE
fix(rust): select a version for rand in the examples

### DIFF
--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 ockam = {path = "../../../implementations/rust/ockam/ockam", features = ["ockam_transport_tcp", "ockam_vault"]}
 
 [dev-dependencies]
-rand = { version = "*", features = ["std_rng"] }
+rand = { version = "0.8.4", features = ["std_rng"] }
 


### PR DESCRIPTION
Fixed up commit from https://github.com/ockam-network/ockam/pull/1553