### PR TITLE
refactor(elixir): make tcp transport listener optional, simplify udp transport API

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/local.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/local.ex
@@ -29,6 +29,8 @@ defmodule Ockam.Example.Stream.BiDirectional.Local do
   alias Ockam.Stream.Client.BiDirectional
   alias Ockam.Stream.Client.BiDirectional.PublisherRegistry
 
+  alias Ockam.Transport.TCP
+
   def config() do
     %{
       hub_ip: "127.0.0.1",
@@ -53,7 +55,7 @@ defmodule Ockam.Example.Stream.BiDirectional.Local do
 
   ## This should be run on the PONG node
   def init_pong() do
-    ensure_tcp(5000)
+    TCP.start()
     ## PONG worker
     {:ok, "pong"} = Pong.create(address: "pong")
 
@@ -62,7 +64,7 @@ defmodule Ockam.Example.Stream.BiDirectional.Local do
   end
 
   def run() do
-    ensure_tcp(3000)
+    TCP.start()
 
     ## PING worker
     Ping.create(address: "ping")
@@ -95,10 +97,6 @@ defmodule Ockam.Example.Stream.BiDirectional.Local do
     }
 
     Ockam.Router.route(msg)
-  end
-
-  def ensure_tcp(port) do
-    Ockam.Transport.TCP.create_listener(port: port, route_outgoing: true)
   end
 
   def subscribe(stream, subscription_id) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
@@ -33,6 +33,8 @@ defmodule Ockam.Example.Stream.BiDirectional.SecureChannel do
   alias Ockam.Stream.Client.BiDirectional
   alias Ockam.Stream.Client.BiDirectional.PublisherRegistry
 
+  alias Ockam.Transport.TCP
+
   require Logger
 
   ## Ignore no local return for secure channel
@@ -65,7 +67,7 @@ defmodule Ockam.Example.Stream.BiDirectional.SecureChannel do
   end
 
   def init_pong() do
-    ensure_tcp(5000)
+    TCP.start()
 
     ## PONG worker
     {:ok, "pong"} = Pong.create(address: "pong")
@@ -78,7 +80,7 @@ defmodule Ockam.Example.Stream.BiDirectional.SecureChannel do
   end
 
   def run() do
-    ensure_tcp(3000)
+    TCP.start()
 
     ## PING worker
     {:ok, "ping"} = Ping.create(address: "ping")
@@ -166,12 +168,8 @@ defmodule Ockam.Example.Stream.BiDirectional.SecureChannel do
     Ockam.Router.route(msg)
   end
 
-  def ensure_tcp(port) do
-    Ockam.Transport.TCP.create_listener(port: port, route_outgoing: true)
-  end
-
   def ensure_udp(port) do
-    Ockam.Transport.UDP.create_listener(port: port, route_outgoing: true)
+    Ockam.Transport.UDP.start(port: port)
   end
 
   def stream_options(protocol) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/index_api.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/index_api.ex
@@ -67,10 +67,10 @@ defmodule Ockam.Examples.Stream.IndexApi do
   end
 
   def init() do
-    ensure_tcp(5000)
+    ensure_tcp()
   end
 
-  def ensure_tcp(port) do
-    Ockam.Transport.TCP.create_listener(port: port, route_outgoing: true)
+  def ensure_tcp() do
+    Ockam.Transport.TCP.start()
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream.ex
@@ -43,7 +43,7 @@ defmodule Ockam.Examples.Stream do
 
   def init() do
     options = stream_options()
-    ensure_tcp()
+    Ockam.Transport.TCP.start()
 
     Map.merge(
       create_publisher(options.stream_name, options.service_route),
@@ -105,10 +105,6 @@ defmodule Ockam.Examples.Stream do
         route_message("#{prefix}_#{n}")
       end
     )
-  end
-
-  def ensure_tcp() do
-    Ockam.Transport.TCP.create_listener(port: 3000, route_outgoing: true)
   end
 end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream_api.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/stream_api.ex
@@ -14,7 +14,7 @@ defmodule Ockam.Examples.Stream.StreamApi do
   end
 
   def outline() do
-    Ockam.Examples.Stream.StreamApi.init()
+    Ockam.Transport.TCP.start()
 
     Ockam.Examples.Stream.StreamApi.create_stream("my_api_stream")
 
@@ -72,13 +72,5 @@ defmodule Ockam.Examples.Stream.StreamApi do
     payload = Message.payload(pull_response)
 
     Ockam.Protocol.decode_payload(StreamProtocol.Pull, :response, payload)
