### PR TITLE
feat(rust): crate release aug 9, 2021

### DIFF
--- a/examples/rust/get_started/Cargo.lock
+++ b/examples/rust/get_started/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.23.0-dev"
+version = "0.23.0"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bls12_381_plus",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_attribute"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "quote",
  "syn",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.12.0-dev"
+version = "0.12.0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1401,7 +1401,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.23.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.22.0 - 2021-08-03
 ### Added
 - Added a simple generator for unique, human-readable identifiers.

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.23.0-dev"
+version = "0.23.0"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bls12_381_plus",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_attribute"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "quote",
  "syn",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1282,7 +1282,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.23.0-dev"
+version = "0.23.0"
 
 [features]
 default = ["std", "ockam_transport_tcp", "software_vault", "noise_xx"]
@@ -25,23 +25,23 @@ alloc = ["ockam_core/alloc", "serde/alloc"]
 no_std = ["ockam_core/no_std", "serde"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"       }
-ockam_node = { path = "../ockam_node", version = "0.22.0-dev"      , optional = true }
-ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.13.0-dev"       }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"       }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"      , optional = true }
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"      , optional = true }
-ockam_channel = { path = "../ockam_channel", version = "0.19.0-dev"       }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "0.18.0-dev"      , optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0-dev"       }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0-dev"      , optional = true }
-ockam_entity = { path = "../ockam_entity", version = "0.13.0-dev"       }
+ockam_core = { path = "../ockam_core", version = "0.24.0"        }
+ockam_node = { path = "../ockam_node", version = "0.22.0"       , optional = true }
+ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.13.0"        }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"        }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"       , optional = true }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"       , optional = true }
+ockam_channel = { path = "../ockam_channel", version = "0.19.0"        }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "0.18.0"       , optional = true }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0"        }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0"       , optional = true }
+ockam_entity = { path = "../ockam_entity", version = "0.13.0"        }
 arrayref = "0.3"
 async-trait = "0.1"
 bls12_381_plus = "0.5"
-signature_core = { version = "0.16.0-dev"      , path = "../signature_core" }
-signature_bbs_plus = { version = "0.16.0-dev"      , path = "../signature_bbs_plus", package = "signature_bbs_plus" }
-signature_bls = { version = "0.14.0-dev"      , path = "../signature_bls", package = "signature_bls" }
+signature_core = { version = "0.16.0"       , path = "../signature_core" }
+signature_bbs_plus = { version = "0.16.0"       , path = "../signature_bbs_plus", package = "signature_bbs_plus" }
+signature_bls = { version = "0.14.0"       , path = "../signature_bls", package = "signature_bls" }
 serde_bare = "0.4"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde-big-array = "0.3"
@@ -51,8 +51,8 @@ rand = "0.8"
 hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"       }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0-dev"       }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"        }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0"        }
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -61,7 +61,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.22.0"
+ockam = "0.23.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.19.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.18.0 - 2021-08-03
 ### Changed
 - Refactored entity secure channel workers.

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "arrayref",
  "ockam_core",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1073,7 +1073,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,13 +20,13 @@ noise_xx = ["ockam_key_exchange_xx"]
 std = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                        }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0-dev"                        }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0-dev"                       , optional = true }
-ockam_node = { path = "../ockam_node", version = "0.22.0-dev"                        }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"                        }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"                       , optional = true }
-ockam_vault = {path = "../ockam_vault", version = "0.18.0-dev"                       , optional = true}
+ockam_core = { path = "../ockam_core", version = "0.24.0"                         }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0"                         }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0"                        , optional = true }
+ockam_node = { path = "../ockam_node", version = "0.22.0"                         }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"                         }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"                        , optional = true }
+ockam_vault = {path = "../ockam_vault", version = "0.18.0"                        , optional = true}
 serde_bare = "0.3.0"
 rand = "0.8"
 async-trait = "0.1"
