### PR TITLE
fix(rust): change `size_t` to `uint32_t` in C header file

### DIFF
--- a/implementations/elixir/ockam/ockam_vault_software/native/vault/software/vault.c
+++ b/implementations/elixir/ockam/ockam_vault_software/native/vault/software/vault.c
@@ -263,7 +263,7 @@ ERL_NIF_TERM secret_export(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
     }
 
     uint8_t buffer[MAX_SECRET_EXPORT_SIZE];
-    size_t length = 0;
+    uint32_t length = 0;
 
     ockam_vault_extern_error_t error = ockam_vault_secret_export(vault, secret_handle, buffer, MAX_SECRET_EXPORT_SIZE, &length);
     if (extern_error_has_error(&error)) {
@@ -297,7 +297,7 @@ ERL_NIF_TERM secret_publickey_get(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
     }
 
     uint8_t buffer[MAX_PUBLICKEY_SIZE];
-    size_t length = 0;
+    uint32_t length = 0;
 
     ockam_vault_extern_error_t error = ockam_vault_secret_publickey_get(vault, secret_handle, buffer, MAX_SECRET_EXPORT_SIZE, &length);
     if (extern_error_has_error(&error)) {
@@ -504,7 +504,7 @@ ERL_NIF_TERM aead_aes_gcm_encrypt(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
 
     memset(cipher_text, 0, size);
 
-    size_t length = 0;
+    uint32_t length = 0;
 
     ockam_vault_extern_error_t error = ockam_vault_aead_aes_gcm_encrypt(vault,
                                                                         key_handle,
@@ -572,7 +572,7 @@ ERL_NIF_TERM aead_aes_gcm_decrypt(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
 
     memset(plain_text, 0, size);
 
-    size_t length = 0;
+    uint32_t length = 0;
 
     ockam_vault_extern_error_t error = ockam_vault_aead_aes_gcm_decrypt(vault,
                                                                         key_handle,

--- a/implementations/rust/ockam/ockam_ffi/include/vault.h
+++ b/implementations/rust/ockam/ockam_ffi/include/vault.h
@@ -69,7 +69,7 @@ ockam_vault_extern_error_t ockam_vault_default_init(ockam_vault_t* vault);
  */
 ockam_vault_extern_error_t ockam_vault_sha256(ockam_vault_t  vault,
                                               const uint8_t* input,
-                                              size_t         input_length,
+                                              uint32_t       input_length,
                                               uint8_t*       digest);
 
 /**
@@ -98,7 +98,7 @@ ockam_vault_extern_error_t ockam_vault_secret_import(ockam_vault_t              
                                                      ockam_vault_secret_t*           secret,
                                                      ockam_vault_secret_attributes_t attributes,
                                                      const uint8_t*                  input,
-                                                     size_t                          input_length);
+                                                     uint32_t                        input_length);
 
 /**
  * @brief   Export data from an ockam vault secret into the supplied output buffer.
@@ -112,7 +112,7 @@ ockam_vault_extern_error_t ockam_vault_secret_import(ockam_vault_t              
 ockam_vault_extern_error_t ockam_vault_secret_export(ockam_vault_t        vault,
                                                      ockam_vault_secret_t secret,
                                                      uint8_t*             output_buffer,
-                                                     size_t               output_buffer_size,
+                                                     uint32_t             output_buffer_size,
                                                      size_t*              output_buffer_length);
 
 /**
@@ -127,7 +127,7 @@ ockam_vault_extern_error_t ockam_vault_secret_export(ockam_vault_t        vault,
 ockam_vault_extern_error_t ockam_vault_secret_publickey_get(ockam_vault_t        vault,
                                                             ockam_vault_secret_t secret,
                                                             uint8_t*             output_buffer,
-                                                            size_t               output_buffer_size,
+                                                            uint32_t             output_buffer_size,
                                                             size_t*              output_buffer_length);
 
 /**
@@ -162,7 +162,7 @@ ockam_vault_extern_error_t ockam_vault_secret_destroy(ockam_vault_t vault, ockam
 ockam_vault_extern_error_t ockam_vault_ecdh(ockam_vault_t         vault,
                                             ockam_vault_secret_t  privatekey,
                                             const uint8_t*        peer_publickey,
-                                            size_t                peer_publickey_length,
+                                            uint32_t              peer_publickey_length,
                                             ockam_vault_secret_t* shared_secret);
 
 /**
@@ -200,11 +200,11 @@ ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_encrypt(ockam_vault_t       
                                                             ockam_vault_secret_t key,
                                                             uint16_t             nonce,
                                                             const uint8_t*       additional_data,
-                                                            size_t               additional_data_length,
+                                                            uint32_t             additional_data_length,
                                                             const uint8_t*       plaintext,
-                                                            size_t               plaintext_length,
+                                                            uint32_t             plaintext_length,
                                                             uint8_t*             ciphertext_and_tag,
-                                                            size_t               ciphertext_and_tag_size,
+                                                            uint32_t             ciphertext_and_tag_size,
                                                             size_t*              ciphertext_and_tag_length);
 
 /**
@@ -225,11 +225,11 @@ ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_decrypt(ockam_vault_t       
                                                             ockam_vault_secret_t key,
                                                             uint16_t             nonce,
                                                             const uint8_t*       additional_data,
-                                                            size_t               additional_data_length,
+                                                            uint32_t             additional_data_length,
                                                             const uint8_t*       ciphertext_and_tag,
-                                                            size_t               ciphertext_and_tag_length,
+                                                            uint32_t             ciphertext_and_tag_length,
                                                             uint8_t*             plaintext,
-                                                            size_t               plaintext_size,
+                                                            uint32_t             plaintext_size,
                                                             size_t*              plaintext_length);
 
 /**

--- a/implementations/rust/ockam/ockam_ffi/include/vault.h
+++ b/implementations/rust/ockam/ockam_ffi/include/vault.h
@@ -113,7 +113,7 @@ ockam_vault_extern_error_t ockam_vault_secret_export(ockam_vault_t        vault,
                                                      ockam_vault_secret_t secret,
                                                      uint8_t*             output_buffer,
                                                      uint32_t             output_buffer_size,
-                                                     size_t*              output_buffer_length);
+                                                     uint32_t&            output_buffer_length);
 
 /**
  * @brief   Retrieve the public key from an ockam vault secret.
@@ -128,7 +128,7 @@ ockam_vault_extern_error_t ockam_vault_secret_publickey_get(ockam_vault_t       
                                                             ockam_vault_secret_t secret,
                                                             uint8_t*             output_buffer,
                                                             uint32_t             output_buffer_size,
-                                                            size_t*              output_buffer_length);
+                                                            uint32_t*            output_buffer_length);
 
 /**
  * @brief   Retrieve the attributes for a specified secret
@@ -205,7 +205,7 @@ ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_encrypt(ockam_vault_t       
                                                             uint32_t             plaintext_length,
                                                             uint8_t*             ciphertext_and_tag,
                                                             uint32_t             ciphertext_and_tag_size,
-                                                            size_t*              ciphertext_and_tag_length);
+                                                            uint32_t*            ciphertext_and_tag_length);
 
 /**
  * @brief   Decrypt a payload using AES-GCM.
@@ -230,7 +230,7 @@ ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_decrypt(ockam_vault_t       
                                                             uint32_t             ciphertext_and_tag_length,
                                                             uint8_t*             plaintext,
                                                             uint32_t             plaintext_size,
-                                                            size_t*              plaintext_length);
+                                                            uint32_t*            plaintext_length);
 
 /**
  * @brief   Deinitialize the specified ockam vault object

--- a/implementations/rust/ockam/ockam_ffi/include/vault.h
+++ b/implementations/rust/ockam/ockam_ffi/include/vault.h
@@ -113,7 +113,7 @@ ockam_vault_extern_error_t ockam_vault_secret_export(ockam_vault_t        vault,
                                                      ockam_vault_secret_t secret,
                                                      uint8_t*             output_buffer,
                                                      uint32_t             output_buffer_size,
-                                                     uint32_t&            output_buffer_length);
+                                                     uint32_t*            output_buffer_length);
 
 /**
  * @brief   Retrieve the public key from an ockam vault secret.

--- a/implementations/rust/ockam/ockam_ffi/src/vault.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault.rs
@@ -130,7 +130,7 @@ pub extern "C" fn ockam_vault_secret_import(
 pub extern "C" fn ockam_vault_secret_export(
     context: FfiVaultFatPointer,
     secret: SecretKeyHandle,
-    output_buffer: &mut u8,
+    output_buffer: *mut u8,
     output_buffer_size: u32,
     output_buffer_length: &mut u32,
 ) -> FfiOckamError {
@@ -158,7 +158,7 @@ pub extern "C" fn ockam_vault_secret_export(
 pub extern "C" fn ockam_vault_secret_publickey_get(
     context: FfiVaultFatPointer,
     secret: SecretKeyHandle,
-    output_buffer: &mut u8,
+    output_buffer: *mut u8,
     output_buffer_size: u32,
     output_buffer_length: &mut u32,
 ) -> FfiOckamError {


### PR DESCRIPTION
### Proposed Changes

- fix  ockam-network/ockam#1791
