### PR TITLE
feat(rust): inject vault into entity construction

### DIFF
--- a/examples/rust/get_started/Cargo.lock
+++ b/examples/rust/get_started/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.19.0"
+version = "0.20.0-dev"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.15.0"
+version = "0.16.0-dev"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.20.0"
+version = "0.21.0-dev"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "async-trait",
  "bls12_381_plus",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.12.0"
+version = "0.13.0-dev"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.12.0"
+version = "0.13.0-dev"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.18.0"
+version = "0.19.0-dev"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_attribute"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "quote",
  "syn",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.14.0"
+version = "0.15.0-dev"
 dependencies = [
  "async-trait",
  "futures",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.14.0"
+version = "0.15.0-dev"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.14.0"
+version = "0.15.0-dev"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.11.0"
+version = "0.12.0-dev"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1294,7 +1294,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.12.0"
+version = "0.13.0-dev"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.12.0"
+version = "0.13.0-dev"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
  "autocfg",
  "bytes",

--- a/examples/rust/get_started/examples/06-secure-channel-many-hops.rs
+++ b/examples/rust/get_started/examples/06-secure-channel-many-hops.rs
@@ -1,6 +1,6 @@
 // This node creates a secure channel with a listener that is multiple hops away.
 
-use ockam::{route, Context, Entity, NoOpTrustPolicy, Result, Route, SecureChannels};
+use ockam::{route, Context, Entity, NoOpTrustPolicy, Result, Route, SecureChannels, Vault};
 use ockam_get_started::{Echoer, Hop};
 
 #[ockam::node]
@@ -8,7 +8,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Start an Echoer worker at address "echoer"
     ctx.start_worker("echoer", Echoer).await?;
 
-    let mut bob = Entity::create(&ctx)?;
+    let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut bob = Entity::create(&ctx, &bob_vault)?;
 
     // Start 3 hop workers at addresses "h1", "h2" and "h3".
     ctx.start_worker("h1", Hop).await?;
@@ -22,7 +23,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     let route = route!["h1", "h2", "h3", "secure_channel_listener"];
 
     // Connect to the secure channel listener and perform a handshake.
-    let mut alice = Entity::create(&ctx)?;
+    let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut alice = Entity::create(&ctx, &alice_vault)?;
 
     let channel_to_bob = alice.create_secure_channel(route, NoOpTrustPolicy)?;
 

--- a/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-initiator.rs
+++ b/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-initiator.rs
@@ -2,7 +2,8 @@
 // It then routes a message, to a worker on a different node, through this encrypted channel.
 
 use ockam::{
-    route, Address, Context, Entity, NoOpTrustPolicy, Result, SecureChannels, TcpTransport, TCP,
+    route, Address, Context, Entity, NoOpTrustPolicy, Result, SecureChannels, TcpTransport, Vault,
+    TCP,
 };
 
 #[ockam::node]
@@ -13,7 +14,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Create a TCP connection.
     tcp.connect("127.0.0.1:3000").await?;
 
-    let mut alice = Entity::create(&ctx)?;
+    let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut alice = Entity::create(&ctx, &alice_vault)?;
     let middle: Address = (TCP, "127.0.0.1:3000").into();
     let responder: Address = (TCP, "127.0.0.1:4000").into();
     let route = route![middle, responder, "bob_secure_channel_listener"];

--- a/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-responder.rs
+++ b/examples/rust/get_started/examples/09-secure-channel-over-many-transport-hops-responder.rs
@@ -1,7 +1,7 @@
 // This node starts a tcp listener, a secure channel listener, and an echoer worker.
 // It then runs forever waiting for messages.
 
-use ockam::{Context, Entity, NoOpTrustPolicy, Result, SecureChannels, TcpTransport};
+use ockam::{Context, Entity, NoOpTrustPolicy, Result, SecureChannels, TcpTransport, Vault};
 use ockam_get_started::Echoer;
 
 #[ockam::node]
@@ -14,7 +14,8 @@ async fn main(ctx: Context) -> Result<()> {
     // Create a TCP listener and wait for incoming connections.
     tcp.listen("127.0.0.1:4000").await?;
 
-    let mut bob = Entity::create(&ctx)?;
+    let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut bob = Entity::create(&ctx, &bob_vault)?;
 
     // Create a secure channel listener at address "bob_secure_channel_listener"
     bob.create_secure_channel_listener("bob_secure_channel_listener", NoOpTrustPolicy)?;

--- a/examples/rust/get_started/examples/12-secure-channel-over-cloud-node-forwarding-initiator.rs
+++ b/examples/rust/get_started/examples/12-secure-channel-over-cloud-node-forwarding-initiator.rs
@@ -1,5 +1,6 @@
 use ockam::{
-    route, Address, Context, Entity, NoOpTrustPolicy, Result, SecureChannels, TcpTransport, TCP,
+    route, Address, Context, Entity, NoOpTrustPolicy, Result, SecureChannels, TcpTransport, Vault,
+    TCP,
 };
 
 #[ockam::node]
@@ -16,7 +17,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Create a TCP connection to your cloud node.
     tcp.connect(cloud_node_tcp_address).await?;
 
-    let mut alice = Entity::create(&ctx)?;
+    let vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut alice = Entity::create(&ctx, &vault)?;
     let cloud_node_address: Address = (TCP, cloud_node_tcp_address).into();
     let cloud_node_route = route![
         cloud_node_address,

--- a/examples/rust/get_started/examples/12-secure-channel-over-cloud-node-forwarding-responder.rs
+++ b/examples/rust/get_started/examples/12-secure-channel-over-cloud-node-forwarding-responder.rs
@@ -1,5 +1,5 @@
 use ockam::{
-    Context, Entity, NoOpTrustPolicy, RemoteForwarder, Result, SecureChannels, TcpTransport,
+    Context, Entity, NoOpTrustPolicy, RemoteForwarder, Result, SecureChannels, TcpTransport, Vault,
 };
 use ockam_get_started::Echoer;
 
@@ -16,7 +16,8 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;
-    let mut bob = Entity::create(&ctx)?;
+    let vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut bob = Entity::create(&ctx, &vault)?;
 
     // Create a secure channel listener at address "bob_secure_channel_listener"
     bob.create_secure_channel_listener("bob_secure_channel_listener", NoOpTrustPolicy)?;

--- a/examples/rust/get_started/examples/13-secure-channel-with-entity.rs
+++ b/examples/rust/get_started/examples/13-secure-channel-with-entity.rs
@@ -1,7 +1,7 @@
 // This node creates a secure channel and routes a message through it.
 
 use ockam::{
-    route, Address, Context, Entity, IdentifierTrustPolicy, Identity, Result, SecureChannels,
+    route, Address, Context, Entity, IdentifierTrustPolicy, Identity, Result, SecureChannels, Vault,
 };
 use ockam_get_started::Echoer;
 
@@ -10,10 +10,12 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Start an Echoer worker at address "echoer"
     ctx.start_worker("echoer", Echoer).await?;
 
-    let mut bob = Entity::create(&ctx)?;
+    let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut bob = Entity::create(&ctx, &bob_vault)?;
 
     // Connect to a secure channel listener and perform a handshake.
-    let mut alice = Entity::create(&ctx)?;
+    let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+    let mut alice = Entity::create(&ctx, &alice_vault)?;
 
     // WIP
 

--- a/implementations/rust/ockam/ockam_entity/examples/api.rs
+++ b/implementations/rust/ockam/ockam_entity/examples/api.rs
@@ -1,10 +1,13 @@
 use ockam_entity::Entity;
 use ockam_node::Context;
+use ockam_vault_sync_core::Vault;
 
 async fn test(ctx: Context) -> ockam_core::Result<()> {
-    let mut bob = Entity::create(&ctx)?;
+    let vault = Vault::create(&ctx).expect("failed to create vault");
 
-    let _home = bob.create_profile()?;
+    let mut bob = Entity::create(&ctx, &vault)?;
+
+    let _home = bob.create_profile(&vault)?;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_entity/src/authentication.rs
+++ b/implementations/rust/ockam/ockam_entity/src/authentication.rs
@@ -57,6 +57,7 @@ mod test {
     use crate::{Entity, Identity};
     use ockam_core::Error;
     use ockam_node::Context;
+    use ockam_vault_sync_core::Vault;
     use rand::{thread_rng, RngCore};
 
     fn test_error<S: Into<String>>(error: S) -> ockam_core::Result<()> {
@@ -64,13 +65,16 @@ mod test {
     }
 
     async fn test_auth_use_case(ctx: &Context) -> ockam_core::Result<()> {
+        let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+        let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+
         // Alice and Bob are distinct Entities.
-        let mut alice = Entity::create(&ctx)?;
-        let mut bob = Entity::create(&ctx)?;
+        let mut alice = Entity::create(&ctx, &alice_vault)?;
+        let mut bob = Entity::create(&ctx, &bob_vault)?;
 
         // Alice and Bob create unique profiles for a Chat app.
-        let mut alice_chat = alice.create_profile()?;
-        let mut bob_chat = bob.create_profile()?;
+        let mut alice_chat = alice.create_profile(&alice_vault)?;
+        let mut bob_chat = bob.create_profile(&bob_vault)?;
 
         // Alice and Bob create Contacts
         let alice_contact = alice_chat.as_contact()?;
@@ -104,13 +108,16 @@ mod test {
     }
 
     async fn test_key_rotation(ctx: &Context) -> ockam_core::Result<()> {
+        let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+        let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+
         // Alice and Bob are distinct Entities.
-        let mut alice = Entity::create(&ctx)?;
-        let mut bob = Entity::create(&ctx)?;
+        let mut alice = Entity::create(&ctx, &alice_vault)?;
+        let mut bob = Entity::create(&ctx, &bob_vault)?;
 
         // Alice and Bob create unique profiles for a Chat app.
-        let mut alice_chat = alice.create_profile()?;
-        let mut bob_chat = bob.create_profile()?;
+        let mut alice_chat = alice.create_profile(&alice_vault)?;
+        let mut bob_chat = bob.create_profile(&bob_vault)?;
 
         // Both profiles rotate keys.
         alice_chat.rotate_profile_key()?;
@@ -133,12 +140,15 @@ mod test {
     }
 
     async fn test_update_contact_and_reprove(ctx: &Context) -> ockam_core::Result<()> {
-        let mut alice = Entity::create(&ctx)?;
-        let mut bob = Entity::create(&ctx)?;
+        let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+        let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+
+        let mut alice = Entity::create(&ctx, &alice_vault)?;
+        let mut bob = Entity::create(&ctx, &bob_vault)?;
 
         // Alice and Bob create unique profiles for a Chat app.
-        let mut alice_chat = alice.create_profile()?;
-        let mut bob_chat = bob.create_profile()?;
+        let mut alice_chat = alice.create_profile(&alice_vault)?;
+        let mut bob_chat = bob.create_profile(&bob_vault)?;
 
         // Alice and Bob create Contacts
         let alice_contact = alice_chat.as_contact()?;

--- a/implementations/rust/ockam/ockam_entity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel.rs
@@ -80,14 +80,18 @@ mod test {
     use super::*;
     use crate::{Entity, SecureChannels};
     use ockam_core::{route, Message};
+    use ockam_vault_sync_core::Vault;
 
     #[test]
     fn disable_test_channel() {
         let (mut ctx, mut executor) = ockam_node::start_node();
         executor
             .execute(async move {
-                let mut alice = Entity::create(&ctx).unwrap();
-                let mut bob = Entity::create(&ctx).unwrap();
+                let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+                let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+
+                let mut alice = Entity::create(&ctx, &alice_vault).unwrap();
+                let mut bob = Entity::create(&ctx, &bob_vault).unwrap();
 
                 let alice_trust_policy = IdentifierTrustPolicy::new(bob.identifier().unwrap());
                 let bob_trust_policy = IdentifierTrustPolicy::new(alice.identifier().unwrap());

--- a/implementations/rust/ockam/ockam_entity/src/entity.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity.rs
@@ -33,9 +33,9 @@ impl Entity {
         self.handle.clone()
     }
 
-    pub fn create(node_ctx: &Context) -> Result<Entity> {
-        block_future(&node_ctx.runtime(), async move {
-            let ctx = node_ctx.new_context(Address::random(0)).await?;
+    pub fn create(ctx: &Context, vault_address: &Address) -> Result<Entity> {
+        block_future(&ctx.runtime(), async move {
+            let ctx = ctx.new_context(Address::random(0)).await?;
             let address = Address::random(0);
             ctx.start_worker(&address, EntityWorker::default()).await?;
 
@@ -44,7 +44,7 @@ impl Entity {
                 current_profile_id: None,
             };
 
-            let default_profile = entity.create_profile()?;
+            let default_profile = entity.create_profile(vault_address)?;
             entity.current_profile_id = Some(default_profile.identifier()?);
             Ok(entity)
         })
@@ -70,8 +70,8 @@ fn err<T>() -> Result<T> {
 }
 
 impl Entity {
-    pub fn create_profile(&mut self) -> Result<Profile> {
-        if let Res::CreateProfile(id) = self.call(CreateProfile)? {
+    pub fn create_profile(&mut self, vault_address: &Address) -> Result<Profile> {
+        if let Res::CreateProfile(id) = self.call(CreateProfile(vault_address.clone()))? {
             Ok(Profile::new(id, self.handle.clone()))
         } else {
             err()

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -168,6 +168,7 @@ impl ProfileSerializationUtil {
 mod test {
     use super::*;
     use ockam_core::Error;
+    use ockam_vault_sync_core::Vault;
 
     fn test_error<S: Into<String>>(msg: S) -> Result<()> {
         Err(Error::new(0, msg.into()))
@@ -246,8 +247,11 @@ mod test {
         let (mut ctx, mut executor) = ockam_node::start_node();
         executor
             .execute(async move {
-                let mut entity_alice = Entity::create(&ctx).unwrap();
-                let mut entity_bob = Entity::create(&ctx).unwrap();
+                let alice_vault = Vault::create(&ctx).expect("failed to create vault");
+                let bob_vault = Vault::create(&ctx).expect("failed to create vault");
+
+                let mut entity_alice = Entity::create(&ctx, &alice_vault).unwrap();
+                let mut entity_bob = Entity::create(&ctx, &bob_vault).unwrap();
 
                 let mut alice = entity_alice.current_profile().unwrap();
                 let mut bob = entity_bob.current_profile().unwrap();

--- a/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
@@ -10,7 +10,7 @@ use ockam_core::{
     Address, Result, Routed, Worker,
 };
 use ockam_node::Context;
-use ockam_vault_sync_core::{Vault, VaultSync};
+use ockam_vault_sync_core::VaultSync;
 
 #[derive(Default)]
 pub struct EntityWorker {
@@ -42,9 +42,8 @@ impl Worker for EntityWorker {
         let reply = msg.return_route();
         let req = msg.body();
         match req {
-            CreateProfile => {
-                let vault = Vault::create(ctx).expect("failed to create EntityWorker vault");
-                let vault_sync = VaultSync::create_with_worker(ctx, &vault)
+            CreateProfile(vault_address) => {
+                let vault_sync = VaultSync::create_with_worker(ctx, &vault_address)
                     .expect("couldn't create profile vault");
 
                 let profile_state =

--- a/implementations/rust/ockam/ockam_entity/src/worker/request.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/request.rs
@@ -14,7 +14,7 @@ pub type Id = ProfileIdentifier;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub enum IdentityRequest {
-    CreateProfile,
+    CreateProfile(Address),
     CreateAuthenticationProof(Id, ByteVec),
     CreateKey(Id, String),
     GetProfilePublicKey(Id),


### PR DESCRIPTION
This inverts control of Vault construction, moving it outside of the entity lifecycle.

`Entity::create` now takes the address of a Vault. Examples and tests have been updated to create explicit software vaults to use with Entities.