-  end
-
-  def init() do
-    ensure_tcp(5000)
-  end
-
-  def ensure_tcp(port) do
-    Ockam.Transport.TCP.create_listener(port: port, route_outgoing: true)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/transport/printer.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/transport/printer.ex
@@ -1,0 +1,14 @@
+defmodule Ockam.Examples.Transport.Printer do
+  @moduledoc """
+  An ockam worker to log all messages
+  """
+  use Ockam.Worker
+
+  require Logger
+
+  @impl true
+  def handle_message(message, state) do
+    Logger.info("Printer received: #{inspect(message)}")
+    {:ok, state}
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/transport/tcp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/transport/tcp.ex
@@ -1,0 +1,42 @@
+defmodule Ockam.Examples.Transport.TCP do
+  @moduledoc """
+  Example usage of tcp transport
+  """
+  alias Ockam.Transport.TCP
+  alias Ockam.Transport.TCPAddress
+
+  def server() do
+    ## Start a transport with listener on port 4000
+    TCP.start(listen: [port: 4000])
+    Ockam.Examples.Transport.Printer.create(address: "printer")
+  end
+
+  def client() do
+    ## Start a transport without a listener
+    TCP.start()
+
+    server_host_address = TCPAddress.new("localhost", 4000)
+
+    Ockam.Router.route(%{
+      onward_route: [server_host_address, "printer"],
+      payload: "Hello!",
+      return_route: []
+    })
+
+    server_ip_address = TCPAddress.new({127, 0, 0, 1}, 4000)
+
+    Ockam.Router.route(%{
+      onward_route: [server_ip_address, "printer"],
+      payload: "Hello!",
+      return_route: []
+    })
+
+    server_string_ip_address = TCPAddress.new("127.0.0.1", 4000)
+
+    Ockam.Router.route(%{
+      onward_route: [server_string_ip_address, "printer"],
+      payload: "Hello!",
+      return_route: []
+    })
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/transport/udp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/transport/udp.ex
@@ -1,0 +1,36 @@
+defmodule Ockam.Examples.Transport.UDP do
+  @moduledoc """
+  An example module on how to use the UDP transport
+  """
+  alias Ockam.Transport.UDP
+  alias Ockam.Transport.UDPAddress
+
+  require Logger
+
+  def alice() do
+    ## Start a transport to use a port 4000
+    UDP.start(port: 4000)
+    Ockam.Examples.Transport.Printer.create(address: "printer")
+  end
+
+  def bob() do
+    ## Start a transport to use a port 3000
+    UDP.start(port: 3000)
+
+    server_ip_address = UDPAddress.new({127, 0, 0, 1}, 4000)
+
+    Ockam.Router.route(%{
+      onward_route: [server_ip_address, "printer"],
+      payload: "Hello!",
+      return_route: []
+    })
+
+    server_string_ip_address = UDPAddress.new("127.0.0.1", 4000)
+
+    Ockam.Router.route(%{
+      onward_route: [server_string_ip_address, "printer"],
+      payload: "Hello!",
+      return_route: []
+    })
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
@@ -1,11 +1,100 @@
 defmodule Ockam.Transport.TCP do
-  @moduledoc false
+  @moduledoc """
+  TCP transport
+  """
 
   alias Ockam.Transport.TCP.Listener
+  alias Ockam.Transport.TCPAddress
 