@@ -34,8 +34,8 @@ serde = {version = "1.0", features = ["derive"]}
 tracing = "0.1"
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                     }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0-dev"                     }
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "0.15.0-dev"                     }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"                     }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                      }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0"                      }
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "0.15.0"                      }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"                      }
 trybuild = {version = "1.0", features = ["diff"]}

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.18.0"
+ockam_channel = "0.19.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.24.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.23.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.23.0"
+ockam_core = "0.24.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.23.0"            , default-features = false }
+ockam_core = { version = "0.24.0"             , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.13.0 - 2021-08-09
+### Changed
+- Ignore error while stopping secure channel listener.
+- Dependencies updated.
+
 ## v0.12.0 - 2021-08-03
 ### Added
 - Added a simple Entity builder.

--- a/implementations/rust/ockam/ockam_entity/Cargo.lock
+++ b/implementations/rust/ockam/ockam_entity/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bls12_381_plus",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1227,7 +1227,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_entity"
-version = "0.13.0-dev"
+version = "0.13.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,23 +20,23 @@ software_vault = ["ockam_vault", "ockam_vault_sync_core", "ockam_vault_sync_core
 std = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                        }
-ockam_node = {path = "../ockam_node", version = "0.22.0-dev"                       }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"                        }
-ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "0.15.0-dev"                       , optional = true}
-ockam_vault = {path = "../ockam_vault", version = "0.18.0-dev"                       , optional = true}
-ockam_channel = {path = "../ockam_channel", version = "0.19.0-dev"                       }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0-dev"                       , optional = true}
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0-dev"  }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                         }
+ockam_node = {path = "../ockam_node", version = "0.22.0"                        }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"                         }
+ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "0.15.0"                        , optional = true}
+ockam_vault = {path = "../ockam_vault", version = "0.18.0"                        , optional = true}
+ockam_channel = {path = "../ockam_channel", version = "0.19.0"                        }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.16.0"                        , optional = true}
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0"   }
 async-trait = "0.1"
 bls12_381_plus = "0.5"
 cfg-if = "1.0.0"
 group = "0.10.0"
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { path = "../signature_core", version = "0.16.0-dev"            }
-signature_bls = { path = "../signature_bls", version = "0.14.0-dev"            }
-signature_bbs_plus = { path = "../signature_bbs_plus", version = "0.16.0-dev"            }
+signature_core = { path = "../signature_core", version = "0.16.0"             }
+signature_bls = { path = "../signature_bls", version = "0.14.0"             }
+signature_bbs_plus = { path = "../signature_bbs_plus", version = "0.16.0"             }
 sha2 = "0.9"
 serde-big-array = "0.3"
 serde_bare = "0.4"
@@ -45,6 +45,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                        }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"                        }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                         }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"                         }
 rand_xorshift = "0"

--- a/implementations/rust/ockam/ockam_entity/README.md
+++ b/implementations/rust/ockam/ockam_entity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_entity = "0.12.0"
+ockam_entity = "0.13.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.23.0-dev"
+version = "0.23.0"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bls12_381_plus",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_attribute"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "quote",
  "syn",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1265,7 +1265,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.14.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.13.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ockam-ffi"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "lazy_static",
  "ockam_core",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -731,7 +731,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.14.0-dev"
