### PR TITLE
fix(rust): include stddef.h in ockam_ffi/include/vault.h

### DIFF
--- a/implementations/rust/ockam/ockam_ffi/include/vault.h
+++ b/implementations/rust/ockam/ockam_ffi/include/vault.h
@@ -3,6 +3,7 @@
 #ifndef RUST_VAULT_H
 #define RUST_VAULT_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Proposed Changes

Add `#include <stddef.h>` to `ockam_ffi/include/vault.h`.

This is a very minor issue I noticed when flipping through files. In order to get `size_t`, which is used all over the place in that code, you should import `stddef.h`. On some platforms, `stdint.h` will itself include `stddef.h`, which means the include probably works on many targets.

This isn't guaranteed though, and at least on my machine (on macOS), it doesn't appear to be the case.