-  @spec create_listener(keyword) :: :ignore | {:error, any} | {:ok, any}
-  @doc false
-  def create_listener(options \\ []) do
-    Listener.create(options)
+  alias Ockam.Message
+  alias Ockam.Router
+  alias Ockam.Transport.TCP.Client
+
+  require Logger
+
+  def child_spec(options) do
+    id = id(options)
+
+    %{
+      id: id,
+      start: {__MODULE__, :start, [options]}
+    }
+  end
+
+  defp id(options) do
+    case Keyword.fetch(options, :listen) do
+      {:ok, listen} ->
+        ip = Keyword.get(listen, :ip, Listener.default_ip())
+        port = Keyword.get(listen, :port, Listener.default_port())
+
+        "TCP_LISTENER_#{TCPAddress.format_host_port(ip, port)}"
+
+      _other ->
+        "TCP_TRANSPORT"
+    end
+  end
+
+  @doc """
+  Start a TCP transport
+
+  ## Parameters
+  - options:
+      listen: t:Listener.options()
+  """
+  @spec start(Keyword.t()) :: :ignore | {:error, any} | {:ok, any}
+  def start(options \\ []) do
+    ## TODO: do we want to stop transports?
+    Router.set_message_handler(TCPAddress.type(), &handle_message/1)
+
+    case Keyword.fetch(options, :listen) do
+      {:ok, listen} -> Listener.start_link(listen)
+      _other -> :ignore
+    end
+  end
+
+  @spec handle_message(Ockam.Message.t()) :: :ok | {:error, any()}
+  defp handle_message(message) do
+    case get_destination_and_onward_route(message) do
+      {:ok, destination, onward_route} ->
+        ## Remove tcp address from onward route
+        message_to_forward =
+          Map.put(create_outgoing_message(message), :onward_route, onward_route)
+
+        ## TODO: reuse clients when using tcp address
+        with {:ok, client_address} <- Client.create(destination: destination) do
+          Ockam.Node.send(client_address, message_to_forward)
+        end
+
+      e ->
+        Logger.error(
+          "Cannot forward message to tcp client: #{inspect(message)} reason: #{inspect(e)}"
+        )
+    end
+  end
+
+  defp get_destination_and_onward_route(message) do
+    {dest_address, onward_route} =
+      message
+      |> Message.onward_route()
+      |> List.pop_at(0)
+
+    with true <- TCPAddress.is_tcp_address(dest_address),
+         {:ok, destination} <- TCPAddress.to_host_port(dest_address) do
+      {:ok, destination, onward_route}
+    else
+      false ->
+        {:error, {:invalid_address_type, dest_address}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp create_outgoing_message(message) do
+    %{
+      onward_route: Message.onward_route(message),
+      payload: Message.payload(message),
+      return_route: Message.return_route(message)
+    }
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/address.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/address.ex
@@ -37,16 +37,19 @@ defmodule Ockam.Transport.TCPAddress do
     end
   end
 
-  @spec new(String.t(), integer()) :: t()
-  def new(host, port) when is_binary(host) and is_integer(port) do
-    %Address{type: @address_type, value: "#{host}:#{port}"}
+  @spec new(String.t() | :inet.ip_address(), integer()) :: t()
+  def new(host, port) when (is_binary(host) or is_tuple(host)) and is_integer(port) do
+    %Address{type: @address_type, value: format_host_port(host, port)}
   end
 
-  @spec new(:inet.ip_address(), integer()) :: t()
-  def new(ip, port) when is_tuple(ip) and is_integer(port) do
-    host = to_string(:inet.ntoa(ip))
+  def format_host_port(host, port) when is_binary(host) do
+    "#{host}:#{port}"
+  end
+
+  def format_host_port(ip, port) when is_tuple(ip) do
     ## TODO: format IPV6 with brackets
-    %Address{type: @address_type, value: "#{host}:#{port}"}
+    host = to_string(:inet.ntoa(ip))
+    format_host_port(host, port)
   end
 
   def is_tcp_address(address) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/handler.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/handler.ex
@@ -1,0 +1,111 @@
+defmodule Ockam.Transport.TCP.Handler do
+  @moduledoc false
+
+  use GenServer
+
+  alias Ockam.Message
+  alias Ockam.Telemetry
+
+  require Logger
+
+  @wire_encoder_decoder Ockam.Wire.Binary.V2
+
+  def start_link(ref, _socket, transport, opts) do
+    start_link(ref, transport, opts)
+  end
+
+  def start_link(ref, transport, opts) do
+    pid = :proc_lib.spawn_link(__MODULE__, :init, [[ref, transport, opts]])
+    {:ok, pid}
+  end
+
+  @impl true
+  def init([ref, transport, opts]) do
+    {:ok, socket} = :ranch.handshake(ref, opts)
+    :ok = :inet.setopts(socket, [{:active, true}, {:packet, 2}, {:nodelay, true}])
+
+    address = Ockam.Node.get_random_unregistered_address()
+
+    Ockam.Node.Registry.register_name(address, self())
+
+    {function_name, _} = __ENV__.function
+    Telemetry.emit_event(function_name)
+
+    :gen_server.enter_loop(
+      __MODULE__,
+      [],
+      %{
+        socket: socket,
+        transport: transport,
+        address: address
+      },
+      {:via, Ockam.Node.process_registry(), address}
+    )
+  end
+
+  @impl true
+  def handle_info({:tcp, socket, data}, %{socket: socket, address: address} = state) do
+    {function_name, _} = __ENV__.function
+
+    with {:ok, decoded} <- Ockam.Wire.decode(@wire_encoder_decoder, data),
+         {:ok, decoded} <- set_return_route(decoded, address) do
+      send_to_router(decoded)
+      Telemetry.emit_event(function_name, metadata: %{name: "decoded_data"})
+    else
+      {:error, %Ockam.Wire.DecodeError{} = e} ->
+        start_time = Telemetry.emit_start_event(function_name)
+        Telemetry.emit_exception_event(function_name, start_time, e)
+        raise e
+
+      e ->
+        raise e
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info({:tcp_closed, socket}, %{socket: socket, transport: transport} = state) do
+    transport.close(socket)
+    {function_name, _} = __ENV__.function
+    Telemetry.emit_event(function_name, metadata: %{name: "transport_close"})
+    {:stop, :normal, state}
+  end
+
+  def handle_info(
+        %{payload: _payload} = message,
+        %{transport: transport, socket: socket, address: address} = state
+      ) do
+    with {:ok, message} <- set_onward_route(message, address),
+         {:ok, encoded} <- Ockam.Wire.encode(@wire_encoder_decoder, message) do
+      transport.send(socket, encoded)
+    else
+      a ->
+        Logger.error("TCP transport send error #{inspect(a)}")
+        raise a
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(other, state) do
+    Logger.warn("TCP HANDLER Received unkown message #{inspect(other)} #{inspect(state)}")
+    {:noreply, state}
+  end
+
+  defp set_onward_route(message, address) do
+    onward_route =
+      message
+      |> Message.onward_route()
+      |> Enum.drop_while(fn a -> a === address end)
+
+    {:ok, %{message | onward_route: onward_route}}
+  end
+
+  defp set_return_route(%{return_route: return_route} = message, address) do
+    {:ok, %{message | return_route: [address | return_route]}}
+  end
+
+  defp send_to_router(message) do
+    Ockam.Router.route(message)
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/listener.ex
@@ -1,36 +1,41 @@
 if Code.ensure_loaded?(:ranch) do
   defmodule Ockam.Transport.TCP.Listener do
-    @moduledoc false
+    @moduledoc """
+    TCP listener GenServer for TCP transport
+    Wrapper for ranch listener
+    """
 
-    use Ockam.Worker
-
-    alias Ockam.Message
-    alias Ockam.Transport.TCP.Client
-    alias Ockam.Transport.TCPAddress
+    ## TODO: is it possible to use ranch listener as a supervised process?
+    use GenServer
 
     require Logger
 
-    @doc false
+    @typedoc """
+    TCP listener options
+    - ip: t::inet.ip_address() - IP address to listen on
+    - port: t:integer() - port to listen on
+    """
+    @type options :: Keyword.t()
+
+    def start_link(options) do
+      GenServer.start_link(__MODULE__, options)
+    end
+
     @impl true
-    def setup(options, state) do
+    def init(options) do
       ip = Keyword.get_lazy(options, :ip, &default_ip/0)
-      state = Map.put(state, :ip, ip)
-
       port = Keyword.get_lazy(options, :port, &default_port/0)
-      state = Map.put(state, :port, port)
-
-      route_outgoing = Keyword.get(options, :route_outgoing, false)
 
       ref = make_ref()
       transport = :ranch_tcp
-      transport_options = [port: port]
-      protocol = __MODULE__.Handler
+      transport_options = [port: port, ip: ip]
+      protocol = Ockam.Transport.TCP.Handler
       protocol_options = [packet: 2, nodelay: true]
 
       with {:ok, _apps} <- Application.ensure_all_started(:ranch),
-           :ok <- start_listener(ref, transport, transport_options, protocol, protocol_options),
-           :ok <- setup_routed_message_handler(route_outgoing, state.address) do
-        {:ok, state}
+           {:ok, ranch_listener} <-
+             start_listener(ref, transport, transport_options, protocol, protocol_options) do
+        {:ok, %{ranch_listener: ranch_listener}}
       end
     end
 
@@ -38,221 +43,13 @@ if Code.ensure_loaded?(:ranch) do
       r = :ranch.start_listener(ref, transport, transport_options, protocol, protocol_options)
 
       case r do
-        {:ok, _child} -> :ok
-        {:ok, _child, _info} -> :ok
+        {:ok, child} -> {:ok, child}
+        {:ok, child, _info} -> {:ok, child}
         {:error, reason} -> {:error, {:could_not_start_ranch_listener, reason}}
       end
     end
 
-    defp setup_routed_message_handler(true, listener) do
-      handler = fn message -> handle_routed_message(listener, message) end
-
-      with :ok <- Router.set_message_handler(TCPAddress.type(), handler) do
-        :ok
-      end
-    end
-
-    defp setup_routed_message_handler(_something_else, _listener), do: :ok
-
-    defp handle_routed_message(listener, message) do
-      Node.send(listener, message)
-    end
-
-    @impl true
-    def handle_message(message, %{address: address} = state) do
-      case get_destination_and_onward_route(message, address) do
-        {:ok, destination, onward_route} ->
-          ## Remove tcp address from onward route
-          message_to_forward =
-            Map.put(create_outgoing_message(message), :onward_route, onward_route)
-
-          ## TODO: do we want to pass a configured address?
-          ## TODO: what to do with failures?
-          with {:ok, client_address} <- Client.create(destination: destination) do
-            Ockam.Node.send(client_address, message_to_forward)
-          end
-
-        e ->
-          Logger.error(
-            "Cannot forward message to tcp client: #{inspect(message)} reason: #{inspect(e)}"
-          )
-      end
-
-      {:ok, state}
-    end
-
-    defp create_outgoing_message(message) do
-      %{
-        onward_route: Message.onward_route(message),
-        payload: Message.payload(message),
-        return_route: Message.return_route(message)
-      }
-    end
-
-    defp get_destination_and_onward_route(message, address) do
-      {dest_address, onward_route} =
-        message
-        |> Message.onward_route()
-        |> Enum.drop_while(fn a -> a === address end)
-        |> List.pop_at(0)
-
-      with true <- TCPAddress.is_tcp_address(dest_address),
-           {:ok, destination} <- TCPAddress.to_host_port(dest_address) do
-        {:ok, destination, onward_route}
-      else
-        false ->
-          {:error, {:invalid_address_type, dest_address}}
-
-        error ->
-          error
-      end
-    end
-
-    defp default_ip, do: {127, 0, 0, 1}
-    defp default_port, do: 4000
-  end
-
-  defmodule Ockam.Transport.TCP.Listener.Handler do
-    @moduledoc false
-
-    use GenServer
-
-    alias Ockam.Message
-    alias Ockam.Telemetry
-
-    require Logger
-
-    @wire_encoder_decoder Ockam.Wire.Binary.V2
-
-    def start_link(ref, _socket, transport, opts) do
-      start_link(ref, transport, opts)
-    end
-
-    def start_link(ref, transport, opts) do
-      pid = :proc_lib.spawn_link(__MODULE__, :init, [[ref, transport, opts]])
-      {:ok, pid}
-    end
-
-    @impl true
-    def init([ref, transport, opts]) do
-      {:ok, socket} = :ranch.handshake(ref, opts)
-      :ok = :inet.setopts(socket, [{:active, true}, {:packet, 2}, {:nodelay, true}])
-
-      address = Ockam.Node.get_random_unregistered_address()
-
-      Ockam.Node.Registry.register_name(address, self())
-
-      {function_name, _} = __ENV__.function
-      Telemetry.emit_event(function_name)
-
-      :gen_server.enter_loop(
-        __MODULE__,
-        [],
-        %{
-          socket: socket,
-          transport: transport,
-          address: address
-        },
-        {:via, Ockam.Node.process_registry(), address}
-      )
-    end
-
-    @impl true
-    def handle_info({:tcp, socket, data}, %{socket: socket, address: address} = state) do
-      {function_name, _} = __ENV__.function
-
-      with {:ok, decoded} <- Ockam.Wire.decode(@wire_encoder_decoder, data),
-           {:ok, decoded} <- set_return_route(decoded, address) do
-        send_to_router(decoded)
-        Telemetry.emit_event(function_name, metadata: %{name: "decoded_data"})
-      else
-        {:error, %Ockam.Wire.DecodeError{} = e} ->
-          start_time = Telemetry.emit_start_event(function_name)
-          Telemetry.emit_exception_event(function_name, start_time, e)
-          raise e
-
-        e ->
-          raise e
-      end
-
-      {:noreply, state}
-    end
-
-    def handle_info({:tcp_closed, socket}, %{socket: socket, transport: transport} = state) do
-      transport.close(socket)
-      {function_name, _} = __ENV__.function
-      Telemetry.emit_event(function_name, metadata: %{name: "transport_close"})
-      {:stop, :normal, state}
-    end
-
-    def handle_info(
-          %{payload: _payload} = message,
-          %{transport: transport, socket: socket, address: address} = state
-        ) do
-      with {:ok, message} <- set_onward_route(message, address),
-           {:ok, encoded} <- Ockam.Wire.encode(@wire_encoder_decoder, message) do
-        transport.send(socket, encoded)
-      else
-        a ->
-          Logger.error("TCP transport send error #{inspect(a)}")
-          raise a
-      end
-
-      {:noreply, state}
-    end
-
-    def handle_info(other, state) do
-      Logger.warn("TCP HANDLER Received unkown message #{inspect(other)} #{inspect(state)}")
-      {:noreply, state}
-    end
-
-    @impl true
-    def handle_call({:send, data}, _from, %{socket: socket, transport: transport} = state) do
-      {:reply, transport.send(socket, data), state}
-    end
-
-    def handle_call(:peername, _from, %{socket: socket} = state) do
-      {ip, port} = :inet.peername(socket)
-      {:reply, {ip, port, self()}, state}
-    end
-
-    def send(ref, {ip, port}, data) do
-      # TODO: this needs to do something other than
-      # just look up by source IP and source port.
-      peernames = peernames(ref)
-
-      {_ip, _port, pid} =
-        Enum.find(peernames, fn {peer_ip, peer_port, _pid} ->
-          peer_ip == ip and peer_port == port
-        end)
-
-      GenServer.call(pid, {:send, data})
-    end
-
-    def peernames(ref) do
-      connections = :ranch.procs(ref, :connections)
-
-      Enum.map(connections, fn conn ->
-        {:ok, {ip, port, pid}} = GenServer.call(conn, :peername)
-        {ip, port, pid}
-      end)
-    end
-
-    defp set_onward_route(message, address) do
-      onward_route =
-        message
-        |> Message.onward_route()
-        |> Enum.drop_while(fn a -> a === address end)
-
-      {:ok, %{message | onward_route: onward_route}}
-    end
-
-    defp set_return_route(%{return_route: return_route} = message, address) do
-      {:ok, %{message | return_route: [address | return_route]}}
-    end
-
-    defp send_to_router(message) do
-      Ockam.Router.route(message)
-    end
+    def default_ip, do: {0, 0, 0, 0}
+    def default_port, do: 4000
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/udp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/udp.ex
@@ -1,11 +1,20 @@
 defmodule Ockam.Transport.UDP do
-  @moduledoc false
+  @moduledoc """
+  UDP transport
+  """
 
   alias Ockam.Transport.UDP.Listener
 
-  @spec create_listener(keyword) :: :ignore | {:error, any} | {:ok, any}
-  @doc false
-  def create_listener(options \\ []) do
-    Listener.create(options)
+  @doc """
+  Start a UDP transport
+
+  ## Parameters
+  - options:
+      port: optional(integer) - port to listen on
+      ip: optional(integer) - ip address to listen on
+  """
+  @spec start(options :: keyword) :: :ignore | {:error, any} | {:ok, any}
+  def start(options \\ []) do
+    Listener.start_link(options)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/address.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/address.ex
@@ -11,7 +11,7 @@ defmodule Ockam.Transport.UDPAddress do
   def type(), do: @address_type
 
   def new(ip, port) do
-    value = serialize_ip_port(ip, port)
+    value = format_ip_port(ip, port)
 
     %Address{type: @address_type, value: value}
   end
@@ -30,8 +30,13 @@ defmodule Ockam.Transport.UDPAddress do
     end
   end
 
-  defp serialize_ip_port(ip, port) do
+  def format_ip_port(ip, port) when is_tuple(ip) do
     ip_str = to_string(:inet.ntoa(ip))
+    "#{ip_str}:#{port}"
+  end
+
+  def format_ip_port(ip_str, port) when is_binary(ip_str) do
+    {:ok, _ip} = :inet.parse_address(to_charlist(ip_str))
     "#{ip_str}:#{port}"
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
@@ -1,66 +1,101 @@
 defmodule Ockam.Transport.UDP.Listener do
   @moduledoc false
 
-  use Ockam.Worker
+  use GenServer
 
   alias Ockam.Message
+  alias Ockam.Router
   alias Ockam.Telemetry
   alias Ockam.Transport.UDPAddress
   alias Ockam.Wire
 
+  require Logger
+
   @wire_encoder_decoder Ockam.Wire.Binary.V2
+
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options)
+  end
+
+  def send_message(listener, message) do
+    GenServer.cast(listener, {:send_message, message})
+  end
+
+  def child_spec(options) do
+    id = process_id(options)
+
+    %{
+      id: id,
+      start: {__MODULE__, :start_link, [options]}
+    }
+  end
+
+  def process_id(options) do
+    ip = Keyword.get_lazy(options, :ip, &default_ip/0)
+    port = Keyword.get_lazy(options, :port, &default_port/0)
+
+    "UDP_LISTENER_#{UDPAddress.format_ip_port(ip, port)}"
+  end
 
   @doc false
   @impl true
