### PR TITLE
feat(rust): add threshold bls signing

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -344,9 +344,9 @@ checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -369,15 +369,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -386,15 +386,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -405,21 +405,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -1032,9 +1032,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1343,6 +1343,7 @@ dependencies = [
  "serde",
  "sha2",
  "subtle",
+ "vsss-rs",
  "zeroize",
 ]
 
@@ -1612,6 +1613,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
+dependencies = [
+ "ff",
+ "group",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.lock
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -509,6 +509,7 @@ dependencies = [
  "serde",
  "sha2",
  "subtle",
+ "vsss-rs",
  "zeroize",
 ]
 
@@ -608,6 +609,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
+dependencies = [
+ "ff",
+ "group",
+ "rand_chacha",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.11.0 - 2021-07-23
+### Added
+- PartialSignature
+- PartialSignatureVt
+- SecretKeyShare
+- SecretKey::split
+- SecretKey::combine
+- Signature::from_partials
+- SignatureVt::from_partials
+- Fix clippy errors
+- Implement format display for existing primitives
+
 ## v0.10.0 - 2021-07-19
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/signature_bls/Cargo.lock
+++ b/implementations/rust/ockam/signature_bls/Cargo.lock
@@ -242,10 +242,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.27"
+name = "ppv-lite86"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -264,6 +270,16 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -351,6 +367,7 @@ dependencies = [
  "serde",
  "sha2",
  "subtle",
+ "vsss-rs",
  "zeroize",
 ]
 
@@ -432,6 +449,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
+dependencies = [
+ "ff",
+ "group",
+ "rand_chacha",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -26,6 +26,7 @@ rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.4", default-features = false }
+vsss-rs = { version = "1.0.0", default-features = false }
 zeroize = { version = "1.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/signature_bls/src/aggregate_signature.rs
+++ b/implementations/rust/ockam/signature_bls/src/aggregate_signature.rs
@@ -1,6 +1,9 @@
 use crate::{PublicKey, Signature};
 use bls12_381_plus::{G1Affine, G1Projective, G2Affine};
-use core::ops::{BitOr, Neg, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Neg, Not},
+};
 use group::{Curve, Group};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -8,6 +11,12 @@ use subtle::{Choice, CtOption};
 /// Represents a BLS signature in G1 for multiple signatures that signed the different messages
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AggregateSignature(pub(crate) G1Projective);
+
+impl Display for AggregateSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl Default for AggregateSignature {
     fn default() -> Self {
@@ -121,7 +130,7 @@ impl AggregateSignature {
     }
 
     /// Get the byte sequence that represents this aggregated signature
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/aggregate_signature_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/aggregate_signature_vt.rs
@@ -1,6 +1,9 @@
 use crate::{PublicKeyVt, SignatureVt};
 use bls12_381_plus::{G1Affine, G2Affine, G2Projective};
-use core::ops::{BitOr, Neg, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Neg, Not},
+};
 use group::{Curve, Group};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -8,6 +11,12 @@ use subtle::{Choice, CtOption};
 /// Represents a BLS signature in G1 for multiple signatures that signed the different messages
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AggregateSignatureVt(pub(crate) G2Projective);
+
+impl Display for AggregateSignatureVt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl Default for AggregateSignatureVt {
     fn default() -> Self {
@@ -121,7 +130,7 @@ impl AggregateSignatureVt {
     }
 
     /// Get the byte sequence that represents this aggregated signature
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/lib.rs
+++ b/implementations/rust/ockam/signature_bls/src/lib.rs
@@ -18,7 +18,6 @@
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
     unused_qualifications,
     warnings
@@ -33,11 +32,14 @@ mod multi_public_key;
 mod multi_public_key_vt;
 mod multi_signature;
 mod multi_signature_vt;
+mod partial_signature;
+mod partial_signature_vt;
 mod proof_of_possession;
 mod proof_of_possession_vt;
 mod public_key;
 mod public_key_vt;
 mod secret_key;
+mod secret_key_share;
 mod signature;
 mod signature_vt;
 
@@ -47,13 +49,17 @@ pub use multi_public_key::*;
 pub use multi_public_key_vt::*;
 pub use multi_signature::*;
 pub use multi_signature_vt::*;
+pub use partial_signature::*;
+pub use partial_signature_vt::*;
 pub use proof_of_possession::*;
 pub use proof_of_possession_vt::*;
 pub use public_key::*;
 pub use public_key_vt::*;
 pub use secret_key::*;
+pub use secret_key_share::*;
 pub use signature::*;
 pub use signature_vt::*;
+pub use vsss_rs::Error;
 
 #[cfg(test)]
 pub struct MockRng(rand_xorshift::XorShiftRng);

--- a/implementations/rust/ockam/signature_bls/src/multi_public_key.rs
+++ b/implementations/rust/ockam/signature_bls/src/multi_public_key.rs
@@ -1,6 +1,9 @@
 use crate::PublicKey;
 use bls12_381_plus::{G2Affine, G2Projective};
-use core::ops::{BitOr, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
 use group::Curve;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -16,6 +19,12 @@ impl From<&[PublicKey]> for MultiPublicKey {
             g += k.0;
         }
         Self(g)
+    }
+}
+
+impl Display for MultiPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -59,7 +68,7 @@ impl MultiPublicKey {
     }
 
     /// Get the byte representation of this key
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/multi_public_key_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/multi_public_key_vt.rs
@@ -1,6 +1,9 @@
 use crate::PublicKeyVt;
 use bls12_381_plus::{G1Affine, G1Projective};
-use core::ops::{BitOr, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
 use group::Curve;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -16,6 +19,12 @@ impl From<&[PublicKeyVt]> for MultiPublicKeyVt {
             g += k.0;
         }
         Self(g)
+    }
+}
+
+impl Display for MultiPublicKeyVt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -59,7 +68,7 @@ impl MultiPublicKeyVt {
     }
 
     /// Get the byte representation of this key
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/multi_signature.rs
+++ b/implementations/rust/ockam/signature_bls/src/multi_signature.rs
@@ -1,6 +1,9 @@
 use crate::{MultiPublicKey, PublicKey, Signature};
 use bls12_381_plus::{G1Affine, G1Projective};
-use core::ops::{BitOr, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
 use group::Curve;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -12,6 +15,12 @@ pub struct MultiSignature(pub(crate) G1Projective);
 impl Default for MultiSignature {
     fn default() -> Self {
         Self(G1Projective::identity())
+    }
+}
+
+impl Display for MultiSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -64,7 +73,7 @@ impl MultiSignature {
     }
 
     /// Get the byte sequence that represents this multisignature
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/multi_signature_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/multi_signature_vt.rs
@@ -1,6 +1,9 @@
 use crate::{MultiPublicKeyVt, PublicKeyVt, SignatureVt};
 use bls12_381_plus::{G2Affine, G2Projective};
-use core::ops::{BitOr, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
 use group::Curve;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -12,6 +15,12 @@ pub struct MultiSignatureVt(pub(crate) G2Projective);
 impl Default for MultiSignatureVt {
     fn default() -> Self {
         Self(G2Projective::identity())
+    }
+}
+
+impl Display for MultiSignatureVt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -64,7 +73,7 @@ impl MultiSignatureVt {
     }
 
     /// Get the byte sequence that represents this multiSignatureVt
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/partial_signature.rs
+++ b/implementations/rust/ockam/signature_bls/src/partial_signature.rs
@@ -1,0 +1,115 @@
+use crate::{SecretKeyShare, Signature};
+use bls12_381_plus::{G1Affine, G1Projective, Scalar};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
+use group::Curve;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use subtle::Choice;
+use vsss_rs::Share;
+
+/// Represents a BLS partial signature in G1 using the proof of possession scheme
+#[derive(Clone, Copy, Debug)]
+pub struct PartialSignature(pub(crate) Share<PARTIAL_SIGNATURE_BYTES>);
+
+impl Default for PartialSignature {
+    fn default() -> Self {
+        Self(Share::default())
+    }
+}
+
+impl Display for PartialSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in &self.0 .0 {
+            b.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Share<PARTIAL_SIGNATURE_BYTES>> for PartialSignature {
+    fn from(share: Share<PARTIAL_SIGNATURE_BYTES>) -> Self {
+        Self(share)
+    }
+}
+
+impl<'a> From<&'a Share<PARTIAL_SIGNATURE_BYTES>> for PartialSignature {
+    fn from(share: &'a Share<PARTIAL_SIGNATURE_BYTES>) -> Self {
+        Self(*share)
+    }
+}
+
+impl Serialize for PartialSignature {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for PartialSignature {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let p = Share::<PARTIAL_SIGNATURE_BYTES>::deserialize(d)?;
+        Ok(Self(p))
+    }
+}
+
+impl PartialSignature {
+    /// Number of bytes needed to represent the signature
+    pub const BYTES: usize = PARTIAL_SIGNATURE_BYTES;
+
+    /// Create a new bls
+    pub fn new<B: AsRef<[u8]>>(sk: &SecretKeyShare, msg: B) -> Option<Self> {
+        if sk.is_zero() {
+            return None;
+        }
+        let a = Signature::hash_msg(msg.as_ref());
+        let t = <[u8; 32]>::try_from(sk.0.value()).unwrap();
+        let res = Scalar::from_bytes(&t).map(|s| {
+            let point = a * s;
+            let mut bytes = [0u8; PARTIAL_SIGNATURE_BYTES];
+            bytes[1..].copy_from_slice(&point.to_affine().to_compressed());
+            bytes[0] = sk.0.identifier();
+            Some(PartialSignature(Share(bytes)))
+        });
+        if res.is_some().unwrap_u8() == 1 {
+            res.unwrap()
+        } else {
+            None
+        }
+    }
+
+    /// Check if this partial signature is valid
+    pub fn is_valid(&self) -> Choice {
+        let t: [u8; 48] = <[u8; 48]>::try_from(self.0.value()).unwrap();
+        let p = G1Affine::from_compressed(&t).map(G1Projective::from);
+        p.map(|v| v.is_identity().not().bitor(v.is_on_curve()))
+            .unwrap_or_else(|| Choice::from(0u8))
+    }
+
+    /// Check if this partial signature is invalid
+    pub fn is_invalid(&self) -> Choice {
+        let t: [u8; 48] = <[u8; 48]>::try_from(self.0.value()).unwrap();
+        let p = G1Affine::from_compressed(&t).map(G1Projective::from);
+        p.map(|v| v.is_identity().bitor(v.is_on_curve().not()))
+            .unwrap_or_else(|| Choice::from(0u8))
+    }
+
+    /// Get the byte sequence that represents this partial signature
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
+        self.0 .0
+    }
+
+    /// Convert a big-endian representation of the partial signature
+    pub fn from_bytes(bytes: &[u8; Self::BYTES]) -> Self {
+        Self(Share(*bytes))
+    }
+}
+
+pub(crate) const PARTIAL_SIGNATURE_BYTES: usize = 49;

--- a/implementations/rust/ockam/signature_bls/src/partial_signature_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/partial_signature_vt.rs
@@ -1,0 +1,115 @@
+use crate::{SecretKeyShare, SignatureVt};
+use bls12_381_plus::{G2Affine, G2Projective, Scalar};
+use core::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
+use group::Curve;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use subtle::Choice;
+use vsss_rs::Share;
+
+/// Represents a BLS partial signature in G2 using the proof of possession scheme
+#[derive(Clone, Copy, Debug)]
+pub struct PartialSignatureVt(pub(crate) Share<PARTIAL_SIGNATURE_VT_BYTES>);
+
+impl Default for PartialSignatureVt {
+    fn default() -> Self {
+        Self(Share::default())
+    }
+}
+
+impl Display for PartialSignatureVt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in &self.0 .0 {
+            b.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Share<PARTIAL_SIGNATURE_VT_BYTES>> for PartialSignatureVt {
+    fn from(share: Share<PARTIAL_SIGNATURE_VT_BYTES>) -> Self {
+        Self(share)
+    }
+}
+
+impl<'a> From<&'a Share<PARTIAL_SIGNATURE_VT_BYTES>> for PartialSignatureVt {
+    fn from(share: &'a Share<PARTIAL_SIGNATURE_VT_BYTES>) -> Self {
+        Self(*share)
+    }
+}
+
+impl Serialize for PartialSignatureVt {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for PartialSignatureVt {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let p = Share::<PARTIAL_SIGNATURE_VT_BYTES>::deserialize(d)?;
+        Ok(Self(p))
+    }
+}
+
+impl PartialSignatureVt {
+    /// Number of bytes needed to represent the signature
+    pub const BYTES: usize = PARTIAL_SIGNATURE_VT_BYTES;
+
+    /// Create a new bls
+    pub fn new<B: AsRef<[u8]>>(sk: &SecretKeyShare, msg: B) -> Option<Self> {
+        if sk.is_zero() {
+            return None;
+        }
+        let a = SignatureVt::hash_msg(msg.as_ref());
+        let t = <[u8; 32]>::try_from(sk.0.value()).unwrap();
+        let res = Scalar::from_bytes(&t).map(|s| {
+            let point = a * s;
+            let mut bytes = [0u8; PARTIAL_SIGNATURE_VT_BYTES];
+            bytes[1..].copy_from_slice(&point.to_affine().to_compressed());
+            bytes[0] = sk.0.identifier();
+            Some(PartialSignatureVt(Share(bytes)))
+        });
+        if res.is_some().unwrap_u8() == 1 {
+            res.unwrap()
+        } else {
+            None
+        }
+    }
+
+    /// Check if this partial signature is valid
+    pub fn is_valid(&self) -> Choice {
+        let t: [u8; 96] = <[u8; 96]>::try_from(self.0.value()).unwrap();
+        let p = G2Affine::from_compressed(&t).map(G2Projective::from);
+        p.map(|v| v.is_identity().not().bitor(v.is_on_curve()))
+            .unwrap_or_else(|| Choice::from(0u8))
+    }
+
+    /// Check if this partial signature is invalid
+    pub fn is_invalid(&self) -> Choice {
+        let t: [u8; 96] = <[u8; 96]>::try_from(self.0.value()).unwrap();
+        let p = G2Affine::from_compressed(&t).map(G2Projective::from);
+        p.map(|v| v.is_identity().bitor(v.is_on_curve().not()))
+            .unwrap_or_else(|| Choice::from(0u8))
+    }
+
+    /// Get the byte sequence that represents this partial signature
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
+        self.0 .0
+    }
+
+    /// Convert a big-endian representation of the partial signature
+    pub fn from_bytes(bytes: &[u8; Self::BYTES]) -> Self {
+        Self(Share(*bytes))
+    }
+}
+
+pub(crate) const PARTIAL_SIGNATURE_VT_BYTES: usize = 97;

--- a/implementations/rust/ockam/signature_bls/src/proof_of_possession.rs
+++ b/implementations/rust/ockam/signature_bls/src/proof_of_possession.rs
@@ -2,7 +2,10 @@ use crate::{PublicKey, SecretKey};
 use bls12_381_plus::{
     multi_miller_loop, ExpandMsgXmd, G1Affine, G1Projective, G2Affine, G2Prepared,
 };
-use core::ops::Neg;
+use core::{
+    fmt::{self, Display},
+    ops::Neg,
+};
 use ff::Field;
 use group::{Curve, Group};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -15,6 +18,12 @@ pub struct ProofOfPossession(pub(crate) G1Projective);
 impl Default for ProofOfPossession {
     fn default() -> Self {
         Self(G1Projective::identity())
+    }
+}
+
+impl Display for ProofOfPossession {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -70,7 +79,7 @@ impl ProofOfPossession {
     }
 
     /// Get the byte sequence that represents this proof
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/proof_of_possession_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/proof_of_possession_vt.rs
@@ -2,7 +2,10 @@ use crate::{PublicKeyVt, SecretKey};
 use bls12_381_plus::{
     multi_miller_loop, ExpandMsgXmd, G1Affine, G2Affine, G2Prepared, G2Projective,
 };
-use core::ops::Neg;
+use core::{
+    fmt::{self, Display},
+    ops::Neg,
+};
 use ff::Field;
 use group::{Curve, Group};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -15,6 +18,12 @@ pub struct ProofOfPossessionVt(pub(crate) G2Projective);
 impl Default for ProofOfPossessionVt {
     fn default() -> Self {
         Self(G2Projective::identity())
+    }
+}
+
+impl Display for ProofOfPossessionVt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -70,7 +79,7 @@ impl ProofOfPossessionVt {
     }
 
     /// Get the byte sequence that represents this proof
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/public_key.rs
+++ b/implementations/rust/ockam/signature_bls/src/public_key.rs
@@ -1,6 +1,9 @@
 use super::SecretKey;
 use bls12_381_plus::{G2Affine, G2Projective};
-use core::ops::{BitOr, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
 use group::Curve;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -12,6 +15,12 @@ pub struct PublicKey(pub G2Projective);
 impl Default for PublicKey {
     fn default() -> Self {
         Self(G2Projective::identity())
+    }
+}
+
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -67,7 +76,7 @@ impl PublicKey {
     }
 
     /// Get the byte representation of this key
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/public_key_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/public_key_vt.rs
@@ -1,6 +1,9 @@
 use super::SecretKey;
 use bls12_381_plus::{G1Affine, G1Projective};
-use core::ops::{BitOr, Not};
+use core::{
+    fmt::{self, Display},
+    ops::{BitOr, Not},
+};
 use group::Curve;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::{Choice, CtOption};
@@ -12,6 +15,12 @@ pub struct PublicKeyVt(pub G1Projective);
 impl Default for PublicKeyVt {
     fn default() -> Self {
         Self(G1Projective::identity())
+    }
+}
+
+impl Display for PublicKeyVt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -67,7 +76,7 @@ impl PublicKeyVt {
     }
 
     /// Get the byte representation of this key
-    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+    pub fn to_bytes(self) -> [u8; Self::BYTES] {
         self.0.to_affine().to_compressed()
     }
 

--- a/implementations/rust/ockam/signature_bls/src/secret_key_share.rs
+++ b/implementations/rust/ockam/signature_bls/src/secret_key_share.rs
@@ -1,0 +1,104 @@
+use core::fmt::{self, Display};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use vsss_rs::Share;
+use zeroize::Zeroize;
+
+/// A secret key share is field element 0 < `x` < `r`
+/// where `r` is the curve order. See Section 4.3 in
+/// <https://eprint.iacr.org/2016/663.pdf>
+/// Must be combined with other secret key shares
+/// to produce the completed key, or used for
+/// creating partial signatures which can be
+/// combined into a complete signature
+#[derive(Clone, Debug, Zeroize)]
+pub struct SecretKeyShare(pub Share<SECRET_KEY_SHARE_BYTES>);
+
+impl Drop for SecretKeyShare {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl From<Share<SECRET_KEY_SHARE_BYTES>> for SecretKeyShare {
+    fn from(share: Share<SECRET_KEY_SHARE_BYTES>) -> Self {
+        Self(share)
+    }
+}
+
+impl<'a> From<&'a Share<SECRET_KEY_SHARE_BYTES>> for SecretKeyShare {
+    fn from(share: &'a Share<SECRET_KEY_SHARE_BYTES>) -> Self {
+        Self(*share)
+    }
+}
+
+impl Default for SecretKeyShare {
+    fn default() -> Self {
+        Self(Share::default())
+    }
+}
+
+impl Display for SecretKeyShare {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in &self.0 .0 {
+            b.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<SecretKeyShare> for [u8; SecretKeyShare::BYTES] {
+    fn from(sk: SecretKeyShare) -> [u8; SecretKeyShare::BYTES] {
+        sk.to_bytes()
+    }
+}
+
+impl<'a> From<&'a SecretKeyShare> for [u8; SecretKeyShare::BYTES] {
+    fn from(sk: &'a SecretKeyShare) -> [u8; SecretKeyShare::BYTES] {
+        sk.to_bytes()
+    }
+}
+
+impl Serialize for SecretKeyShare {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretKeyShare {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let share = Share::<SECRET_KEY_SHARE_BYTES>::deserialize(d)?;
+        Ok(Self(share))
+    }
+}
+
+impl SecretKeyShare {
+    /// Number of bytes needed to represent the secret key
+    pub const BYTES: usize = SECRET_KEY_SHARE_BYTES;
+
+    /// Is this share zero
+    pub fn is_zero(&self) -> bool {
+        let mut r = 0u8;
+        for b in self.0.value() {
+            r |= *b;
+        }
+        r == 0
+    }
+
+    /// Get the byte representation of this key
+    pub fn to_bytes(&self) -> [u8; Self::BYTES] {
+        self.0 .0
+    }
+
+    /// Convert a big-endian representation of the secret key.
+    pub fn from_bytes(bytes: &[u8; Self::BYTES]) -> Self {
+        Self(Share(*bytes))
+    }
+}
+
+pub(crate) const SECRET_KEY_SHARE_BYTES: usize = 33;

--- a/implementations/rust/ockam/signature_core/Cargo.lock
+++ b/implementations/rust/ockam/signature_core/Cargo.lock
@@ -266,9 +266,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]

--- a/implementations/rust/ockam/signature_ps/Cargo.lock
+++ b/implementations/rust/ockam/signature_ps/Cargo.lock
@@ -329,9 +329,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -480,6 +480,7 @@ dependencies = [
  "serde",
  "sha2",
  "subtle",
+ "vsss-rs",
  "zeroize",
 ]
 
@@ -603,6 +604,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b809fb740b3dbd450f411269eec820bbd29dee9268ea1b7c48a0f7e8f283bbb0"
+dependencies = [
+ "ff",
+ "group",
+ "rand_chacha",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds threshold BLS signatures. 
Threshold BLS works by using key shares to sign instead of secret keys which yield partial signatures which cannot be verified by itself. Partial signatures must be combined with a minimum threshold of partial signatures to produce a complete signature which can be verified.