### PR TITLE
test: add basic tcp transport integration test

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -1,11 +1,10 @@
 use core::iter;
 use std::time::Duration;
 
-use ockam_core::compat::sync::Arc;
-use ockam_core::{route, Error, Result, Routed, Worker};
+use ockam_core::{route, Address, Error, Result, Routed, Worker};
 use ockam_node::Context;
 use rand::Rng;
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::oneshot;
 use tokio::time::timeout;
 
 use ockam_transport_tcp::{TcpTransport, TCP};
@@ -20,35 +19,36 @@ async fn send_receive() {
     assert!(rx.await.unwrap().is_ok(), "'run' method should return Ok");
 }
 
-async fn run_with_timeout(tx: oneshot::Sender<Result<()>>, ctx: Context) {
-    let ctx = Arc::new(RwLock::new(ctx));
-    match timeout(Duration::from_secs(1), run_test(ctx.clone())).await {
+async fn run_with_timeout(tx: oneshot::Sender<Result<()>>, mut ctx: Context) {
+    match timeout(Duration::from_secs(1), run_test(&ctx)).await {
         Ok(res) => tx.send(res).unwrap(),
         Err(_) => tx.send(Err(Error::new(0, ""))).unwrap(),
     };
-    let mut ctx = ctx.write().await;
     let _ = ctx.stop().await;
 }
 
-async fn run_test(ctx: Arc<RwLock<Context>>) -> Result<()> {
-    let mut ctx = ctx.write().await;
-    let transport = TcpTransport::create(&ctx).await?;
-    transport.listen("127.0.0.1:4000").await?;
-
-    ctx.start_worker("echoer", Echoer).await?;
-
-    let msg: String = {
-        let mut rng = rand::thread_rng();
-        iter::repeat(())
-            .map(|()| rng.sample(&rand::distributions::Alphanumeric))
-            .take(10)
-            .collect()
+async fn run_test(ctx: &Context) -> Result<()> {
+    let _listener = {
+        let transport = TcpTransport::create(ctx).await?;
+        transport.listen("127.0.0.1:4000").await?;
+        ctx.start_worker("echoer", Echoer).await?;
     };
-    let r = route![(TCP, "127.0.0.1:4000"), "echoer"];
-    ctx.send(r, msg.clone()).await?;
+    let _sender = {
+        let mut ctx = ctx.new_context(Address::random(0)).await?;
+        let msg: String = {
+            let mut rng = rand::thread_rng();
+            iter::repeat(())
+                .map(|()| rng.sample(&rand::distributions::Alphanumeric))
+                .take(10)
+                .collect()
+        };
+        let r = route![(TCP, "127.0.0.1:4000"), "echoer"];
+        ctx.send(r, msg.clone()).await?;
 
-    let reply = ctx.receive::<String>().await?;
-    assert_eq!(reply, msg, "Should receive the same message");
+        let reply = ctx.receive::<String>().await?;
+        assert_eq!(reply, msg, "Should receive the same message");
+        ctx.stop().await?;
+    };
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -1,0 +1,65 @@
+use core::iter;
+use std::time::Duration;
+
+use ockam_core::compat::sync::Arc;
+use ockam_core::{route, Error, Result, Routed, Worker};
+use ockam_node::Context;
+use rand::Rng;
+use tokio::sync::{oneshot, RwLock};
+use tokio::time::timeout;
+
+use ockam_transport_tcp::{TcpTransport, TCP};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_receive() {
+    let (tx, rx) = oneshot::channel::<Result<()>>();
+    let (ctx, mut executor) = ockam_node::start_node();
+    executor
+        .execute(async move { run_with_timeout(tx, ctx).await })
+        .expect("Executor should not fail");
+    assert!(rx.await.unwrap().is_ok(), "'run' method should return Ok");
+}
+
+async fn run_with_timeout(tx: oneshot::Sender<Result<()>>, ctx: Context) {
+    let ctx = Arc::new(RwLock::new(ctx));
+    match timeout(Duration::from_secs(1), run_test(ctx.clone())).await {
+        Ok(res) => tx.send(res).unwrap(),
+        Err(_) => tx.send(Err(Error::new(0, ""))).unwrap(),
+    };
+    let mut ctx = ctx.write().await;
+    let _ = ctx.stop().await;
+}
+
+async fn run_test(ctx: Arc<RwLock<Context>>) -> Result<()> {
+    let mut ctx = ctx.write().await;
+    let transport = TcpTransport::create(&ctx).await?;
+    transport.listen("127.0.0.1:4000").await?;
+
+    ctx.start_worker("echoer", Echoer).await?;
+
+    let msg: String = {
+        let mut rng = rand::thread_rng();
+        iter::repeat(())
+            .map(|()| rng.sample(&rand::distributions::Alphanumeric))
+            .take(10)
+            .collect()
+    };
+    let r = route![(TCP, "127.0.0.1:4000"), "echoer"];
+    ctx.send(r, msg.clone()).await?;
+
+    let reply = ctx.receive::<String>().await?;
+    assert_eq!(reply, msg, "Should receive the same message");
+    Ok(())
+}
+
+pub struct Echoer;
+
+#[ockam_core::worker]
+impl Worker for Echoer {
+    type Message = String;
+    type Context = Context;
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
+        ctx.send(msg.return_route(), msg.body()).await
+    }
+}


### PR DESCRIPTION
## Description

Now that the transport crates are getting some refactors (and more to come), it would be nice to have some integration tests before abstracting the internal transports' logic with new traits, etc.

This PR adds just one test, so we can discuss the testing strategy before adding more. The test checks that a couple of workers can send and receive messages through the tcp transport, which is basically the `echoer` example with some asserts.

As you will see, the setup to run the test is a bit tricky. 

Here are the main challenges I've come across:

* **proc_macro for nodes**. I know having both the node's `Executor` and the `#[tokio::test]`'s is wrong, as well as that nasty oneshot channel to get the test result out of the nested runtime. I just don't know how to create a proc_macro for this or if the proc_macro is the way to go. I've seen there are other proc_macro for tests (`vault_test`)

* **Running the test with a timeout**. The listener/receiver worker must be stopped to finish the test. This worker could hang up for several reasons, including bugs, so I guess it makes sense to run the test with a timeout to force stopping the workers and fail fast

* **Hardcoded port**. Not sure how to handle this. With random ports we will have flaky tests. With hardcoded ports, port-dependent tests should be run sequentially. A third approach would be developing a `port_pool`, so we just have to ask for a free port and return it back to the pool once the test is finished.
  
That's all. Any help with this would be awesome.

## Related issues

* https://github.com/ockam-network/ockam/issues/1575
* Also, I remember there was an issue discussing the creation of a new proc_macro for tests, but I couldn't find it. Maybe I'm making that up :laughing: 