-  def setup(options, state) do
+  def init(options) do
     ip = Keyword.get_lazy(options, :ip, &default_ip/0)
     port = Keyword.get_lazy(options, :port, &default_port/0)
 
     udp_open_options = [:binary, :inet, {:ip, ip}, {:active, true}]
-    udp_address = UDPAddress.new(ip, port)
-
-    route_outgoing = Keyword.get(options, :route_outgoing, false)
 
     with {:ok, socket} <- :gen_udp.open(port, udp_open_options),
-         :ok <- setup_routed_message_handler(route_outgoing, state.address) do
-      state = Map.put(state, :socket, socket)
-      state = Map.put(state, :udp_address, udp_address)
-      {:ok, state}
+         :ok <- setup_routed_message_handler(self()) do
+      {:ok, %{socket: socket}}
     end
   end
 
-  defp setup_routed_message_handler(true, listener) do
-    handler = fn message -> handle_routed_message(listener, message) end
+  defp setup_routed_message_handler(listener) do
+    handler = fn message ->
+      handle_routed_message(listener, message)
+    end
 
     with :ok <- Router.set_message_handler(UDPAddress.type(), handler) do
       :ok
     end
   end
 
-  defp setup_routed_message_handler(_something_else, _listener), do: :ok
-
   defp handle_routed_message(listener, message) do
