### PR TITLE
feat(rust): initial publish of ockam_node_no_std

### DIFF
--- a/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.0.0 - 2021-02-10
+## v0.1.0 - 2021-08-23
 
 Initial release.

--- a/implementations/rust/ockam/ockam_node_no_std/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node_no_std/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_no_std"
-version = "0.14.0-dev"
+version = "0.1.0-dev"
 dependencies = [
  "executor",
 ]

--- a/implementations/rust/ockam/ockam_node_no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_no_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_node_no_std"
-version = "0.14.0-dev"
+version = "0.1.0-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_node_no_std/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_no_std/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+//! `no_std` implementation of Ockam Node
 
 use core::future::Future;
 
+/// Block on the execution of the given future.
 pub fn block_on<T>(future: impl Future<Output = T> + 'static + Send) -> T
 where
     T: Send + 'static,


### PR DESCRIPTION
Initial publish of the  `ockam_node_no_std` crate. 