### PR TITLE
chore: ockam_vault_core builds again with no-std feature

### DIFF
--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -19,7 +19,7 @@ no_std = ["heapless"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.21.0-dev"                   }
-heapless = { version = "0.7", optional = true }
+heapless = { version = "0.7", features = ["serde"], optional = true }
 serde = {version = "1.0", features = ["derive"]}
 serde-big-array = "0.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_vault_core/src/types.rs
+++ b/implementations/rust/ockam/ockam_vault_core/src/types.rs
@@ -18,22 +18,16 @@ pub const AES128_SECRET_LENGTH: usize = 16;
 
 cfg_if! {
     if #[cfg(feature = "no_std")] {
-        use heapless::consts::*;
         /// Secret Key Vector
-        pub type SecretKeyVec = heapless::Vec<u8, U32>;
+        pub type SecretKeyVec = heapless::Vec<u8, 32>;
         /// Public Key Vector
-        pub type PublicKeyVec = heapless::Vec<u8, U65>;
+        pub type PublicKeyVec = heapless::Vec<u8, 65>;
         /// Bufer for small vectors (e.g. array of attributes). Max size - 4
-        pub type SmallBuffer<T> = heapless::Vec<T, U4>;
+        pub type SmallBuffer<T> = heapless::Vec<T, 4>;
         /// Buffer for large binaries (e.g. encrypted data). Max size - 512
-        pub type Buffer<T> = heapless::Vec<T, U512>;
-        pub type KeyId = heapless::String<U64>;
-
-        impl From<&str> for KeyId {
-            fn from(s: &str) -> Self {
-                heapless::String::from(s)
-            }
-        }
+        pub type Buffer<T> = heapless::Vec<T, 512>;
+        /// ID of a Key
+        pub type KeyId = heapless::String<64>;
     }
     else {
         extern crate alloc;


### PR DESCRIPTION
Since the [stabilisation](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp) of the const-generics-mvp, the `heapless` crate removed the `heapless::consts` module with their `0.7.0` version.

Some changes should be done [here](https://github.com/ockam-network/ockam/blob/52dc91acf33f0e3ef6c7a58bb80ee78221687a04/implementations/rust/ockam/ockam_vault_core/src/types.rs#L21,L30) in order to take this into account since the Cargo manifest contains said [version](https://github.com/ockam-network/ockam/blob/52dc91acf33f0e3ef6c7a58bb80ee78221687a04/implementations/rust/ockam/ockam_vault_core/Cargo.toml#L22).

The `serde` feature for `heapless` seems to be needed when enabling the `no-std` feature.

An [implementation](https://github.com/ockam-network/ockam/blob/52dc91acf33f0e3ef6c7a58bb80ee78221687a04/implementations/rust/ockam/ockam_vault_core/src/types.rs#L32) of `From<&str>` for `heapless:String<U64>` seems to violate the orphan rule (please correct me if I am wrong) and also it is in conflict with the
```rust
impl<'a, N> From<&'a str> for heapless::String<N>
```
from the `heapless` crate.

### Proposed Changes
* Change the generic parameters for the `heapless` crate `structs`
* Add the `serde`feature to the `heapless` dependency
* Remove the `From<&str>` implementation for `KeyId`