### PR TITLE
mrinal/kafka guide

### DIFF
--- a/documentation/use-cases/end-to-end-encryption-through-kafka/README.md
+++ b/documentation/use-cases/end-to-end-encryption-through-kafka/README.md
@@ -107,7 +107,7 @@ To make it easy to try, we've created a Docker image that contains both Alice an
 1. Run Bob’s program:
 
     ```
-    docker run --interactive --tty ghcr.io/ockam-network/examples/kafka bob
+    docker run --rm --interactive --tty ghcr.io/ockam-network/examples/kafka bob
     ```
 
     The Bob program creates a Secure Channel Listener to accept requests to begin an Authenticated Key
@@ -126,7 +126,7 @@ To make it easy to try, we've created a Docker image that contains both Alice an
 3. In a separate terminal window, run the Alice program:
 
     ```
-    docker run --interactive --tty ghcr.io/ockam-network/examples/kafka alice
+    docker run --rm --interactive --tty ghcr.io/ockam-network/examples/kafka alice
     ```
 
 4. The Alice program will stop to ask for the stream addresses that were printed in step 2. Enter them.

--- a/examples/rust/ockam_kafka/Dockerfile
+++ b/examples/rust/ockam_kafka/Dockerfile
@@ -1,24 +1,15 @@
-FROM debian:10-slim AS builder
-RUN apt-get -y update
-RUN apt-get -y install libterm-readline-gnu-perl
-RUN apt-get -y install apt-utils
-RUN apt-get -y upgrade
-RUN apt-get -y install clang lld curl git pkg-config libssl-dev
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+FROM ghcr.io/ockam-network/ockam/builder AS builder
 
 WORKDIR /build
 
 COPY . ./
 
-RUN . ~/.cargo/env && cargo build --example bob
-RUN . ~/.cargo/env && cargo build --example alice
+RUN cargo build --example bob
+RUN cargo build --example alice
 
-FROM debian:10-slim
-
-WORKDIR /run
+FROM ghcr.io/ockam-network/ockam/base
 
 COPY --from=builder /build/target/debug/examples/bob ./bob
 COPY --from=builder /build/target/debug/examples/alice ./alice
 
-ENV PATH="/run:${PATH}"
-
+ENV PATH="/work:${PATH}"

--- a/examples/rust/ockam_kafka/scripts/entry.sh
+++ b/examples/rust/ockam_kafka/scripts/entry.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-source ~/.cargo/env
-
-cargo run --example $1


### PR DESCRIPTION
- build: use ockam builder and base for kafka example docker image
- docs: add rm to docker commands in kafka guide
