### PR TITLE
fix(elixir): cleanup config to disable node ip resolution on start

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/runtime.exs
@@ -62,28 +62,13 @@ node_fqdn =
       case config_env() do
         :dev -> "localhost"
         :test -> "localhost"
-        _ -> "1.node.ockam.network"
+        _ -> nil
       end
-  end
-
-node_ip =
-  case config_env() do
-    :prod ->
-      {:ok, {:hostent, _, _, :inet, 4, [node_ip]}} = :inet.gethostbyname(to_charlist(node_fqdn))
-
-      node_ip
-
-    :test ->
-      {127, 0, 0, 1}
-
-    :dev ->
-      {127, 0, 0, 1}
   end
 
 config :ockam_hub,
   auth_message: ui_auth_message,
   auth_host: ui_auth_host,
-  node_ip: node_ip,
   node_fqdn: node_fqdn,
   tcp_transport_port: 4000,
   udp_transport_port: 7000,

--- a/implementations/elixir/ockam/ockam_hub/lib/hub.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub.ex
@@ -7,7 +7,6 @@ defmodule Ockam.Hub do
 
   use Application
 
-  alias Ockam.Hub.TelemetryForwarder
   alias Ockam.Transport
 
   require Logger
@@ -32,10 +31,6 @@ defmodule Ockam.Hub do
 
     ## Start all configured services
     Ockam.Hub.Service.Provider.start_configured_services()
-
-    # on app start, create the node if it does not exist
-    # we probably don't care if this errors.
-    TelemetryForwarder.init()
 
     web_port = Application.get_env(:ockam_hub, :web_port)
     # Specifications of child processes that will be started and supervised.


### PR DESCRIPTION
Node IP is used by TelemetryForwarder, which is a left over from
the previous integraiton with the Hub Console.

Remove IP resolution and default host from the config.

Disable TelemetryForwarder.
