### PR TITLE
feat(elixir): make hub services supervised by hub root supervisor

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -38,7 +38,6 @@ defmodule Ockam.Worker do
       alias Ockam.Router
       alias Ockam.Telemetry
 
-      @doc false
       def create(options) when is_list(options) do
         options = Keyword.put_new_lazy(options, :address, &Node.get_random_unregistered_address/0)
 
@@ -58,15 +57,14 @@ defmodule Ockam.Worker do
         end
       end
 
-      @doc false
       def start_link(options) when is_list(options) do
         with {:ok, address} <- get_from_options(:address, options),
-             {:ok, pid} <- start(address, options) do
+             {:ok, pid} <- start_link(address, options) do
           {:ok, pid, address}
         end
       end
 
-      defp start(address, options) do
+      def start_link(address, options) do
         GenServer.start_link(__MODULE__, options, name: {:via, Node.process_registry(), address})
       end
 
@@ -103,7 +101,7 @@ defmodule Ockam.Worker do
       @doc false
       @impl true
       def handle_continue(:post_init, options) do
-        metadata = %{options: options}
+        metadata = %{address: Keyword.get(options, :address)}
         start_time = Telemetry.emit_start_event([__MODULE__, :init], metadata: metadata)
 
         with {:ok, address} <- get_from_options(:address, options) do

--- a/implementations/elixir/ockam/ockam_hub/lib/hub.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub.ex
@@ -7,8 +7,6 @@ defmodule Ockam.Hub do
 
   use Application
 
-  alias Ockam.Transport
-
   require Logger
 
   # Called when the Ockam application is started.
@@ -21,31 +19,33 @@ defmodule Ockam.Hub do
     Logger.info("Starting Ockam Hub.")
 
     tcp_transport_port = Application.get_env(:ockam_hub, :tcp_transport_port)
-
-    # Add a TCP listener on port 4000
-    Transport.TCP.create_listener(port: tcp_transport_port)
-
     udp_transport_port = Application.get_env(:ockam_hub, :udp_transport_port)
 
-    Transport.UDP.create_listener(port: udp_transport_port, route_outgoing: true)
-
-    ## Start all configured services
-    Ockam.Hub.Service.Provider.start_configured_services()
+    ## Get configured services child specs
+    {:ok, services_specs} = Ockam.Hub.Service.Provider.configured_child_specs()
 
     web_port = Application.get_env(:ockam_hub, :web_port)
     # Specifications of child processes that will be started and supervised.
     #
     # See the "Child specification" section in the `Supervisor` module for more
     # detailed information.
-    children = [
-      {
-        :telemetry_poller,
-        [
-          period: :timer.seconds(5)
-        ]
-      },
-      {Ockam.Hub.Web.Router, [port: Application.get_env(:ockam_hub, :web_port, web_port)]}
-    ]
+    children =
+      [
+        {
+          :telemetry_poller,
+          [
+            period: :timer.seconds(5)
+          ]
+        },
+        # Add a TCP listener
+        {Ockam.Transport.TCP.Listener,
+         [port: tcp_transport_port, address: "TCP_LISTENER_#{tcp_transport_port}"]},
+        # Add a UDP listener
+        {Ockam.Transport.UDP.Listener,
+         [port: udp_transport_port, address: "UDP_LISTENER_#{udp_transport_port}"]},
+        {Ockam.Hub.Web.Router, [port: Application.get_env(:ockam_hub, :web_port, web_port)]}
+      ] ++
+        services_specs
 
     children =
       if Application.get_env(:telemetry_influxdb, :host, nil) do

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
@@ -25,4 +25,13 @@ defmodule Ockam.Hub.Service.Provider.Routing do
   def start_service(:forwarding, args) do
     ForwardingService.create(Keyword.merge([address: "forwarding_service"], args))
   end
+
+  @impl true
+  def child_spec(:echo, args) do
+    {EchoService, Keyword.merge([address: "echo_service"], args)}
+  end
+
+  def child_spec(:forwarding, args) do
+    {ForwardingService, Keyword.merge([address: "forwarding_service"], args)}
+  end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/stream.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/stream.ex
@@ -24,4 +24,13 @@ defmodule Ockam.Hub.Service.Provider.Stream do
   def start_service(:stream_index, args) do
     StreamIndexService.create(Keyword.merge([address: "stream_index"], args))
   end
+
+  @impl true
+  def child_spec(:stream, args) do
+    {StreamService, Keyword.merge([address: "stream"], args)}
+  end
+
+  def child_spec(:stream_index, args) do
+    {StreamIndexService, Keyword.merge([address: "stream_index"], args)}
+  end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/web/handlers/kafka_stream_handler.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/web/handlers/kafka_stream_handler.ex
@@ -55,7 +55,7 @@ defmodule Ockam.Hub.KafkaStreamHandler do
   end
 
   def services_enabled() do
-    services = ServiceProvider.get_services()
+    services = ServiceProvider.get_configured_services()
     Keyword.has_key?(services, :stream_kafka) and Keyword.has_key?(services, :stream_kafka_index)
   end
 


### PR DESCRIPTION
### Background

Ockam.Node supervisor restarts all workers on max_restarts, this will
stop the service workers and not restart them because they're started
dynamically on hub start.

### Changes

Move services and transports to the Hub supervisor so they are
restarted separately from dynamic workers.

This should improve availability of Hub services in case of failures. 

