### PR TITLE
feat: support named aliases for forwarding with a new alias_service

### DIFF
--- a/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-initiator.rs
+++ b/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-initiator.rs
@@ -9,7 +9,7 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Run 11-forwarding-via-a-cloud-node-responder,
     // it will print the forwarding address of echoer on your cloud node
-    let echoer_forwarding_address = "forward_here";
+    let echoer_forwarding_address = "ALIAS_forward_here";
 
     // Initialize the TCP Transport.
     let tcp = TcpTransport::create(&ctx).await?;

--- a/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-initiator.rs
+++ b/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-initiator.rs
@@ -9,7 +9,7 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Run 11-forwarding-via-a-cloud-node-responder,
     // it will print the forwarding address of echoer on your cloud node
-    let echoer_forwarding_address = "Paste the forwarding address of the echoer here.";
+    let echoer_forwarding_address = "forward_here";
 
     // Initialize the TCP Transport.
     let tcp = TcpTransport::create(&ctx).await?;

--- a/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-responder.rs
+++ b/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-responder.rs
@@ -15,7 +15,10 @@ async fn main(ctx: Context) -> Result<()> {
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;
 
-    let forwarder = RemoteForwarder::create_named(&ctx, cloud_node_tcp_address, "echoer", "forward_here").await?;
+    let alias = "forward_here";
+
+    RemoteForwarder::delete_named(&ctx, cloud_node_tcp_address, alias).await?;
+    let forwarder = RemoteForwarder::create_named(&ctx, cloud_node_tcp_address, "echoer", alias).await?;
     println!(
         "Forwarding address of echoer: {}",
         forwarder.remote_address()

--- a/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-responder.rs
+++ b/examples/rust/get_started/examples/11-forwarding-via-a-cloud-node-responder.rs
@@ -15,7 +15,7 @@ async fn main(ctx: Context) -> Result<()> {
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;
 
-    let forwarder = RemoteForwarder::create(&ctx, cloud_node_tcp_address, "echoer").await?;
+    let forwarder = RemoteForwarder::create_named(&ctx, cloud_node_tcp_address, "echoer", "forward_here").await?;
     println!(
         "Forwarding address of echoer: {}",
         forwarder.remote_address()

--- a/implementations/elixir/ockam/ockam/lib/ockam/protocol/protocol.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/protocol/protocol.ex
@@ -76,7 +76,7 @@ defmodule Ockam.Protocol do
         decode(protocol_mod, direction, protocol_data)
 
       other ->
-        raise("Decode error: #{other}")
+        {:error, {:base_decode_failed, other}}
     end
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
@@ -8,6 +8,7 @@ defmodule Ockam.Hub.Service.Provider.Routing do
 
   alias Ockam.Hub.Service.Echo, as: EchoService
   alias Ockam.Hub.Service.Forwarding, as: ForwardingService
+  alias Ockam.Hub.Service.Alias, as: AliasService
 
   @services [:echo, :forwarding]
 
@@ -23,6 +24,14 @@ defmodule Ockam.Hub.Service.Provider.Routing do
   end
 
   def start_service(:forwarding, args) do
-    ForwardingService.create(Keyword.merge([address: "forwarding_service"], args))
+    alias_result = AliasService.create(Keyword.merge([address: "alias_service"], args))
+    forwarding_result = ForwardingService.create(Keyword.merge([address: "forwarding_service"], args))
+
+    case {forwarding_result, alias_result} do
+      {{:ok, fr}, {:ok, ar}} ->
+        {:ok, {fr, ar}}
+      {fr, ar} ->
+        {:error, [forwarding: fr, alias: ar]}
+    end
   end
 end


### PR DESCRIPTION
Alias service protocol:
in: :string - name of the alias
out: :string - "OK" or "ERROR" (ERROR basically means the name is already taken)

There are changes in `RemoteForwarder` rust code to support named aliases. 

@SanjoDeundiak @jared-s I used a simple copy-paste, please review and update the Rust code if needed.