-    Node.send(listener, message)
+    send_message(listener, message)
   end
 
   @doc false
   @impl true
-
-  def handle_message({:udp, _socket, _from_ip, _from_port, _packet} = udp_message, state) do
+  def handle_info({:udp, _socket, _from_ip, _from_port, _packet} = udp_message, state) do
     ## TODO: use from_ip and from_port to route messages back
-    decode_and_send_to_router(udp_message, state)
+    case decode_and_send_to_router(udp_message, state) do
+      {:ok, state} ->
+        {:noreply, state}
+
+      {:error, error} ->
+        {:stop, {:error, error}, state}
+    end
   end
 
-  def handle_message(message, state) do
-    encode_and_send_over_udp(message, state)
+  @impl true
+  def handle_cast({:send_message, message}, state) do
+    case encode_and_send_over_udp(message, state) do
+      {:ok, state} ->
+        {:noreply, state}
+
+      {:error, error} ->
+        {:stop, {:error, error}, state}
+    end
   end
 
   defp decode_and_send_to_router(udp_message, state) do
     {function_name, _} = __ENV__.function
-    {:udp, _socket, _from_ip, _from_port, packet} = udp_message
+    {:udp, _socket, from_ip, from_port, packet} = udp_message
 
     with {:ok, decoded} <- Wire.decode(@wire_encoder_decoder, packet),
