### PR TITLE
feat(elixir): add tracing service to trace payloads

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/runtime.exs
@@ -192,7 +192,8 @@ config :ockam_hub,
     :pub_sub,
     :stream,
     :stream_index,
-    :secure_channel
+    :secure_channel,
+    :tracing
   ]
 
 cleanup_crontab = System.get_env("CLEANUP_CRONTAB")

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
@@ -9,8 +9,9 @@ defmodule Ockam.Hub.Service.Provider.Routing do
   alias Ockam.Hub.Service.Echo, as: EchoService
   alias Ockam.Hub.Service.Forwarding, as: ForwardingService
   alias Ockam.Hub.Service.PubSub, as: PubSubService
+  alias Ockam.Hub.Service.Tracing, as: TracingService
 
-  @services [:echo, :forwarding, :pub_sub]
+  @services [:echo, :forwarding, :pub_sub, :tracing]
 
   @impl true
   def services() do
@@ -31,6 +32,10 @@ defmodule Ockam.Hub.Service.Provider.Routing do
     PubSubService.create(Keyword.merge([address: "pub_sub_service", prefix: "pub_sub_t"], args))
   end
 
+  def start_service(:tracing, args) do
+    TracingService.create(Keyword.merge([address: "tracing_service"], args))
+  end
+
   @impl true
   def child_spec(:echo, args) do
     {EchoService, Keyword.merge([address: "echo_service"], args)}
@@ -42,5 +47,9 @@ defmodule Ockam.Hub.Service.Provider.Routing do
 
   def child_spec(:pub_sub, args) do
     {PubSubService, Keyword.merge([address: "pub_sub_service", prefix: "pub_sub_t"], args)}
+  end
+
+  def child_spec(:tracing, args) do
+    {TracingService, Keyword.merge([address: "tracing_service"], args)}
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/tracing.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/tracing.ex
@@ -1,0 +1,98 @@
+defmodule Ockam.Hub.Service.Tracing do
+  @moduledoc """
+  Tracing service.
+
+  Create watchers - workers to intercept traffic
+
+  Watchers will forward all traffic without changes
+  but send a copy of the payload to the tracing route.
+  """
+
+  use Ockam.Worker
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  require Logger
+
+  @impl true
+  def handle_message(message, state) do
+    Logger.info("TRACING service\nMESSAGE: #{inspect(message)}")
+    tracing_route = Message.return_route(message)
+    payload = Message.payload(message)
+
+    {:ok, _alias_address} =
+      __MODULE__.Watcher.create(
+        tracing_route: tracing_route,
+        reply: payload
+      )
+
+    {:ok, state}
+  end
+end
+
+defmodule Ockam.Hub.Service.Tracing.Watcher do
+  @moduledoc """
+  Tracing watcher.
+
+  Upon creation sends a message to the tracing_route to communicate its address
+
+  On message will send a copy of the payload to the tracing_route
+  """
+
+  use Ockam.Worker
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  require Logger
+
+  @impl true
+  def setup(options, state) do
+    Logger.info("Created new watcher for #{inspect(options)}")
+    tracing_route = Keyword.fetch!(options, :tracing_route)
+    reply = Keyword.fetch!(options, :reply)
+
+    state = Map.put(state, :tracing_route, tracing_route)
+
+    Logger.info("REGISTER OK: #{inspect(reply)}")
+    send_trace(reply, state)
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_message(message, state) do
+    route_further(message, state)
+
+    Logger.info("Tracing #{inspect(message)} to #{inspect(state.tracing_route)}")
+    send_trace(Message.payload(message), state)
+
+    {:ok, state}
+  end
+
+  def route_further(message, %{address: address}) do
+    ## TODO: use helpers for those things
+    onward_route =
+      case Message.onward_route(message) do
+        [^address | onward_route] -> onward_route
+        onward_route -> onward_route
+      end
+
+    req = %{
+      onward_route: onward_route,
+      return_route: [address | Message.return_route(message)],
+      payload: Message.payload(message)
+    }
+
+    Router.route(req)
+  end
+
+  def send_trace(payload, %{tracing_route: tracing_route, address: address}) do
+    Router.route(%{
+      onward_route: tracing_route,
+      return_route: [address],
+      payload: payload
+    })
+  end
+end

--- a/implementations/elixir/ockam/ockam_hub/test/hub/service/tracing_test.exs
+++ b/implementations/elixir/ockam/ockam_hub/test/hub/service/tracing_test.exs
@@ -1,0 +1,46 @@
+defmodule Test.Hub.Service.TracingTest do
+  use ExUnit.Case
+
+  alias Ockam.Router
+  alias Test.Utils
+
+  test "trace payloads" do
+    Ockam.Hub.Service.Tracing.create(address: "tracing_service")
+    Ockam.Hub.Service.Echo.create(address: "echo_service")
+    Ockam.Node.register_address("TEST", self())
+
+    Ockam.Router.route(%{
+      onward_route: ["tracing_service"],
+      return_route: ["TEST"],
+      payload: "register"
+    })
+
+    tracing_address =
+      receive do
+        %{payload: "register", return_route: [tracing_address]} -> tracing_address
+      after
+        5000 ->
+          exit("Cannot register tracing address")
+      end
+
+    payload = "Hello!"
+    echo_request = %{onward_route: [tracing_address, "echo_service"], payload: payload}
+    echo_reply = Ockam.Workers.Call.call(echo_request)
+
+    # Receive outgoing message
+    receive do
+      %{payload: ^payload} -> :ok
+    after
+      5000 ->
+        exit("Timeout receiving trace message")
+    end
+
+    # Receive reply message
+    receive do
+      %{payload: ^payload} -> :ok
+    after
+      5000 ->
+        exit("Timeout receiving trace message")
+    end
+  end
+end


### PR DESCRIPTION
### Proposed Changes

Add a new service to trace messages going through the Hub.

A tracing address is registered same way as forwarding address
Registered tracing address worker copies payloads to the registered route