### PR TITLE
docs: wip integrating entity secure channel with streams

### DIFF
--- a/examples/rust/get_started/examples/15-secure-channel-via-streams-initiator.rs
+++ b/examples/rust/get_started/examples/15-secure-channel-via-streams-initiator.rs
@@ -1,0 +1,53 @@
+use ockam::{
+    route, stream::Stream, Context, Entity, Result, SecureChannels, TcpTransport,
+    TrustEveryonePolicy, Vault, TCP,
+};
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    let _tcp = TcpTransport::create(&ctx).await?;
+
+    // Set the address of the Kafka node you created here. (e.g. "192.0.2.1:4000")
+    let hub_node_tcp_address = "54.177.61.138:4000";
+
+    // Create a vault
+    let vault = Vault::create(&ctx)?;
+    let mut alice = Entity::create(&ctx, &vault)?;
+
+    // Create a stream client
+    let (sender, _receiver) = Stream::new(&ctx)?
+        .stream_service("stream_kafka")
+        .index_service("stream_kafka_index")
+        .client_id("secure-channel-over-stream-over-cloud-node-initiator")
+        .connect(
+            route![(TCP, hub_node_tcp_address)], // route to hub
+            "sc-initiator-to-responder",         // outgoing stream
+            "sc-responder-to-initiator",         // incoming stream
+        )
+        .await?;
+
+    // Create a secure channel
+    let secure_channel = alice.create_secure_channel(
+        route![
+            sender.clone(),            // via the "sc-initiator-to-responder" stream
+            "secure_channel_listener"  // to the "secure_channel_listener" listener
+        ],
+        TrustEveryonePolicy,
+    )?;
+
+    // Send a message
+    ctx.send(
+        route![
+            secure_channel, // via the secure channel
+            "echoer"        // to the "echoer" worker
+        ],
+        "Hello World!".to_string(),
+    )
+    .await?;
+
+    // Receive a message from the "sc-responder-to-initiator" stream
+    let reply = ctx.receive_block::<String>().await?;
+    println!("Reply through secure channel via stream: {}", reply);
+
+    ctx.stop().await
+}

--- a/examples/rust/get_started/examples/15-secure-channel-via-streams-responder.rs
+++ b/examples/rust/get_started/examples/15-secure-channel-via-streams-responder.rs
@@ -1,0 +1,36 @@
+use hello_ockam::Echoer;
+use ockam::{
+    route, stream::Stream, Context, Entity, Result, SecureChannels, TcpTransport,
+    TrustEveryonePolicy, Vault, TCP,
+};
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    let _tcp = TcpTransport::create(&ctx).await?;
+
+    // Set the address of the Kafka node you created here. (e.g. "192.0.2.1:4000")
+    let hub_node_tcp_address = "54.177.61.138:4000";
+
+    // Create a vault
+    let vault = Vault::create(&ctx)?;
+    let mut bob = Entity::create(&ctx, &vault)?;
+    bob.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)?;
+
+    // Create a stream client
+    Stream::new(&ctx)?
+        .stream_service("stream_kafka")
+        .index_service("stream_kafka_index")
+        .client_id("secure-channel-over-stream-over-cloud-node-responder")
+        .connect(
+            route![(TCP, hub_node_tcp_address)], // route to hub
+            "sc-responder-to-initiator",         // outgoing stream
+            "sc-initiator-to-responder",         // incoming stream
+        )
+        .await?;
+
+    // Start an echoer worker
+    ctx.start_worker("echoer", Echoer).await?;
+
+    // Don't call ctx.stop() here so this node runs forever.
+    Ok(())
+}


### PR DESCRIPTION
WIP source for Secure Channels via Hub, using Entities.

This code builds, but when the Stream is initiated, a panic is received in the initiator. There may also be problems when host names are used for hub node routes, I think i saw a different class of error there.


## Responder output

```
Jul 30 11:03:05.579  INFO ockam_node::node: Initializing ockam node
Jul 30 11:03:05.581  INFO ockam_vault::software_vault: Creating vault
Jul 30 11:03:05.589  INFO ockam_channel::secure_channel: Starting SecureChannel listener at 0#4d8f051ffd1e2509a0fc088b9084d555
Jul 30 11:03:05.589  INFO ockam::stream::consumer: Initialising stream consumer 0#035f1f078951adb750b91fc83453ec01
Jul 30 11:03:07.155  INFO ockam::stream::consumer: Initialised consumer for stream 'sc-initiator-to-responder' and route: 1#54.177.61.138:4000 => 0#61810b3006cee1ea
Jul 30 11:03:08.104  INFO ockam::stream::producer: Initialised consumer for stream 'sc-responder-to-initiator' and route: 1#54.177.61.138:4000 => 0#78acf013dc511ecf
Jul 30 11:03:08.789  INFO ockam::stream::consumer: Updating index 'sc-initiator-to-responder' to: 5
Jul 30 11:03:09.049  INFO ockam::stream::consumer: Forwarding sc-initiator-to-responder message to addr: 0#secure_channel_listener
Jul 30 11:03:16.941  INFO ockam::stream::consumer: Forwarding sc-initiator-to-responder message to addr: 0#secure_channel_listener
Jul 30 11:03:17.256  INFO ockam::stream::consumer: Forwarding sc-initiator-to-responder message to addr: 0#secure_channel_listener

Process finished with exit code 130 (interrupted by signal 2: SIGINT)
```

## Initiator output

```
Jul 30 11:03:14.566  INFO ockam_node::node: Initializing ockam node
Jul 30 11:03:14.568  INFO ockam_vault::software_vault: Creating vault
Jul 30 11:03:14.574  INFO ockam::stream::consumer: Initialising stream consumer 0#e49841a09199e460c8a17e7e2abf02d6
Jul 30 11:03:15.633  INFO ockam::stream::consumer: Initialised consumer for stream 'sc-responder-to-initiator' and route: 1#54.177.61.138:4000 => 0#78acf013dc511ecf
Jul 30 11:03:15.780  INFO ockam::stream::consumer: Updating index 'sc-responder-to-initiator' to: 4
Jul 30 11:03:16.072  INFO ockam::stream::consumer: Forwarding sc-responder-to-initiator message to addr: 0#bbd9ff9ced5aa0e88f87b33d85b886b9
Jul 30 11:03:16.072 ERROR ockam::stream::consumer: Failed forwarding stream message: Error { code: 11004, domain: "OCKAM_NODE" }
Jul 30 11:03:16.306  INFO ockam::stream::consumer: Forwarding sc-responder-to-initiator message to addr: 0#bbd9ff9ced5aa0e88f87b33d85b886b9
Jul 30 11:03:16.307 ERROR ockam::stream::consumer: Failed forwarding stream message: Error { code: 11004, domain: "OCKAM_NODE" }
Jul 30 11:03:16.592  INFO ockam::stream::producer: Initialised consumer for stream 'sc-initiator-to-responder' and route: 1#54.177.61.138:4000 => 0#61810b3006cee1ea
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Error { code: 11011, domain: "OCKAM_NODE" }',
```