-         :ok <- Router.route(decoded) do
+         {:ok, message} <- set_return_route(decoded, UDPAddress.new(from_ip, from_port)),
+         :ok <- Router.route(message) do
       Telemetry.emit_event(function_name, metadata: %{name: "successfully_decoded"})
       {:ok, state}
     else
@@ -68,18 +103,18 @@ defmodule Ockam.Transport.UDP.Listener do
     end
   end
 
-  defp encode_and_send_over_udp(message, %{socket: socket, udp_address: address} = state) do
+  defp encode_and_send_over_udp(message, %{socket: socket} = state) do
     message = create_outgoing_message(message)
     {function_name, _} = __ENV__.function
 
-    with {:ok, destination, message} <- pick_destination_and_set_onward_route(message, address),
-         {:ok, message} <- set_return_route(message, address),
+    with {:ok, destination, message} <- pick_destination_and_set_onward_route(message),
          {:ok, encoded_message} <- Wire.encode(@wire_encoder_decoder, message),
          :ok <- :gen_udp.send(socket, destination.ip, destination.port, encoded_message) do
       Telemetry.emit_event(function_name, metadata: %{name: "successfully_encoded_and_sent"})
       {:ok, state}
     else
-      {:error, reason} -> {:error, Telemetry.emit_event(function_name, metadata: %{name: reason})}
+      {:error, reason} ->
+        {:error, Telemetry.emit_event(function_name, metadata: %{name: reason})}
     end
   end
 
