### PR TITLE
feat(rust): add a simple generator for unique, human-readable identifiers

### DIFF
--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -39,6 +39,7 @@ mod lease;
 mod monotonic;
 mod protocols;
 mod remote_forwarder;
+mod unique;
 
 pub use delay::*;
 pub use error::*;
@@ -47,6 +48,7 @@ pub use ockam_core::worker;
 pub use ockam_entity::*;
 pub use protocols::*;
 pub use remote_forwarder::*;
+pub use unique::*;
 
 pub mod stream;
 

--- a/implementations/rust/ockam/ockam/src/unique.rs
+++ b/implementations/rust/ockam/ockam/src/unique.rs
@@ -1,0 +1,27 @@
+use ockam_core::lib::String;
+use rand::{thread_rng, Rng};
+
+/// A simple generator for unique, human-readable identifiers suitable
+/// for use in distributed systems.
+pub struct Unique;
+
+impl Unique {
+    /// Generate a short, human-readable 32-bit random identifier with
+    /// the given prefix.
+    pub fn with_prefix<S>(prefix: S) -> String
+    where
+        S: Into<String>,
+    {
+        let mut rng = thread_rng();
+        const HEX: &[u8] = b"0123456789abcdef";
+
+        let name: String = (0..8)
+            .map(|_| {
+                let idx: usize = rng.gen_range(0..HEX.len());
+                HEX[idx] as char
+            })
+            .collect();
+
+        format!("{}_{}", prefix.into(), name)
+    }
+}


### PR DESCRIPTION
### Proposed Changes

A new module, living in the `ockam` crate that makes it possible to easily generate unique identifiers that are suitable for use in distributed systems.

Examples:

```rust
use ockam::Unique;

// looks like: responder-to-initiator_07b11da9
let sender_name = Unique::with_prefix("responder-to-initiator");
```


