### PR TITLE
fix(elixir): update module name to start stream_kafka_index service

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/kafka.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/kafka.ex
@@ -27,7 +27,7 @@ defmodule Ockam.Kafka.Hub.Service.Provider do
 
   @behaviour Ockam.Hub.Service.Provider
 
-  alias Ockam.Stream.Index.Worker, as: StreamIndexService
+  alias Ockam.Stream.Index.Service, as: StreamIndexService
   alias Ockam.Stream.Workers.Service, as: StreamService
 
   @services [:stream_kafka, :stream_kafka_index]


### PR DESCRIPTION
Follow up to #1691