@@ -91,11 +126,10 @@ defmodule Ockam.Transport.UDP.Listener do
     }
   end
 
-  defp pick_destination_and_set_onward_route(message, address) do
+  defp pick_destination_and_set_onward_route(message) do
     {dest_address, onward_route} =
       message
       |> Message.onward_route()
-      |> Enum.drop_while(fn a -> a === address end)
       |> List.pop_at(0)
 
     with true <- UDPAddress.is_udp_address(dest_address),
@@ -115,7 +149,7 @@ defmodule Ockam.Transport.UDP.Listener do
   end
 
   defp default_ip do
-    Application.get_env(:ockam, :default_ip, {127, 0, 0, 1})
+    Application.get_env(:ockam, :default_ip, {0, 0, 0, 0})
   end
 
   defp default_port do

--- a/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/router_test.exs
@@ -147,9 +147,9 @@ defmodule Ockam.Router.Tests do
 
       :erlang.trace(printer, true, [:receive])
 
-      assert {:ok, _address_a} = UDP.create_listener(port: 3000, route_outgoing: true)
+      assert {:ok, _address_b} = UDP.start(port: 4000)
 
-      assert {:ok, _address_b} = UDP.create_listener(port: 4000)
+      assert {:ok, _address_a} = UDP.start(port: 3000)
 
       Ockam.Router.route(message)
 
@@ -177,9 +177,7 @@ defmodule Ockam.Router.Tests do
 
       :erlang.trace(printer, true, [:receive])
 
-      assert {:ok, _address_a} = TCP.create_listener(port: 3000, route_outgoing: true)
-
-      assert {:ok, _address_b} = TCP.create_listener(port: 4000)
+      assert {:ok, _address_b} = TCP.start(listen: [port: 4000])
 
       Ockam.Router.route(message)
 
@@ -205,9 +203,7 @@ defmodule Ockam.Router.Tests do
 
       :erlang.trace(printer, true, [:receive])
 
