### PR TITLE
chore(rust): refactor streams code for clarity & ergonomics

### DIFF
--- a/examples/rust/get_started/examples/14-stream-over-cloud-node-initiator.rs
+++ b/examples/rust/get_started/examples/14-stream-over-cloud-node-initiator.rs
@@ -3,14 +3,12 @@
 /// means that you can run `initiator` and `responder` in any order
 /// you like.
 use ockam::{route, stream::Stream, Context, Result, TcpTransport, TCP};
-use std::time::Duration;
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let (tx, _rx) = Stream::new(&ctx)?
-        .with_interval(Duration::from_millis(100))
+    let (sender, _receiver) = Stream::new(&ctx)?
         .connect(
             route![(TCP, "localhost:4000")],
             // Stream name from THIS node to the OTHER node
@@ -20,8 +18,11 @@ async fn main(mut ctx: Context) -> Result<()> {
         )
         .await?;
 
-    ctx.send(tx.to_route().append("echoer"), "Hello World!".to_string())
-        .await?;
+    ctx.send(
+        sender.to_route().append("echoer"),
+        "Hello World!".to_string(),
+    )
+    .await?;
 
     let reply = ctx.receive_block::<String>().await?;
     println!("Reply via stream: {}", reply);

--- a/examples/rust/get_started/examples/14-stream-over-cloud-node-responder.rs
+++ b/examples/rust/get_started/examples/14-stream-over-cloud-node-responder.rs
@@ -1,17 +1,15 @@
 use ockam::{route, stream::Stream, Context, Result, TcpTransport, TCP};
 use ockam_get_started::Echoer;
-use std::time::Duration;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    // Start a printer
+    // Start an echoer
     ctx.start_worker("echoer", Echoer).await?;
 
     // Create the stream
     Stream::new(&ctx)?
-        .with_interval(Duration::from_millis(100))
         .connect(
             route![(TCP, "localhost:4000")],
             // Stream name from THIS to OTHER

--- a/examples/rust/get_started/examples/15-secure-channel-over-stream-over-cloud-node-responder.rs
+++ b/examples/rust/get_started/examples/15-secure-channel-over-stream-over-cloud-node-responder.rs
@@ -1,6 +1,5 @@
 use ockam::{route, stream::Stream, Context, Result, SecureChannel, TcpTransport, Vault, TCP};
 use ockam_get_started::Echoer;
-use std::time::Duration;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -15,7 +14,6 @@ async fn main(ctx: Context) -> Result<()> {
     // Create a bi-directional stream
     Stream::new(&ctx)?
         .client_id("secure-channel-over-stream-over-cloud-node-responder")
-        .with_interval(Duration::from_millis(100))
         .connect(
             route![(TCP, "localhost:4000")],
             // Stream name from THIS node to the OTHER node


### PR DESCRIPTION
* rename tx, rx to sender, receiver
* rename some variables to match their types in order to increase code clarity
* match struct layout order to constructor argument order for better readability
* modify default stream polling interval to a more reasonable value (250 ms)
* remove default stream interval override in examples

<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
