### PR TITLE
feat: vault keys validation on import

### DIFF
--- a/implementations/rust/ockam/ockam_vault/src/error.rs
+++ b/implementations/rust/ockam/ockam_vault/src/error.rs
@@ -36,6 +36,8 @@ pub enum VaultError {
     InvalidCurve25519Secret,
     /// Invalid BLS secret length
     InvalidBlsSecretLength,
+    /// Invalid BLS secret
+    InvalidBlsSecret,
 }
 
 impl VaultError {

--- a/implementations/rust/ockam/ockam_vault/src/error.rs
+++ b/implementations/rust/ockam/ockam_vault/src/error.rs
@@ -30,6 +30,12 @@ pub enum VaultError {
     HkdfExpandError,
     /// Secret not found
     SecretNotFound,
+    /// Invalid Curve25519 secret length
+    InvalidCurve25519SecretLength,
+    /// Invalid Curve25519 secret (scalar not clamped)
+    InvalidCurve25519Secret,
+    /// Invalid BLS secret length
+    InvalidBlsSecretLength,
 }
 
 impl VaultError {

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -63,7 +63,10 @@ impl SoftwareVault {
                 if secret.len() != BlsSecretKey::BYTES {
                     return Err(VaultError::InvalidBlsSecretLength.into());
                 }
-                if BlsSecretKey::from_bytes(secret.try_into().unwrap()).is_none().into() {
+                if BlsSecretKey::from_bytes(secret.try_into().unwrap())
+                    .is_none()
+                    .into()
+                {
                     return Err(VaultError::InvalidBlsSecret.into());
                 }
             }

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -54,7 +54,7 @@ impl SoftwareVault {
                     return Err(VaultError::InvalidCurve25519SecretLength.into());
                 }
                 let clamped = x25519_dalek::StaticSecret::from(
-                    TryInto::<[u8; CURVE25519_SECRET_LENGTH]>::try_into(secret.clone()).unwrap(),
+                    TryInto::<[u8; CURVE25519_SECRET_LENGTH]>::try_into(secret).unwrap(),
                 )
                 .to_bytes();
                 if secret != &clamped[..] {
@@ -244,7 +244,7 @@ mod tests {
     fn secret_generate_compute_key_id() {
         for attrs in &[new_curve255519_attrs(), new_bls_attrs()] {
             let mut vault = new_vault();
-            let sec_idx = vault.secret_generate(attrs.clone()).unwrap();
+            let sec_idx = vault.secret_generate(*attrs).unwrap();
             check_key_id_computation(vault, sec_idx);
         }
     }
@@ -253,12 +253,12 @@ mod tests {
     fn secret_import_compute_key_id() {
         for attrs in &[new_curve255519_attrs(), new_bls_attrs()] {
             let mut vault = new_vault();
-            let sec_idx = vault.secret_generate(attrs.clone()).unwrap();
+            let sec_idx = vault.secret_generate(*attrs).unwrap();
             let secret = vault.secret_export(&sec_idx).unwrap();
             drop(vault); // The first vault was only used to generate random keys
 
             let mut vault = new_vault();
-            let sec_idx = vault.secret_import(secret.as_ref(), attrs.clone()).unwrap();
+            let sec_idx = vault.secret_import(secret.as_ref(), *attrs).unwrap();
 
             check_key_id_computation(vault, sec_idx);
         }

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -63,7 +63,7 @@ impl SoftwareVault {
                 if secret.len() != BlsSecretKey::BYTES {
                     return Err(VaultError::InvalidBlsSecretLength.into());
                 }
-                if BlsSecretKey::from_bytes(secret.try_into().unwrap()).is_none() {
+                if BlsSecretKey::from_bytes(secret.try_into().unwrap()).is_none().into() {
                     return Err(VaultError::InvalidBlsSecret.into());
                 }
             }

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -53,9 +53,11 @@ impl SoftwareVault {
                 if secret.len() != CURVE25519_SECRET_LENGTH {
                     return Err(VaultError::InvalidCurve25519SecretLength.into());
                 }
-                let is_clamped =
-                    secret[0] & !248 == 0 && secret[31] & !127 == 0 && secret[31] & 64 == 64;
-                if !is_clamped {
+                let clamped = x25519_dalek::StaticSecret::from(
+                    TryInto::<[u8; CURVE25519_SECRET_LENGTH]>::try_into(secret.clone()).unwrap(),
+                )
+                .to_bytes();
+                if secret != &clamped[..] {
                     return Err(VaultError::InvalidCurve25519Secret.into());
                 }
             }

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -63,6 +63,9 @@ impl SoftwareVault {
                 if secret.len() != BlsSecretKey::BYTES {
                     return Err(VaultError::InvalidBlsSecretLength.into());
                 }
+                if BlsSecretKey::from_bytes(secret.try_into().unwrap()).is_none() {
+                    return Err(VaultError::InvalidBlsSecret.into());
+                }
             }
             SecretType::Buffer | SecretType::Aes | SecretType::P256 => {}
         }


### PR DESCRIPTION
### Proposed Changes
#### Validating `Curve25519` secret keys

Every constructor in `x25519_dalek` seems to use the following function on its input:
```rust
fn clamp_scalar(mut scalar: [u8; 32]) -> Scalar {
    scalar[0] &= 248;
    scalar[31] &= 127;
    scalar[31] |= 64;

    Scalar::from_bits(scalar)
}
```

and there is no validation so, I think a good way to validate these secrets is to do something like the following:

```rust
fn is_valid_curve25519_secret(scalar: [u8;32]) -> bool {
    scalar[0] & !248 == 0
        && scalar[31] & !127 == 0
        && scalar[31] & 64 == 64
}
```

#### Validating `Bls` secret keys

I choosed to use `signature_bbs_plus::SecretKey::from_bytes` and then see if it is `Some`.