-      assert {:ok, _address_a} = TCP.create_listener(port: 3001, route_outgoing: true)
-
-      assert {:ok, _address_b} = TCP.create_listener(port: 4001)
+      assert {:ok, _address_b} = TCP.start(listen: [port: 4001])
 
       Ockam.Router.route(message)
 
@@ -234,11 +230,9 @@ defmodule Ockam.Router.Tests do
 
       :erlang.trace(printer, true, [:receive])
 
-      assert {:ok, _address_a} = TCP.create_listener(port: 3002, route_outgoing: true)
+      assert {:ok, _address_a} = TCP.start(listen: [port: 5002])
 
-      assert {:ok, _address_a} = TCP.create_listener(port: 5002, route_outgoing: true)
-
-      assert {:ok, _address_b} = TCP.create_listener(port: 4002, route_outgoing: true)
+      assert {:ok, _address_b} = TCP.start(listen: [port: 4002])
 
       Ockam.Router.route(message)
 
@@ -279,9 +273,7 @@ defmodule Ockam.Router.Tests do
       :erlang.trace(echo, true, [:receive])
       :erlang.trace(client_forwarder, true, [:receive])
 
-      assert {:ok, _listener_address_a} = TCP.create_listener(port: 6000, route_outgoing: true)
-
-      assert {:ok, _listener_address_b} = TCP.create_listener(port: 5000)
+      assert {:ok, _listener_address_b} = TCP.start(listen: [port: 5000])
 
       Ockam.Router.route(request)
 
@@ -375,9 +367,7 @@ defmodule Ockam.Router.Tests do
         payload: "ping 1"
       }
 
-      assert {:ok, _listener_address_a} = TCP.create_listener(port: 6001, route_outgoing: true)
-
-      assert {:ok, _listener_address_b} = TCP.create_listener(port: 5001)
+      assert {:ok, _listener_address_b} = TCP.start(listen: [port: 5001])
 
       Ockam.Router.route(request)
 

--- a/implementations/elixir/ockam/ockam/test/ockam/transport/udp_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/transport/udp_test.exs
@@ -4,8 +4,13 @@ defmodule Ockam.Transport.UDP.Tests do
   alias Ockam.Transport.UDP
 
   describe "Ockam.Transport.UDP" do
-    test "create_listener/1 creates a listener with default options" do
-      assert {:ok, _listener} = UDP.create_listener()
+    test "start/1 creates a listener with default options" do
+      assert {:ok, listener} = UDP.start()
+      socket = listener |> :sys.get_state() |> Map.get(:socket)
+
+      info = Port.info(socket)
+
+      assert 'udp_inet' = Keyword.get(info, :name)
     end
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub.ex
@@ -38,18 +38,11 @@ defmodule Ockam.Hub do
           ]
         },
         # Add a TCP listener
-        {Ockam.Transport.TCP.Listener,
-         [
-           port: tcp_transport_port,
-           address: "TCP_LISTENER_#{tcp_transport_port}",
-           route_outgoing: true
-         ]},
+        {Ockam.Transport.TCP, [listen: [port: tcp_transport_port]]},
         # Add a UDP listener
         {Ockam.Transport.UDP.Listener,
          [
-           port: udp_transport_port,
-           address: "UDP_LISTENER_#{udp_transport_port}",
-           route_outgoing: true
+           port: udp_transport_port
          ]},
         {Ockam.Hub.Web.Router, [port: Application.get_env(:ockam_hub, :web_port, web_port)]}
       ] ++


### PR DESCRIPTION
Separate tcp transport from tcp listener
Make tcp listener a gen server instead of a worker
Change the transport start API to make send enabled by default, but listener optional

TCP transport usage:

To create a listening transport:
```
Ockam.Transport.TCP.start(listen: [port: 4000])
```

To create a client-only transport:
```
Ockam.Transport.TCP.start()
```

Listening transport always supports client connections:
```
>> Ockam.Transport.TCP.start(listen: [port: 4000])
>> Ockam.Node.register_address("me", self())
>> Ockam.Router.route(%{onward_route: [Ockam.Transport.TCPAddress.new("localhost", 4000), "me"], return_route: [], payload: "HI"})

>> flush()
%{
  onward_route: ["me"],
  payload: "HI",
  return_route: ["c5bf5d5c23a6e238"],
  version: 1
}
```

Non-listening transport does not require port binding and can still send messages:

Node A:
```
>> Ockam.Transport.TCP.start(listen: [port: 4000])
>> Ockam.Node.register_address("me", self())
```

Node B:
```
>> Ockam.Transport.TCP.start()
>> Ockam.Router.route(%{onward_route: [Ockam.Transport.TCPAddress.new("localhost", 4000), "me"], return_route: [], payload: "HI"})
```

Node A:
```
>> flush()
%{
  onward_route: ["me"],
  payload: "HI",
  return_route: ["6ec14e4479d489e6"],
  version: 1
}
:ok

```