+version = "0.14.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 lto = true
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"                         }
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"                          }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                          }
 lazy_static = "1.4"

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.15.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ description = """The Ockam Key Exchange trait.
 """
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_vault_core = { path = "../ockam_vault_core" , version = "0.18.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_vault_core = { path = "../ockam_vault_core" , version = "0.18.0"                          }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.15.0"
+ockam_key_exchange_core = "0.16.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.15.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.14.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "arrayref",
  "ockam_core",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1023,7 +1023,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.15.0-dev"
+version = "0.15.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,12 +13,12 @@ description = """The Ockam X3DH impementation.
 """
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_vault_core = { path = "../ockam_vault_core" , version = "0.18.0-dev"                         }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "0.16.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_vault_core = { path = "../ockam_vault_core" , version = "0.18.0"                          }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "0.16.0"                          }
 arrayref = "0.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"                        }
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                        }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"                         }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                         }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.14.0"
+ockam_key_exchange_x3dh = "0.15.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.15.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1023,7 +1023,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,12 +13,12 @@ description = """The Ockam Noise XX impementation.
 """
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"                         }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"                          }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.16.0"                          }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0-dev"                        }
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                        }
-ockam_node = { path = "../ockam_node" , version = "0.22.0-dev"                        }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.15.0"                         }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                         }
+ockam_node = { path = "../ockam_node" , version = "0.22.0"                         }

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.15.0"
+ockam_key_exchange_xx = "0.16.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.22.0 - 2021-08-09
+### Changed
+- Move sender out of Mailbox
+- Avoid RelayMessage cloning
+- Make mailbox field private
+- Restructure router internals
+- Dependencies updated.
+### Deleted
+- Remove Drop implementation for Context
+
 ## v0.21.0 - 2021-08-03
 ### Changed
 - Raised default message polling timeout to 30 seconds.

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "ockam_core",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "cryptography", "network-programming", "encryption"]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
 tokio = {version = "1.8", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"] }

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.21.0"
+ockam_node = "0.22.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node_attribute/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node_attribute/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.13.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.12.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_node_attribute/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node_attribute/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ockam_node_attribute"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "quote",
  "syn",

--- a/implementations/rust/ockam/ockam_node_attribute/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_attribute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ockam_node_attribute"
 categories = ["cryptography", "asynchronous", "authentication","network-programming"]
-version = "0.13.0-dev"
+version = "0.13.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.18.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.17.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -23,8 +23,8 @@ default = ["std"]
 std = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_node = { path = "../ockam_node", version = "0.22.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_node = { path = "../ockam_node", version = "0.22.0"                          }
 serde_bare = "0.3.0"
 serde = {version = "1.0", features = ["derive"]}
 tokio = {version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"]}

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.17.0"
+ockam_transport_tcp = "0.18.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.12.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.11.0 - 2021-08-03
 ### Changed
 - Refactored entity secure channel workers.

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.23.0-dev"
+version = "0.23.0"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.19.0-dev"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown 0.11.2",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "bls12_381_plus",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_attribute"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "quote",
  "syn",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "futures 0.3.16",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.12.0-dev"
+version = "0.12.0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -1393,7 +1393,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.12.0-dev"
+version = "0.12.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -26,8 +26,8 @@ std = []
 [dependencies]
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"       }
-ockam_node = { path = "../ockam_node", version = "0.22.0-dev"       }
+ockam_core = { path = "../ockam_core", version = "0.24.0"        }
+ockam_node = { path = "../ockam_node", version = "0.22.0"        }
 serde_bare = "0.4.0"
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.11.0"
+ockam_transport_websocket = "0.12.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.18.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.17.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "heapless",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_attribute"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "quote",
  "syn",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -741,7 +741,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,8 +21,8 @@ std = ["ockam_core/std"]
 no_std = ["ockam_vault_core/heapless"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"                         }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"                          }
 arrayref = "0.3"
 aes-gcm = "0.9"
 curve25519-dalek = "3.1"
@@ -33,8 +33,8 @@ sha2 = "0.9"
 x25519-dalek = "1.1"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 tracing = "0.1.26"
-signature_bbs_plus = {path = "../signature_bbs_plus", version = "0.16.0-dev"            }
+signature_bbs_plus = {path = "../signature_bbs_plus", version = "0.16.0"             }
 
 [dev-dependencies]
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "0.13.0-dev"                         }
-ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.15.0-dev"                        }
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "0.13.0"                          }
+ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.15.0"                         }

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.17.0"
+ockam_vault = "0.18.0"
 ```
 
 ## Crate Features
@@ -33,7 +33,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault = { version = "0.17.0"            , default-features = false }
+ockam_vault = { version = "0.18.0"             , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_vault_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.18.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.17.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "heapless",

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ std = ["ockam_core/std"]
 no_std = ["heapless"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"      }
+ockam_core = { path = "../ockam_core", version = "0.24.0"       }
 heapless = { version = "0.7", features = ["serde"], optional = true }
 serde = {version = "1.0", features = ["derive"]}
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam_vault_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_core = "0.17.0"
+ockam_vault_core = "0.18.0"
 ```
 
 ## Crate Features
@@ -30,7 +30,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault_core = { version = "0.17.0"            , default-features = false }
+ockam_vault_core = { version = "0.18.0"             , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.15.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.14.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.22.0-dev"
+version = "0.22.0"
 dependencies = [
  "ockam_core",
  "tokio",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "ockam_core",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_attribute"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "quote",
  "syn",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",
@@ -1020,7 +1020,7 @@ checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_sync_core"
-version = "0.15.0-dev"
+version = "0.15.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -18,10 +18,10 @@ default = []
 software_vault = ["ockam_vault"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.24.0-dev"                         }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0-dev"                         }
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                        , optional = true }
-ockam_node = {path = "../ockam_node", version = "0.22.0-dev"                        }
+ockam_core = { path = "../ockam_core", version = "0.24.0"                          }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.18.0"                          }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                         , optional = true }
+ockam_node = {path = "../ockam_node", version = "0.22.0"                         }
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 serde = {version = "1.0", features = ["derive"]}
 serde-big-array = "0.3"
@@ -30,6 +30,6 @@ async-trait = "0.1"
 rand = "0.8"
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "0.18.0-dev"                         }
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "0.13.0-dev"                         }
-ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.15.0-dev"                        }
+ockam_vault = { path = "../ockam_vault", version = "0.18.0"                          }
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "0.13.0"                          }
+ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.15.0"                         }

--- a/implementations/rust/ockam/ockam_vault_sync_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_sync_core = "0.14.0"
+ockam_vault_sync_core = "0.15.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_vault_test_attribute/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_attribute/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.15.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.14.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_vault_test_attribute/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_test_attribute/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ockam_vault_test_attribute"
-version = "0.15.0-dev"
+version = "0.15.0"
 dependencies = [
  "quote",
  "syn",

--- a/implementations/rust/ockam/ockam_vault_test_attribute/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_attribute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_test_attribute"
-version = "0.15.0-dev"
+version = "0.15.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_test_attribute/README.md
+++ b/implementations/rust/ockam/ockam_vault_test_attribute/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_test_attribute = "0.14.0"
+ockam_vault_test_attribute = "0.15.0"
 ```
 ## License
 

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.13.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.12.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
@@ -65,7 +65,7 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "ockam_core"
-version = "0.24.0-dev"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "hashbrown",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.18.0-dev"
+version = "0.18.0"
 dependencies = [
  "cfg-if",
  "ockam_core",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.13.0-dev"
+version = "0.13.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -3,7 +3,7 @@ name = "ockam_vault_test_suite"
 categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded"]
 description = """Ockam Vault test suite.
 """
-version = "0.13.0-dev"
+version = "0.13.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,5 +13,5 @@ homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault_test_suite"
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "0.24.0-dev"                        }
-ockam_vault_core = {path = "../ockam_vault_core", version = "0.18.0-dev"                        }
+ockam_core = {path = "../ockam_core", version = "0.24.0"                         }
+ockam_vault_core = {path = "../ockam_vault_core", version = "0.18.0"                         }

--- a/implementations/rust/ockam/ockam_vault_test_suite/README.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_test_suite = "0.12.0"
+ockam_vault_test_suite = "0.13.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.15.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.lock
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bbs_plus"
-version = "0.16.0-dev"
+version = "0.16.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,8 +25,8 @@ managed = { version = "0.8", features = ["map"] }
 pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
-signature_core = { version = "0.16.0-dev"                        , path = "../signature_core" }
-signature_bls = { version = "0.14.0-dev"                        , path = "../signature_bls" }
+signature_core = { version = "0.16.0"                         , path = "../signature_core" }
+signature_bls = { version = "0.14.0"                         , path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_bbs_plus/README.md
+++ b/implementations/rust/ockam/signature_bbs_plus/README.md
@@ -18,14 +18,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_bbs_plus = "0.15.0"
+signature_bbs_plus = "0.16.0"
 ```
 
 ## Crate Features
 
 ```
 [dependencies]
-signature_bbs_plus = { version = "0.15.0"            , default-features = false }
+signature_bbs_plus = { version = "0.16.0"             , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.14.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.13.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/signature_bls/Cargo.lock
+++ b/implementations/rust/ockam/signature_bls/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_bls/README.md
+++ b/implementations/rust/ockam/signature_bls/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_bls = "0.13.0"
+signature_bls = "0.14.0"
 ```
 
 ## Crate Features
@@ -27,7 +27,7 @@ disabled as follows
 
 ```
 [dependencies]
-signature_bls = { version = "0.13.0"            , default-features = false }
+signature_bls = { version = "0.14.0"             , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/signature_core/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.16.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.15.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/signature_core/Cargo.lock
+++ b/implementations/rust/ockam/signature_core/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 authors = ["Ockam Deveopers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_core/README.md
+++ b/implementations/rust/ockam/signature_core/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_core = "0.15.0"
+signature_core = "0.16.0"
 ```
 
 ## Crate Features

--- a/implementations/rust/ockam/signature_ps/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_ps/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.14.0 - 2021-08-09
+### Changed
+- Dependencies updated.
+
 ## v0.13.0 - 2021-08-03
 ### Changed
 - Dependencies updated.

--- a/implementations/rust/ockam/signature_ps/Cargo.lock
+++ b/implementations/rust/ockam/signature_ps/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "bls12_381_plus",
  "ff",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.16.0-dev"
+version = "0.16.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "signature_ps"
-version = "0.14.0-dev"
+version = "0.14.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_ps"
-version = "0.14.0-dev"
+version = "0.14.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ description = """The Ockam PS signature impementation.
 
 [dependencies]
 blake2 = "0.9"
-signature_bls = { version = "0.14.0-dev"                        , path = "../signature_bls" }
+signature_bls = { version = "0.14.0"                         , path = "../signature_bls" }
 bls12_381_plus = "0.5"
 digest = { version = "0.9", default-features = false }
 ff = "0.10"
@@ -27,7 +27,7 @@ pairing = "0.20"
 rand_core = "0.6"
 rand_chacha = { version = "0.3", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-signature_core = { version = "0.16.0-dev"                        , path = "../signature_core" }
+signature_core = { version = "0.16.0"                         , path = "../signature_core" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_ps/README.md
+++ b/implementations/rust/ockam/signature_ps/README.md
@@ -16,14 +16,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_ps = "0.13.0"
+signature_ps = "0.14.0"
 ```
 
 ## Crate Features
 
 ```
 [dependencies]
-signature_ps = { version = "0.13.0"            , default-features = false }
+signature_ps = { version = "0.14.0"             , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency


### PR DESCRIPTION
feat(rust): update heapless, trybuild, et al
docs(rust): improve readme of ockam crate
feat(rust): update curve25519-dalek and embedded-hal
test(rust): reenable tunneling tests
fix(rust): ignore error while stopping secure channel listener
feat(rust): move sender out of mailbox
chore(rust): avoid relay message cloning
chore(rust): add context todo comment
feat(rust): make mailbox field private
feat(rust): restructure router internals to reduce uncontrolled sender cloning
feat(rust): remove drop implementation for context
test(rust): add simple ockam_node tests