### PR TITLE
feat(rust): add nostd + alloc compilation support to ockam

### DIFF
--- a/examples/rust/get_started/Cargo.lock
+++ b/examples/rust/get_started/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -881,7 +881,7 @@ dependencies = [
  "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
  "tracing",
 ]
 
@@ -894,7 +894,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
 ]
 
 [[package]]
@@ -917,7 +917,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -982,7 +982,7 @@ dependencies = [
  "ockam_transport_core",
  "rand 0.7.3",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tokio",
  "tracing",
 ]
@@ -996,7 +996,7 @@ dependencies = [
  "ockam_core",
  "ockam_node",
  "ockam_transport_core",
- "serde_bare 0.4.0",
+ "serde_bare",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1383,18 +1383,8 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -8,7 +8,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+ "heapless",
  "rand_core 0.6.3",
 ]
 
@@ -78,6 +79,18 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-trait"
@@ -168,7 +181,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -224,16 +237,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal 0.2.5",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -246,6 +271,36 @@ dependencies = [
  "bitfield",
  "embedded-hal",
  "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-rt"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
 ]
 
 [[package]]
@@ -265,17 +320,43 @@ checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
+<<<<<<< HEAD
  "cortex-m",
+=======
+ "cortex-m 0.7.3",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
  "riscv",
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -285,7 +366,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -317,7 +398,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -493,6 +574,24 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -587,6 +686,7 @@ checksum = "fe65ef062f1af5b1b189842b0bc45bd671c38e1d22c6aa22e6ada03d01026d53"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "serde",
  "spin 0.9.2",
  "stable_deref_trait",
 ]
@@ -643,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -676,6 +776,12 @@ name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
 
 [[package]]
 name = "lock_api"
@@ -800,7 +906,7 @@ dependencies = [
  "bls12_381_plus",
  "hex",
  "ockam_channel",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_entity",
  "ockam_key_exchange_core",
  "ockam_key_exchange_xx",
@@ -814,7 +920,7 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "serde_json",
  "sha2",
  "signature_bbs_plus",
@@ -829,7 +935,7 @@ name = "ockam_channel"
 version = "0.26.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_key_exchange_xx",
  "ockam_node",
@@ -837,8 +943,9 @@ dependencies = [
  "ockam_vault_core",
  "ockam_vault_sync_core",
  "rand 0.8.4",
+ "rand_pcg",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
  "tracing",
 ]
 
@@ -854,7 +961,24 @@ dependencies = [
  "rand 0.8.4",
  "rand_pcg",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
+ "spin 0.9.2",
+]
+
+[[package]]
+name = "ockam_core"
+version = "0.31.0"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+dependencies = [
+ "async-trait",
+ "core2",
+ "hashbrown 0.11.2",
+ "heapless",
+ "hex",
+ "rand 0.8.4",
+ "rand_pcg",
+ "serde",
+ "serde_bare",
  "spin 0.9.2",
 ]
 
@@ -868,7 +992,7 @@ dependencies = [
  "group",
  "heapless",
  "ockam_channel",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_key_exchange_xx",
  "ockam_node",
@@ -878,7 +1002,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -887,10 +1011,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_executor"
+version = "0.0.1"
+source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+dependencies = [
+ "alloc-cortex-m",
+ "cortex-m 0.7.3",
+ "cortex-m-rt",
+ "cortex-m-semihosting",
+ "crossbeam-queue",
+ "futures",
+ "heapless",
+ "ockam_core 0.31.0 (git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc)",
+ "panic-semihosting",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "ockam_key_exchange_core"
 version = "0.23.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "zeroize",
 ]
@@ -899,7 +1041,7 @@ dependencies = [
 name = "ockam_key_exchange_xx"
 version = "0.23.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_vault_core",
  "zeroize",
@@ -910,7 +1052,8 @@ name = "ockam_node"
 version = "0.29.0"
 dependencies = [
  "heapless",
- "ockam_core",
+ "ockam_core 0.31.0",
+ "ockam_executor",
  "ockam_node_no_std",
  "tokio",
  "tracing",
@@ -936,7 +1079,7 @@ dependencies = [
 name = "ockam_transport_core"
 version = "0.5.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "tracing",
 ]
 
@@ -947,12 +1090,12 @@ dependencies = [
  "async-trait",
  "futures",
  "hashbrown 0.9.1",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_node",
  "ockam_transport_core",
  "rand 0.7.3",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tokio",
  "tracing",
 ]
@@ -966,9 +1109,10 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "rand 0.8.4",
+ "rand_pcg",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -984,7 +1128,8 @@ name = "ockam_vault_core"
 version = "0.25.0"
 dependencies = [
  "cfg-if",
- "ockam_core",
+ "heapless",
+ "ockam_core 0.31.0",
  "serde",
  "serde-big-array",
  "zeroize",
@@ -995,11 +1140,12 @@ name = "ockam_vault_sync_core"
 version = "0.22.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_node",
  "ockam_vault",
  "ockam_vault_core",
  "rand 0.8.4",
+ "rand_pcg",
  "serde",
  "serde-big-array",
  "tracing",
@@ -1025,6 +1171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "panic-semihosting"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
+dependencies = [
+ "cortex-m 0.7.3",
+ "cortex-m-semihosting",
 ]
 
 [[package]]
@@ -1111,6 +1267,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
 name = "radium"
@@ -1330,19 +1492,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1717,7 +1870,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -66,6 +66,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "alloc-cortex-m"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
+dependencies = [
+ "cortex-m 0.6.7",
+ "linked_list_allocator",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +262,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -320,17 +347,11 @@ checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
-<<<<<<< HEAD
- "cortex-m",
-=======
  "cortex-m 0.7.3",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
  "riscv",
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,7 +371,6 @@ dependencies = [
 ]
 
 [[package]]
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +974,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown 0.11.2",
  "heapless",
  "hex",
@@ -968,10 +988,10 @@ dependencies = [
 [[package]]
 name = "ockam_core"
 version = "0.31.0"
-source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#29e2287e54199ffb335753f9665504b4c7612457"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown 0.11.2",
  "heapless",
  "hex",
@@ -1013,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "ockam_executor"
 version = "0.0.1"
-source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+source = "git+https://github.com/ockam-network/ockam_executor.git?rev=3daeffa#3daeffa593f2d55611a8e4229978bb6839f4c669"
 dependencies = [
  "alloc-cortex-m",
  "cortex-m 0.7.3",
@@ -1493,9 +1513,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -21,7 +21,7 @@ noise_xx = ["ockam_key_exchange_xx", "ockam_channel/noise_xx"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "ockam_node/std", "serde/std", "ockam_node_attribute/std"]
+std = ["ockam_core/std", "ockam_node/std", "serde/std", "serde_bare/std", "ockam_node_attribute/std"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
@@ -29,7 +29,7 @@ no_std = ["ockam_core/no_std", "ockam_node/no_std", "serde"]
 
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
-alloc = ["ockam_core/alloc", "ockam_node/alloc", "serde/alloc", "ockam_node_attribute/no_std"]
+alloc = ["ockam_core/alloc", "ockam_node/alloc", "serde/alloc", "serde_bare/alloc", "ockam_node_attribute/no_std"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default-features = false }
@@ -49,7 +49,7 @@ bls12_381_plus = "0.5"
 signature_core = { version = "0.23.0"    , path = "../signature_core" }
 signature_bbs_plus = { version = "0.23.0"    , path = "../signature_bbs_plus", package = "signature_bbs_plus" }
 signature_bls = { version = "0.21.0"    , path = "../signature_bls", package = "signature_bls" }
-serde_bare = "0.4"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde-big-array = "0.3"
 sha2 = "0.9"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -68,25 +68,6 @@ alloc = [
     "serde_bare/alloc"
 ]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = [
-    "ockam_core/unsafe_random",
-    "ockam_node/unsafe_random",
-    "ockam_vault_core/unsafe_random",
-    "ockam_vault_sync_core/unsafe_random",
-    "ockam_vault/unsafe_random",
-    "ockam_channel/unsafe_random",
-    "ockam_key_exchange_core/unsafe_random",
-    "ockam_key_exchange_xx/unsafe_random",
-    "ockam_entity/unsafe_random",
-    "signature_bbs_plus/unsafe_random",
-    "signature_bls/unsafe_random"
-]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default-features = false }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    , default-features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -86,7 +86,7 @@ bls12_381_plus = { version = "0.5", default-features = false }
 signature_core = { version = "0.23.0"    , path = "../signature_core" }
 signature_bbs_plus = { version = "0.23.0"    , path = "../signature_bbs_plus", package = "signature_bbs_plus" }
 signature_bls = { version = "0.21.0"    , path = "../signature_bls", package = "signature_bls" }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Ockam Developers"]
 categories = ["cryptography", "asynchronous", "authentication", "network-programming", "embedded"]
 description = "End-to-end encryption and mutual authentication for distributed applications."
 edition = "2018"
+resolver = "2"
 exclude = [
     "tests/**"
 ]
@@ -21,40 +22,95 @@ noise_xx = ["ockam_key_exchange_xx", "ockam_channel/noise_xx"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "ockam_node/std", "serde/std", "serde_bare/std", "ockam_node_attribute/std"]
+std = [
+    "ockam_core/std",
+    "ockam_node/std",
+    "ockam_node_attribute/std",
+    "ockam_vault_core/std",
+    "ockam_vault_sync_core/std",
+    "ockam_vault/std",
+    "ockam_channel/std",
+    "ockam_key_exchange_core/std",
+    "ockam_key_exchange_xx/std",
+    "ockam_entity/std",
+    "rand/default",
+    "serde/std",
+    "serde_bare/std"
+]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
-no_std = ["ockam_core/no_std", "ockam_node/no_std", "serde"]
+no_std = [
+    "ockam_core/no_std",
+    "ockam_node/no_std",
+    "ockam_vault_core/no_std",
+    "ockam_vault_sync_core/no_std",
+    "ockam_vault/no_std",
+    "ockam_channel/no_std",
+    "ockam_key_exchange_core/no_std",
+    "ockam_key_exchange_xx/no_std",
+    "ockam_entity/no_std"
+]
 
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
-alloc = ["ockam_core/alloc", "ockam_node/alloc", "serde/alloc", "serde_bare/alloc", "ockam_node_attribute/no_std"]
+alloc = [
+    "ockam_core/alloc",
+    "ockam_node/alloc",
+    "ockam_vault_core/alloc",
+    "ockam_vault_sync_core/alloc",
+    "ockam_vault/alloc",
+    "ockam_channel/alloc",
+    "ockam_key_exchange_core/alloc",
+    "ockam_key_exchange_xx/alloc",
+    "ockam_entity/alloc",
+    "serde/alloc",
+    "serde_bare/alloc"
+]
+
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = [
+    "ockam_core/unsafe_random",
+    "ockam_node/unsafe_random",
+    "ockam_vault_core/unsafe_random",
+    "ockam_vault_sync_core/unsafe_random",
+    "ockam_vault/unsafe_random",
+    "ockam_channel/unsafe_random",
+    "ockam_key_exchange_core/unsafe_random",
+    "ockam_key_exchange_xx/unsafe_random",
+    "ockam_entity/unsafe_random",
+    "signature_bbs_plus/unsafe_random",
+    "signature_bls/unsafe_random"
+]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default-features = false }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    , default-features = false }
-ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.20.0"    }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.22.0"    , optional = true }
-ockam_vault = { path = "../ockam_vault", version = "0.25.0"    , optional = true }
-ockam_channel = { path = "../ockam_channel", version = "0.26.0"    }
+ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.20.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0", default_features = false }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.22.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "0.25.0", default_features = false, optional = true }
+ockam_channel = { path = "../ockam_channel", version = "0.26.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "0.25.0"    , optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.23.0"    }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.23.0"    , optional = true }
-ockam_entity = { path = "../ockam_entity", version = "0.20.0"    }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.23.0", default_features = false }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.23.0", default_features = false, optional = true }
+ockam_entity = { path = "../ockam_entity", version = "0.20.0", default_features = false }
 arrayref = "0.3"
 async-trait = "0.1"
-bls12_381_plus = "0.5"
+bls12_381_plus = { version = "0.5", default-features = false }
 signature_core = { version = "0.23.0"    , path = "../signature_core" }
 signature_bbs_plus = { version = "0.23.0"    , path = "../signature_bbs_plus", package = "signature_bbs_plus" }
 signature_bls = { version = "0.21.0"    , path = "../signature_bls", package = "signature_bls" }
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
-sha2 = "0.9"
-tracing = "0.1"
-rand = "0.8"
+sha2 = { version = "0.9", default-features = false }
+tracing = { version = "0.1", default-features = false }
+rand = { version = "0.8", default-features = false }
 hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam/src/forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/forwarder.rs
@@ -1,4 +1,5 @@
 use crate::Context;
+use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{Address, Any, LocalMessage, Result, Route, Routed, TransportMessage, Worker};
 use tracing::info;
 

--- a/implementations/rust/ockam/ockam/src/lease.rs
+++ b/implementations/rust/ockam/ockam/src/lease.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 
+use ockam_core::compat::{string::String, vec::Vec};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// A lease for managing secrets

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate core;
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 #[macro_use]
@@ -30,11 +31,7 @@ pub use ockam_node_attribute::*;
 // ---
 
 // Export node implementation
-#[cfg(feature = "std")]
 pub use ockam_node::*;
-
-#[cfg(not(feature = "std"))]
-pub use ockam_node_no_std::*;
 // ---
 
 mod delay;
@@ -51,6 +48,7 @@ pub use error::*;
 pub use forwarder::*;
 pub use lease::*;
 pub use ockam_core::compat;
+pub use ockam_core::println;
 pub use ockam_core::worker;
 pub use ockam_entity::*;
 pub use protocols::*;

--- a/implementations/rust/ockam/ockam/src/protocols/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/mod.rs
@@ -1,5 +1,6 @@
 //! Advanced Ockam worker protocols
 
+use ockam_core::compat::vec::Vec;
 use ockam_core::{Message, ProtocolId};
 use serde::{Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam/src/protocols/parser.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/parser.rs
@@ -3,8 +3,12 @@ use crate::{
     Routed, Worker,
 };
 use core::{marker::PhantomData, ops::Deref};
-use ockam_core::compat::{collections::BTreeMap, sync::Arc};
-use std::sync::RwLock;
+use ockam_core::compat::{
+    boxed::Box,
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+    vec::Vec,
+};
 
 /// A parser for a protocol fragment
 ///
@@ -102,6 +106,10 @@ impl<W: Worker> ProtocolParserImpl<W> {
     {
         let p: Arc<Box<dyn ParserFragment<W> + Send + Sync>> = Arc::new(Box::new(parser));
 
+        // TODO Match semantics of no_std RwLock implementation to std library
+        #[cfg(not(feature = "std"))]
+        let mut map = self.map.write();
+        #[cfg(feature = "std")]
         let mut map = self.map.write().unwrap();
         p.ids().into_iter().for_each(|pid| {
             map.insert(pid, Arc::clone(&p));
@@ -120,7 +128,9 @@ impl<W: Worker> ProtocolParserImpl<W> {
         trace!("Parsing message for '{}' protocol", proto.as_str());
 
         // Get the protocol specific parser
-        let map = self.map.read().unwrap();
+        let map = self.map.read(); // TODO
+        #[cfg(feature = "std")]
+        let map = map.unwrap();
         let parser = map.get(&proto).ok_or(OckamError::NoSuchParser)?;
 
         // Finally call the parser

--- a/implementations/rust/ockam/ockam/src/protocols/stream/requests.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/requests.rs
@@ -1,6 +1,7 @@
 //! Stream protocol request payloads
 
 use crate::protocols::ProtocolPayload;
+use ockam_core::compat::{string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
 use serde_bare::Uint;
 

--- a/implementations/rust/ockam/ockam/src/protocols/stream/responses.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/responses.rs
@@ -4,6 +4,7 @@ use crate::{
     protocols::{ParserFragment, ProtocolPayload},
     Any, Context, Message, ProtocolId, Result, Routed, Worker,
 };
+use ockam_core::compat::{string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
 use serde_bare::Uint;
 

--- a/implementations/rust/ockam/ockam/src/remote_forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/remote_forwarder.rs
@@ -1,13 +1,19 @@
 #![deny(missing_docs)]
 
 use crate::{route, Context, OckamError};
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
+use ockam_core::compat::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::{Address, Any, LocalMessage, Result, Route, Routed, TransportMessage, Worker};
-#[cfg(feature = "std")]
-use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
+
+#[cfg(not(feature = "std"))]
+use ockam_core::compat::rand::random;
+#[cfg(feature = "std")]
+use rand::random;
 
 /// Information about a remotely forwarded worker.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]

--- a/implementations/rust/ockam/ockam/src/remote_forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/remote_forwarder.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 
 use crate::{route, Context, OckamError};
+use ockam_core::compat::rand::random;
 use ockam_core::compat::{
     boxed::Box,
     string::{String, ToString},
@@ -9,11 +10,6 @@ use ockam_core::compat::{
 use ockam_core::{Address, Any, LocalMessage, Result, Route, Routed, TransportMessage, Worker};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
-
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
-#[cfg(feature = "std")]
-use rand::random;
 
 /// Information about a remotely forwarded worker.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]

--- a/implementations/rust/ockam/ockam/src/stream/cmd.rs
+++ b/implementations/rust/ockam/ockam/src/stream/cmd.rs
@@ -2,6 +2,7 @@ use crate::{
     protocols::{ParserFragment, ProtocolPayload},
     Address, Any, Context, Message, ProtocolId, Result, Route, Routed, TransportMessage, Worker,
 };
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// A protocol exchanged between a stream consumer and stream producer

--- a/implementations/rust/ockam/ockam/src/stream/consumer.rs
+++ b/implementations/rust/ockam/ockam/src/stream/consumer.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use crate::{Address, Any, Context, Result, Route, Routed, Worker};
 use core::time::Duration;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::LocalMessage;
 
 /// A stream worker

--- a/implementations/rust/ockam/ockam/src/stream/mod.rs
+++ b/implementations/rust/ockam/ockam/src/stream/mod.rs
@@ -1,7 +1,12 @@
 #![allow(unused)]
 
 use crate::protocols::stream::responses::StreamMessage;
+use ockam_core::compat::string::String;
 use ockam_core::RouteBuilder;
+
+#[cfg(feature = "unsafe_random")]
+use ockam_core::compat::rand::{self, distributions::Standard, prelude::Distribution, Rng};
+#[cfg(not(feature = "unsafe_random"))]
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 
 mod cmd;

--- a/implementations/rust/ockam/ockam/src/stream/mod.rs
+++ b/implementations/rust/ockam/ockam/src/stream/mod.rs
@@ -1,13 +1,9 @@
 #![allow(unused)]
 
 use crate::protocols::stream::responses::StreamMessage;
+use ockam_core::compat::rand::{self, distributions::Standard, prelude::Distribution, Rng};
 use ockam_core::compat::string::String;
 use ockam_core::RouteBuilder;
-
-#[cfg(feature = "unsafe_random")]
-use ockam_core::compat::rand::{self, distributions::Standard, prelude::Distribution, Rng};
-#[cfg(not(feature = "unsafe_random"))]
-use rand::{distributions::Standard, prelude::Distribution, Rng};
 
 mod cmd;
 pub use cmd::{StreamCmdParser, StreamWorkerCmd};

--- a/implementations/rust/ockam/ockam/src/stream/producer.rs
+++ b/implementations/rust/ockam/ockam/src/stream/producer.rs
@@ -8,7 +8,7 @@ use crate::{
     stream::StreamWorkerCmd,
     Any, Context, Message, Result, Route, Routed, TransportMessage, Worker,
 };
-use ockam_core::compat::collections::VecDeque;
+use ockam_core::compat::{boxed::Box, collections::VecDeque, string::String};
 
 use super::StreamCmdParser;
 

--- a/implementations/rust/ockam/ockam/src/unique.rs
+++ b/implementations/rust/ockam/ockam/src/unique.rs
@@ -1,4 +1,8 @@
 use ockam_core::compat::string::String;
+
+#[cfg(feature = "unsafe_random")]
+use ockam_core::compat::rand::{thread_rng, Rng};
+#[cfg(not(feature = "unsafe_random"))]
 use rand::{thread_rng, Rng};
 
 /// A simple generator for unique, human-readable identifiers suitable

--- a/implementations/rust/ockam/ockam/src/unique.rs
+++ b/implementations/rust/ockam/ockam/src/unique.rs
@@ -1,9 +1,5 @@
-use ockam_core::compat::string::String;
-
-#[cfg(feature = "unsafe_random")]
 use ockam_core::compat::rand::{thread_rng, Rng};
-#[cfg(not(feature = "unsafe_random"))]
-use rand::{thread_rng, Rng};
+use ockam_core::compat::string::String;
 
 /// A simple generator for unique, human-readable identifiers suitable
 /// for use in distributed systems.

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -51,14 +51,15 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-=======
+]
+
+[[package]]
 name = "aligned"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +76,6 @@ checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
 dependencies = [
  "cortex-m 0.6.7",
  "linked_list_allocator",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -122,12 +122,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
-<<<<<<< HEAD
  "critical-section",
  "riscv-target",
-=======
- "cortex-m 0.7.3",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -260,6 +256,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -272,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
 dependencies = [
  "aligned",
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
  "cortex-m 0.7.3",
  "volatile-register",
@@ -330,7 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,9 +341,11 @@ checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
- "cortex-m",
+ "cortex-m 0.7.3",
  "riscv",
-=======
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,7 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -908,7 +912,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -922,10 +926,10 @@ dependencies = [
 [[package]]
 name = "ockam_core"
 version = "0.31.0"
-source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#29e2287e54199ffb335753f9665504b4c7612457"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -939,7 +943,7 @@ dependencies = [
 [[package]]
 name = "ockam_executor"
 version = "0.0.1"
-source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+source = "git+https://github.com/ockam-network/ockam_executor.git?rev=3daeffa#3daeffa593f2d55611a8e4229978bb6839f4c669"
 dependencies = [
  "alloc-cortex-m",
  "cortex-m 0.7.3",
@@ -1356,9 +1360,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 
@@ -1627,7 +1631,19 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "heapless",
  "rand_core 0.6.3",
 ]
@@ -51,12 +51,31 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+=======
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "alloc-cortex-m"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
+dependencies = [
+ "cortex-m 0.6.7",
+ "linked_list_allocator",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -75,6 +94,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,8 +122,12 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
+<<<<<<< HEAD
  "critical-section",
  "riscv-target",
+=======
+ "cortex-m 0.7.3",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -163,7 +198,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -219,16 +254,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -244,6 +291,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cortex-m-rt"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +330,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +340,24 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "riscv",
+=======
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -270,7 +366,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -280,7 +376,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -312,7 +408,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -391,6 +487,102 @@ name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "futures"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+
+[[package]]
+name = "futures-task"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+
+[[package]]
+name = "futures-util"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "generic-array"
@@ -536,7 +728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -569,6 +761,12 @@ name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
 
 [[package]]
 name = "lock_api"
@@ -689,7 +887,7 @@ name = "ockam_channel"
 version = "0.26.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_key_exchange_x3dh",
  "ockam_key_exchange_xx",
@@ -722,10 +920,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_core"
+version = "0.31.0"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+dependencies = [
+ "async-trait",
+ "core2",
+ "hashbrown",
+ "heapless",
+ "hex",
+ "rand",
+ "rand_pcg",
+ "serde",
+ "serde_bare",
+ "spin 0.9.2",
+]
+
+[[package]]
+name = "ockam_executor"
+version = "0.0.1"
+source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+dependencies = [
+ "alloc-cortex-m",
+ "cortex-m 0.7.3",
+ "cortex-m-rt",
+ "cortex-m-semihosting",
+ "crossbeam-queue",
+ "futures",
+ "heapless",
+ "ockam_core 0.31.0 (git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc)",
+ "panic-semihosting",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "ockam_key_exchange_core"
 version = "0.23.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "zeroize",
 ]
@@ -735,7 +968,7 @@ name = "ockam_key_exchange_x3dh"
 version = "0.22.0"
 dependencies = [
  "arrayref",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_vault_core",
  "zeroize",
@@ -745,7 +978,7 @@ dependencies = [
 name = "ockam_key_exchange_xx"
 version = "0.23.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_vault_core",
  "zeroize",
@@ -756,7 +989,8 @@ name = "ockam_node"
 version = "0.29.0"
 dependencies = [
  "heapless",
- "ockam_core",
+ "ockam_core 0.31.0",
+ "ockam_executor",
  "ockam_node_no_std",
  "tokio",
  "tracing",
@@ -779,7 +1013,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "rand",
  "rand_pcg",
@@ -799,7 +1033,7 @@ version = "0.25.0"
 dependencies = [
  "cfg-if",
  "heapless",
- "ockam_core",
+ "ockam_core 0.31.0",
  "serde",
  "serde-big-array",
  "zeroize",
@@ -810,7 +1044,7 @@ name = "ockam_vault_sync_core"
 version = "0.22.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_node",
  "ockam_vault",
  "ockam_vault_core",
@@ -841,6 +1075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "panic-semihosting"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
+dependencies = [
+ "cortex-m 0.7.3",
+ "cortex-m-semihosting",
 ]
 
 [[package]]
@@ -875,6 +1119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "polyval"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1171,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
 name = "radium"
@@ -1088,9 +1356,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1359,19 +1627,7 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1459,7 +1715,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -3,6 +3,7 @@ name = "ockam_channel"
 version = "0.26.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault"
@@ -30,6 +31,13 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_key_exch
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc", "serde_bare/alloc"]
 
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random"]
+
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.23.0"    , default_features = false }
@@ -38,7 +46,7 @@ ockam_node = { path = "../ockam_node", version = "0.29.0"    , default_features 
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.22.0"    , default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "0.25.0"    , default_features = false, optional = true }
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 async-trait = "0.1"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -39,7 +39,7 @@ ockam_node = { path = "../ockam_node", version = "0.29.0"    , default_features 
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.22.0"    , default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "0.25.0"    , default_features = false, optional = true }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 async-trait = "0.1"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -31,13 +31,6 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_key_exch
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc", "serde_bare/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.23.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -20,7 +20,7 @@ noise_xx = ["ockam_key_exchange_xx"]
 
 # Option (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "ockam_key_exchange_core/std", "ockam_key_exchange_xx/std", "ockam_node/std", "ockam_vault_core/std", "ockam_vault_sync_core/std", "ockam_vault/std",  "serde_bare", "rand/std", "rand/std_rng"]
+std = ["ockam_core/std", "ockam_key_exchange_core/std", "ockam_key_exchange_xx/std", "ockam_node/std", "ockam_vault_core/std", "ockam_vault_sync_core/std", "ockam_vault/std",  "serde_bare/std", "rand/std", "rand/std_rng"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
@@ -28,7 +28,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_key_exch
 
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
-alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc", "serde_bare"]
+alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc", "serde_bare/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
@@ -38,7 +38,7 @@ ockam_node = { path = "../ockam_node", version = "0.29.0"    , default_features 
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.22.0"    , default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "0.25.0"    , default_features = false, optional = true }
-serde_bare = { version = "0.4.0", default-features = false, optional = true }
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 async-trait = "0.1"

--- a/implementations/rust/ockam/ockam_channel/src/lib.rs
+++ b/implementations/rust/ockam/ockam_channel/src/lib.rs
@@ -20,6 +20,7 @@
 extern crate core;
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 mod error;

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -2,13 +2,10 @@ use crate::{
     KeyExchangeCompleted, SecureChannelListener, SecureChannelNewKeyExchanger, SecureChannelVault,
     SecureChannelWorker,
 };
-#[cfg(not(feature = "std"))]
 use ockam_core::compat::rand::random;
 use ockam_core::{Address, Result, Route};
 use ockam_key_exchange_core::KeyExchanger;
 use ockam_node::Context;
-#[cfg(feature = "std")]
-use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
@@ -1,14 +1,15 @@
 use crate::{SecureChannelNewKeyExchanger, SecureChannelVault, SecureChannelWorker};
 use async_trait::async_trait;
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::random;
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{Address, LocalMessage, Message, Result, Routed, TransportMessage, Worker};
 use ockam_node::Context;
-#[cfg(feature = "std")]
-use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+
+#[cfg(not(feature = "std"))]
+use ockam_core::compat::rand::random;
+#[cfg(feature = "std")]
+use rand::random;
 
 /// SecureChannelListener listens for messages from SecureChannel initiators
 /// and creates responder SecureChannels

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
@@ -1,15 +1,11 @@
 use crate::{SecureChannelNewKeyExchanger, SecureChannelVault, SecureChannelWorker};
 use async_trait::async_trait;
+use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{Address, LocalMessage, Message, Result, Routed, TransportMessage, Worker};
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
-
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
-#[cfg(feature = "std")]
-use rand::random;
 
 /// SecureChannelListener listens for messages from SecureChannel initiators
 /// and creates responder SecureChannels

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -85,8 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
 ]
@@ -390,9 +389,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -85,6 +85,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -219,7 +227,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -389,9 +397,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -48,5 +48,5 @@ hex = { version = "0.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
-core2 = { git = "ssh://git@github.com/ockam-network/core2.git", branch = "ockam-network/add-read-to-end", default-features = false, optional = true }
-spin = { version = "0.9.1", default-features = false, features = ["mutex", "spin_mutex"], optional = true }
+core2 = { git = "https://github.com/technocreatives/core2.git", default-features = false, optional = true }
+spin = { version = "0.9.1", default-features = false, features = ["mutex", "rwlock", "spin_mutex"], optional = true }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -3,6 +3,7 @@ name = "ockam_core"
 version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_core"
@@ -37,12 +38,12 @@ alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc",
 # cryptographically secure implementations.
 # WARNING: Under no circumstances should this ever be enabled in
 #          production builds!
-unsafe_random  = []
+unsafe_random = []
 
 [dependencies]
 async-trait = "0.1.42"
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
-hashbrown =  { version = "0.11", features = ["serde"] }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+hashbrown =  { version = "0.11", default-features = false, features = ["ahash", "serde"] }
 heapless = { version = "0.7.1", optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -35,12 +35,12 @@ alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc",
 
 [dependencies]
 async-trait = "0.1.42"
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 hashbrown =  { version = "0.11", default-features = false, features = ["ahash", "serde"] }
 heapless = { version = "0.7.1", optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
-core2 = { git = "https://github.com/technocreatives/core2.git", default-features = false, optional = true }
+core2 = { git = "https://github.com/technocreatives/core2.git", rev = "57c84bc", default-features = false, optional = true }
 spin = { version = "0.9.1", default-features = false, features = ["mutex", "rwlock", "spin_mutex"], optional = true }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -33,13 +33,6 @@ no_std = ["core2", "hex", "rand_pcg", "spin"]
 # platforms, requires nightly.
 alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc", "serde_bare/alloc"]
 
-# Feature: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = []
-
 [dependencies]
 async-trait = "0.1.42"
 serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -22,15 +22,15 @@ default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["hex/std", "rand/std", "rand/std_rng", "serde_bare"]
+std = ["hex/std", "rand/std", "rand/std_rng", "serde_bare/std"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
-no_std = ["core2", "hex", "rand_pcg", "serde_bare", "spin"]
+no_std = ["core2", "hex", "rand_pcg", "spin"]
 
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
-alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc", "serde_bare"]
+alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc", "serde_bare/alloc"]
 
 # Feature: "unsafe_random" enables development support for random
 # number generation on no_std platforms that do not yet have
@@ -39,15 +39,14 @@ alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc",
 #          production builds!
 unsafe_random  = []
 
-
 [dependencies]
 async-trait = "0.1.42"
-serde_bare = { version = "0.4.0", default-features = false, optional = true }
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 hashbrown =  { version = "0.11", features = ["serde"] }
 heapless = { version = "0.7.1", optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
-core2 = { version = "0.3.1", default-features = false, optional = true }
+core2 = { git = "ssh://git@github.com/ockam-network/core2.git", branch = "ockam-network/add-read-to-end", default-features = false, optional = true }
 spin = { version = "0.9.1", default-features = false, features = ["mutex", "spin_mutex"], optional = true }

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -168,6 +168,12 @@ pub mod sync {
     pub use std::sync::Mutex;
 }
 
+/// std::task
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+pub use alloc::task;
+#[cfg(feature = "std")]
+pub use std::task;
+
 /// std::vec
 pub mod vec {
     #[cfg(all(not(feature = "std"), feature = "alloc"))]

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -101,6 +101,7 @@ pub mod rand {
 
         /// rand::thread_rng()
         /// WARNING: This implementation is neither random nor thread-local.
+        #[allow(unsafe_code)]
         pub fn thread_rng() -> rand_pcg::Lcg64Xsh32 {
             use rand::SeedableRng;
             rand_pcg::Pcg32::seed_from_u64(1234)

--- a/implementations/rust/ockam/ockam_core/src/processor.rs
+++ b/implementations/rust/ockam/ockam_core/src/processor.rs
@@ -1,3 +1,4 @@
+use crate::compat::boxed::Box;
 use crate::Result;
 use async_trait::async_trait;
 

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -1,4 +1,3 @@
-#[cfg(not(feature = "std"))]
 use crate::compat::rand::{distributions::Standard, prelude::Distribution, random, Rng};
 use crate::compat::{
     string::{String, ToString},
@@ -7,8 +6,6 @@ use crate::compat::{
 use core::fmt::{self, Debug, Display};
 use core::ops::Deref;
 use core::str::from_utf8;
-#[cfg(feature = "std")]
-use rand::{distributions::Standard, prelude::Distribution, random, Rng};
 use serde::{Deserialize, Serialize};
 
 /// A collection of Addresses

--- a/implementations/rust/ockam/ockam_entity/Cargo.lock
+++ b/implementations/rust/ockam/ockam_entity/Cargo.lock
@@ -57,14 +57,15 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-=======
+]
+
+[[package]]
 name = "aligned"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +82,6 @@ checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
 dependencies = [
  "cortex-m 0.6.7",
  "linked_list_allocator",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -128,12 +128,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
-<<<<<<< HEAD
  "critical-section",
  "riscv-target",
-=======
- "cortex-m 0.7.3",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -266,6 +262,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -278,7 +282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
 dependencies = [
  "aligned",
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
  "cortex-m 0.7.3",
  "volatile-register",
@@ -336,7 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,9 +347,11 @@ checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
- "cortex-m",
+ "cortex-m 0.7.3",
  "riscv",
-=======
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,7 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -925,7 +929,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown 0.11.2",
  "heapless",
  "hex",
@@ -939,10 +943,10 @@ dependencies = [
 [[package]]
 name = "ockam_core"
 version = "0.31.0"
-source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#29e2287e54199ffb335753f9665504b4c7612457"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown 0.11.2",
  "heapless",
  "hex",
@@ -987,7 +991,7 @@ dependencies = [
 [[package]]
 name = "ockam_executor"
 version = "0.0.1"
-source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+source = "git+https://github.com/ockam-network/ockam_executor.git?rev=3daeffa#3daeffa593f2d55611a8e4229978bb6839f4c669"
 dependencies = [
  "alloc-cortex-m",
  "cortex-m 0.7.3",
@@ -1459,9 +1463,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_entity/Cargo.lock
+++ b/implementations/rust/ockam/ockam_entity/Cargo.lock
@@ -8,7 +8,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+ "heapless",
  "rand_core 0.6.3",
 ]
 
@@ -56,12 +57,31 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+=======
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "alloc-cortex-m"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
+dependencies = [
+ "cortex-m 0.6.7",
+ "linked_list_allocator",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -80,6 +100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,8 +128,12 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
+<<<<<<< HEAD
  "critical-section",
  "riscv-target",
+=======
+ "cortex-m 0.7.3",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -168,7 +204,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -224,7 +260,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -240,6 +297,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cortex-m-rt"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +336,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +346,24 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "riscv",
+=======
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -266,7 +372,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -276,7 +382,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -308,7 +414,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -340,6 +446,29 @@ checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
 dependencies = [
  "nb 0.1.3",
  "void",
+]
+
+[[package]]
+name = "executor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc386acdbd994c2c2dc45829352eaff2bfc3b3191c220e4b61d1bcc44b56191"
+dependencies = [
+ "executor-macros",
+ "lazy_static",
+ "spin 0.5.2",
+ "woke",
+]
+
+[[package]]
+name = "executor-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76702ca666fb8b55aea1f5099cdbbdb42e50392de44ad60c86224e7d4236c401"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -455,6 +584,24 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -543,7 +690,8 @@ checksum = "fe65ef062f1af5b1b189842b0bc45bd671c38e1d22c6aa22e6ada03d01026d53"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "spin",
+ "serde",
+ "spin 0.9.2",
  "stable_deref_trait",
 ]
 
@@ -599,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -623,12 +771,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
 
 [[package]]
 name = "lock_api"
@@ -749,7 +906,7 @@ name = "ockam_channel"
 version = "0.26.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_key_exchange_xx",
  "ockam_node",
@@ -757,8 +914,9 @@ dependencies = [
  "ockam_vault_core",
  "ockam_vault_sync_core",
  "rand 0.8.4",
+ "rand_pcg",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
  "tracing",
 ]
 
@@ -767,11 +925,32 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
+ "core2",
  "hashbrown 0.11.2",
+ "heapless",
  "hex",
  "rand 0.8.4",
+ "rand_pcg",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
+ "spin 0.9.2",
+]
+
+[[package]]
+name = "ockam_core"
+version = "0.31.0"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+dependencies = [
+ "async-trait",
+ "core2",
+ "hashbrown 0.11.2",
+ "heapless",
+ "hex",
+ "rand 0.8.4",
+ "rand_pcg",
+ "serde",
+ "serde_bare",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -784,7 +963,7 @@ dependencies = [
  "group",
  "heapless",
  "ockam_channel",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_key_exchange_xx",
  "ockam_node",
@@ -796,7 +975,7 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "serde_json",
  "sha2",
  "signature_bbs_plus",
@@ -806,10 +985,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_executor"
+version = "0.0.1"
+source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+dependencies = [
+ "alloc-cortex-m",
+ "cortex-m 0.7.3",
+ "cortex-m-rt",
+ "cortex-m-semihosting",
+ "crossbeam-queue",
+ "futures",
+ "heapless",
+ "ockam_core 0.31.0 (git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc)",
+ "panic-semihosting",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "ockam_key_exchange_core"
 version = "0.23.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "zeroize",
 ]
@@ -818,7 +1015,7 @@ dependencies = [
 name = "ockam_key_exchange_xx"
 version = "0.23.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_key_exchange_core",
  "ockam_vault_core",
  "zeroize",
@@ -828,17 +1025,27 @@ dependencies = [
 name = "ockam_node"
 version = "0.29.0"
 dependencies = [
- "ockam_core",
+ "heapless",
+ "ockam_core 0.31.0",
+ "ockam_executor",
+ "ockam_node_no_std",
  "tokio",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
+name = "ockam_node_no_std"
+version = "0.6.0"
+dependencies = [
+ "executor",
+]
+
+[[package]]
 name = "ockam_transport_core"
 version = "0.5.0"
 dependencies = [
- "ockam_core",
+ "ockam_core 0.31.0",
  "tracing",
 ]
 
@@ -849,12 +1056,12 @@ dependencies = [
  "async-trait",
  "futures",
  "hashbrown 0.9.1",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_node",
  "ockam_transport_core",
  "rand 0.7.3",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tokio",
  "tracing",
 ]
@@ -868,9 +1075,10 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "rand 0.8.4",
+ "rand_pcg",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -886,7 +1094,8 @@ name = "ockam_vault_core"
 version = "0.25.0"
 dependencies = [
  "cfg-if",
- "ockam_core",
+ "heapless",
+ "ockam_core 0.31.0",
  "serde",
  "serde-big-array",
  "zeroize",
@@ -897,11 +1106,12 @@ name = "ockam_vault_sync_core"
 version = "0.22.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_node",
  "ockam_vault",
  "ockam_vault_core",
  "rand 0.8.4",
+ "rand_pcg",
  "serde",
  "serde-big-array",
  "tracing",
@@ -927,6 +1137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "panic-semihosting"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
+dependencies = [
+ "cortex-m 0.7.3",
+ "cortex-m-semihosting",
 ]
 
 [[package]]
@@ -1015,6 +1235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
+
+[[package]]
 name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1323,15 @@ name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -1223,19 +1458,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1387,6 +1613,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -1571,7 +1803,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -1649,6 +1881,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "woke"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafdab77c9ee549298ca6585107832aa89d77b14ba13cda220fec6105b17dbb1"
 
 [[package]]
 name = "wyz"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -32,13 +32,6 @@ no_std = ["ockam_core/no_std", "ockam_channel/no_std", "ockam_key_exchange_core/
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc","ockam_channel/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde_bare/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random", "signature_bbs_plus/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0", default-features = false  }
 ockam_node = {path = "../ockam_node", version = "0.29.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -3,6 +3,7 @@ name = "ockam_entity"
 version = "0.20.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_entity"
@@ -15,37 +16,53 @@ and trustfully with cloud services and other devices.
 
 [features]
 default = ["std", "software_vault", "noise_xx"]
-std = ["serde_bare/std"]
-alloc = ["serde_bare/alloc"]
 noise_xx = ["ockam_key_exchange_xx"]
 software_vault = ["ockam_vault", "ockam_vault_sync_core", "ockam_vault_sync_core/software_vault"]
 lease_proto_json = ["serde_json"]
 
+# Option (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = ["ockam_core/std", "ockam_channel/std", "ockam_key_exchange_core/std", "ockam_key_exchange_xx/std", "ockam_node/std", "ockam_vault_core/std", "ockam_vault_sync_core/std", "ockam_vault/std", "serde_bare/std"]
+
+# Option: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = ["ockam_core/no_std", "ockam_channel/no_std", "ockam_key_exchange_core/no_std", "ockam_key_exchange_xx/no_std", "ockam_node/no_std", "ockam_vault_core/no_std", "ockam_vault_sync_core/no_std", "ockam_vault/no_std"]
+
+# Option: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = ["ockam_core/alloc","ockam_channel/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde_bare/alloc"]
+
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random", "signature_bbs_plus/unsafe_random"]
+
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "0.31.0"    }
-ockam_node = {path = "../ockam_node", version = "0.29.0"    }
-ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    }
-ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "0.22.0"    , optional = true}
-ockam_vault = {path = "../ockam_vault", version = "0.25.0"    , optional = true}
-ockam_channel = {path = "../ockam_channel", version = "0.26.0"    }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.23.0"    , optional = true}
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.23.0"    }
+ockam_core = { path = "../ockam_core", version = "0.31.0", default-features = false  }
+ockam_node = {path = "../ockam_node", version = "0.29.0", default-features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0", default-features = false }
+ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "0.22.0", default-features = false, optional = true}
+ockam_vault = {path = "../ockam_vault", version = "0.25.0", default-features = false, optional = true}
+ockam_channel = {path = "../ockam_channel", version = "0.26.0", default-features = false }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "0.23.0", default-features = false, optional = true}
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "0.23.0", default-features = false }
 async-trait = "0.1"
-bls12_381_plus = "0.5"
+bls12_381_plus = { version = "0.5", default-features = false }
 cfg-if = "1.0.0"
-group = "0.10.0"
+group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "0.23.0"    }
 signature_bls = { path = "../signature_bls", version = "0.21.0"    }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "0.23.0"    }
 serde_json = { version ="1.0", optional = true }
-
-sha2 = "0.9"
+sha2 = { version = "0.9", default-features = false }
 serde-big-array = "0.3"
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
-rand = "0.8"
-tracing = "0.1"
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+rand = { version = "0.8", default-features = false }
+tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -15,10 +15,11 @@ and trustfully with cloud services and other devices.
 
 [features]
 default = ["std", "software_vault", "noise_xx"]
+std = ["serde_bare/std"]
+alloc = ["serde_bare/alloc"]
 noise_xx = ["ockam_key_exchange_xx"]
 software_vault = ["ockam_vault", "ockam_vault_sync_core", "ockam_vault_sync_core/software_vault"]
 lease_proto_json = ["serde_json"]
-std = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
@@ -42,7 +43,7 @@ serde_json = { version ="1.0", optional = true }
 
 sha2 = "0.9"
 serde-big-array = "0.3"
-serde_bare = "0.4"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 rand = "0.8"
 tracing = "0.1"
 

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -53,7 +53,7 @@ signature_bbs_plus = { path = "../signature_bbs_plus", version = "0.23.0"    }
 serde_json = { version ="1.0", optional = true }
 sha2 = { version = "0.9", default-features = false }
 serde-big-array = "0.3"
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 rand = { version = "0.8", default-features = false }
 tracing = { version = "0.1", default_features = false }
 

--- a/implementations/rust/ockam/ockam_entity/src/authentication.rs
+++ b/implementations/rust/ockam/ockam_entity/src/authentication.rs
@@ -1,4 +1,5 @@
 use crate::{EntityError, ProfileVault};
+use ockam_core::compat::vec::Vec;
 use ockam_vault::{PublicKey, Secret};
 use ockam_vault_core::Signature;
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_entity/src/change.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change.rs
@@ -1,3 +1,4 @@
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 pub use crate::proof::*;

--- a/implementations/rust/ockam/ockam_entity/src/change_history.rs
+++ b/implementations/rust/ockam/ockam_entity/src/change_history.rs
@@ -5,6 +5,7 @@ use crate::{
     EntityError, EventIdentifier, KeyAttributes, MetaKeyAttributes, ProfileChange,
     ProfileChangeEvent, ProfileChangeProof, ProfileVault, SignatureType,
 };
+use ockam_core::compat::{string::ToString, vec::Vec};
 use ockam_core::{allow, deny};
 use ockam_vault::{PublicKey, SecretAttributes};
 use ockam_vault_core::{SecretPersistence, SecretType, CURVE25519_SECRET_LENGTH};
@@ -193,7 +194,7 @@ impl ProfileChangeHistory {
             ProfileChangeProof::Signature(s) => match s.stype() {
                 SignatureType::RootSign => {
                     let events_to_look = if existing_events.is_empty() {
-                        std::slice::from_ref(new_change_event)
+                        core::slice::from_ref(new_change_event)
                     } else {
                         existing_events
                     };

--- a/implementations/rust/ockam/ockam_entity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel.rs
@@ -1,5 +1,6 @@
 use crate::{Identity, ProfileIdentifier};
 use async_trait::async_trait;
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Message, Result, Route, Routed};
 use ockam_node::Context;
 use ockam_vault_sync_core::VaultSync;

--- a/implementations/rust/ockam/ockam_entity/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/listener.rs
@@ -1,8 +1,13 @@
 use crate::{Identity, SecureChannelWorker, TrustPolicy};
 use ockam_channel::{CreateResponderChannelMessage, SecureChannel};
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Result, Routed, Worker};
 use ockam_key_exchange_xx::{XXNewKeyExchanger, XXVault};
 use ockam_node::Context;
+
+#[cfg(not(feature = "std"))]
+use ockam_core::compat::rand::random;
+#[cfg(feature = "std")]
 use rand::random;
 
 pub(crate) struct ProfileChannelListener<T: TrustPolicy, P: Identity + Clone, V: XXVault + Sync> {

--- a/implementations/rust/ockam/ockam_entity/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/listener.rs
@@ -1,14 +1,10 @@
 use crate::{Identity, SecureChannelWorker, TrustPolicy};
 use ockam_channel::{CreateResponderChannelMessage, SecureChannel};
 use ockam_core::compat::boxed::Box;
+use ockam_core::compat::rand::random;
 use ockam_core::{Address, Result, Routed, Worker};
 use ockam_key_exchange_xx::{XXNewKeyExchanger, XXVault};
 use ockam_node::Context;
-
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
-#[cfg(feature = "std")]
-use rand::random;
 
 pub(crate) struct ProfileChannelListener<T: TrustPolicy, P: Identity + Clone, V: XXVault + Sync> {
     trust_policy: T,

--- a/implementations/rust/ockam/ockam_entity/src/channel/local_info.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/local_info.rs
@@ -1,4 +1,5 @@
 use crate::{EntityError, ProfileIdentifier};
+use ockam_core::compat::string::{String, ToString};
 use ockam_core::{Encoded, Message, Result};
 use serde::{Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam_entity/src/channel/messages.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/messages.rs
@@ -1,4 +1,5 @@
 use crate::Contact;
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]

--- a/implementations/rust/ockam/ockam_entity/src/channel/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/secure_channel_worker.rs
@@ -8,18 +8,20 @@ use core::pin::Pin;
 use ockam_channel::{
     CreateResponderChannelMessage, KeyExchangeCompleted, SecureChannel, SecureChannelInfo,
 };
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
+use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{
     route, Address, Any, LocalMessage, Message, Result, Route, Routed, TransportMessage, Worker,
 };
 use ockam_key_exchange_core::NewKeyExchanger;
 use ockam_key_exchange_xx::{XXNewKeyExchanger, XXVault};
 use ockam_node::Context;
-#[cfg(feature = "std")]
-use rand::random;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
+
+#[cfg(not(feature = "std"))]
+use ockam_core::compat::rand::random;
+#[cfg(feature = "std")]
+use rand::random;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct AuthenticationConfirmation(pub Address);

--- a/implementations/rust/ockam/ockam_entity/src/channel/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/secure_channel_worker.rs
@@ -8,6 +8,7 @@ use core::pin::Pin;
 use ockam_channel::{
     CreateResponderChannelMessage, KeyExchangeCompleted, SecureChannel, SecureChannelInfo,
 };
+use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{
     route, Address, Any, LocalMessage, Message, Result, Route, Routed, TransportMessage, Worker,
@@ -17,11 +18,6 @@ use ockam_key_exchange_xx::{XXNewKeyExchanger, XXVault};
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
-
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
-#[cfg(feature = "std")]
-use rand::random;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct AuthenticationConfirmation(pub Address);

--- a/implementations/rust/ockam/ockam_entity/src/contact.rs
+++ b/implementations/rust/ockam/ockam_entity/src/contact.rs
@@ -6,6 +6,8 @@ use ockam_vault::PublicKey;
 use crate::change_history::ProfileChangeHistory;
 use crate::profile::Profile;
 use crate::{EventIdentifier, KeyAttributes, ProfileChangeEvent, ProfileIdentifier, ProfileVault};
+
+use ockam_core::compat::{string::ToString, vec::Vec};
 use ockam_core::{allow, deny};
 
 /// Contact is an abstraction responsible for storing user's public data (mainly - public keys).

--- a/implementations/rust/ockam/ockam_entity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential.rs
@@ -1,5 +1,6 @@
 // TODO restore #![deny(missing_docs)]
 
+use ockam_core::compat::{string::String, vec::Vec};
 use serde_big_array::big_array;
 
 big_array! { BigArray; }

--- a/implementations/rust/ockam/ockam_entity/src/credential/attribute.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/attribute.rs
@@ -1,5 +1,6 @@
 use super::CredentialAttributeType;
 use bls12_381_plus::Scalar;
+use ockam_core::compat::string::{String, ToString};
 use serde::{Deserialize, Serialize};
 use signature_core::lib::Message;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/attribute_schema.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/attribute_schema.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ockam_core::compat::string::{String, ToString};
 use serde::{Deserialize, Serialize};
 
 /// An attribute describes a statement that the issuer of a credential is

--- a/implementations/rust/ockam/ockam_entity/src/credential/error.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/error.rs
@@ -32,7 +32,7 @@ impl CredentialError {
     /// Integer code associated with the error domain.
     pub const DOMAIN_CODE: u32 = 33_000;
 
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     /// Descriptive name for the error domain
     pub const DOMAIN_NAME: &'static str = "OCKAM_CREDENTIAL";
 
@@ -53,7 +53,7 @@ impl CredentialError {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl From<CredentialError> for Error {
     fn from(v: CredentialError) -> Error {
         let t = v.as_u32();
@@ -64,7 +64,7 @@ impl From<CredentialError> for Error {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), not(feature = "alloc")))]
 impl From<CredentialError> for Error {
     fn from(v: CredentialError) -> Error {
         Error::new(CredentialError::DOMAIN_CODE + v.as_u32())

--- a/implementations/rust/ockam/ockam_entity/src/credential/ext.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/ext.rs
@@ -1,6 +1,7 @@
 use bls12_381_plus::{G1Affine, G1Projective};
 use group::Curve;
 use heapless::Vec as HVec;
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_big_array::big_array;
 use signature_bbs_plus::{BlindSignatureContext, PokSignatureProof};

--- a/implementations/rust/ockam/ockam_entity/src/credential/fragment2.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/fragment2.rs
@@ -1,4 +1,5 @@
 use super::CredentialAttribute;
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 use signature_bbs_plus::BlindSignature;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/messages.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/messages.rs
@@ -2,6 +2,7 @@ use crate::{
     CredentialAttribute, CredentialFragment2, CredentialOffer, CredentialPresentation,
     CredentialRequest, ProofRequestId,
 };
+use ockam_core::compat::{string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]

--- a/implementations/rust/ockam/ockam_entity/src/credential/presentation.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/presentation.rs
@@ -1,5 +1,6 @@
 use super::CredentialAttribute;
 use crate::{ExtPokSignatureProof, PresentationIdBytes};
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// Indicates how to present a credential

--- a/implementations/rust/ockam/ockam_entity/src/credential/presentation_manifest.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/presentation_manifest.rs
@@ -1,5 +1,6 @@
 use super::CredentialSchema;
 use crate::SigningPublicKey;
+use ockam_core::compat::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_big_array::big_array;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/traits.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/traits.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use core::convert::TryFrom;
 use core::fmt::{Display, Formatter};
+use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::{hex, Address, Error, Result, Route};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;

--- a/implementations/rust/ockam/ockam_entity/src/credential/util.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/util.rs
@@ -1,5 +1,6 @@
 use super::CredentialAttributeSchema;
 use core::fmt;
+use ockam_core::compat::{string::String, vec::Vec};
 
 use serde::{
     de::{Error as DError, SeqAccess, Visitor},
@@ -76,7 +77,7 @@ where
             let mut buf = Vec::new();
             while let Some(a) = s.next_element()? {
                 let _result = buf.push(a);
-                #[cfg(not(feature = "std"))]
+                #[cfg(all(not(feature = "std"), not(feature = "alloc")))]
                 {
                     _result.map_err(|_| DError::invalid_length(_l, &self))?;
                 }

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/holder.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/holder.rs
@@ -5,8 +5,13 @@ use crate::{
 };
 use async_trait::async_trait;
 use core::convert::TryInto;
+use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{Address, Result, Route, Routed, Worker};
 use ockam_node::Context;
+
+#[cfg(not(feature = "std"))]
+use ockam_core::compat::rand::random;
+#[cfg(feature = "std")]
 use rand::random;
 
 enum State {

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/holder.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/holder.rs
@@ -5,14 +5,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use core::convert::TryInto;
+use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{Address, Result, Route, Routed, Worker};
 use ockam_node::Context;
-
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::random;
-#[cfg(feature = "std")]
-use rand::random;
 
 enum State {
     AcceptOffer,

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/issuer.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/issuer.rs
@@ -3,6 +3,7 @@ use crate::{
     EntityError, Issuer, OfferId, Profile, ProfileIdentifier,
 };
 use async_trait::async_trait;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{Result, Route, Routed, Worker};
 use ockam_node::Context;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/listener.rs
@@ -3,6 +3,7 @@ use crate::{
     IssuerWorker, Profile, SecureChannelTrustInfo, TrustPolicy, TrustPolicyImpl,
 };
 use async_trait::async_trait;
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Result, Routed, Worker};
 use ockam_node::Context;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/presenter.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/presenter.rs
@@ -3,6 +3,7 @@ use crate::{
     PresentationManifest, Profile,
 };
 use async_trait::async_trait;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{Address, Result, Route, Routed, Worker};
 use ockam_node::Context;
 

--- a/implementations/rust/ockam/ockam_entity/src/credential/workers/verifier.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/workers/verifier.rs
@@ -5,6 +5,7 @@ use crate::{
     ProfileIdentifier, ProofRequestId, SigningPublicKey,
 };
 use async_trait::async_trait;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{Address, Result, Routed, Worker};
 use ockam_node::Context;
 

--- a/implementations/rust/ockam/ockam_entity/src/entity.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity.rs
@@ -10,6 +10,10 @@ use crate::{
     SecureChannels, SigningPublicKey, TrustPolicy, TrustPolicyImpl, VerifierWorker, TTL,
 };
 use core::convert::TryInto;
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::{Address, Result, Route};
 use ockam_node::{block_future, Context};
 use ockam_vault::ockam_vault_core::{PublicKey, Secret};

--- a/implementations/rust/ockam/ockam_entity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_entity/src/identifiers.rs
@@ -2,6 +2,7 @@ use crate::profile::Profile;
 use crate::EntityError;
 use core::convert::TryFrom;
 use core::fmt::{Display, Formatter};
+use ockam_core::compat::string::String;
 use ockam_core::hex::encode;
 use ockam_core::{Error, Result};
 use ockam_vault_core::{Hasher, KeyId};

--- a/implementations/rust/ockam/ockam_entity/src/key_attributes.rs
+++ b/implementations/rust/ockam/ockam_entity/src/key_attributes.rs
@@ -1,3 +1,4 @@
+use ockam_core::compat::string::{String, ToString};
 use ockam_vault::SecretAttributes;
 use ockam_vault_core::{SecretPersistence, SecretType, CURVE25519_SECRET_LENGTH};
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_entity/src/lease.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lease.rs
@@ -1,3 +1,5 @@
+use ockam_core::compat::string::{String, ToString};
+
 #[cfg(feature = "lease_proto_json")]
 pub mod json_proto;
 

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate core;
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 pub use change::*;
@@ -29,7 +30,8 @@ pub use identifiers::*;
 pub use key_attributes::*;
 pub use lease::*;
 use ockam_channel::SecureChannelVault;
-use ockam_core::{compat::collections::HashMap, Address, Message, Result};
+use ockam_core::compat::{collections::HashMap, string::String, vec::Vec};
+use ockam_core::{Address, Message, Result};
 use ockam_node::{block_future, Context};
 use ockam_vault::{Hasher, KeyIdVault, SecretVault, Signer, Verifier};
 pub use profile::*;

--- a/implementations/rust/ockam/ockam_entity/src/profile.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile.rs
@@ -26,6 +26,10 @@ use crate::{
     ProfileChangeEvent, ProfileIdentifier, ProofRequestId, SecureChannels, SigningPublicKey,
     TrustPolicy, TTL,
 };
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::{Address, Result, Route};
 use ockam_vault::{PublicKey, Secret};
 use signature_bls::SecretKey;

--- a/implementations/rust/ockam/ockam_entity/src/profile_state.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile_state.rs
@@ -22,17 +22,13 @@ use crate::{
 };
 use core::convert::TryInto;
 use ockam_core::compat::collections::{HashMap, HashSet};
+use ockam_core::compat::rand::{thread_rng, CryptoRng, RngCore};
 use ockam_vault_core::{SecretPersistence, SecretType, SecretVault, CURVE25519_SECRET_LENGTH};
 use sha2::digest::{generic_array::GenericArray, Digest, FixedOutput};
 use signature_bbs_plus::{Issuer as BbsIssuer, PokSignatureProof, Prover};
 use signature_bbs_plus::{MessageGenerators, ProofOfPossession};
 use signature_core::challenge::Challenge;
 use signature_core::lib::{HiddenMessage, Message, Nonce, ProofMessage};
-
-#[cfg(feature = "unsafe_random")]
-use ockam_core::compat::rand::{thread_rng, RngCore};
-#[cfg(not(feature = "unsafe_random"))]
-use rand::{thread_rng, CryptoRng, RngCore};
 
 /// Profile implementation
 #[derive(Clone)]
@@ -53,8 +49,7 @@ impl ProfileState {
         change_events: Changes,
         contacts: Contacts,
         vault: VaultSync,
-        #[cfg(not(feature = "unsafe_random"))] rng: impl RngCore + CryptoRng + Clone,
-        #[cfg(feature = "unsafe_random")] rng: impl RngCore + Clone,
+        rng: impl RngCore + CryptoRng + Clone,
     ) -> Self {
         Self {
             id: identifier,

--- a/implementations/rust/ockam/ockam_entity/src/traits.rs
+++ b/implementations/rust/ockam/ockam_entity/src/traits.rs
@@ -5,6 +5,10 @@ use crate::{
     CredentialRequestFragment, CredentialSchema, EntityCredential, Lease, OfferId,
     PresentationManifest, ProfileChangeEvent, ProfileIdentifier, ProofRequestId, TrustPolicy, TTL,
 };
+use ockam_core::compat::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use ockam_core::{Address, Result, Route};
 use ockam_vault_core::{PublicKey, Secret};
 use signature_bls::SecretKey;

--- a/implementations/rust/ockam/ockam_entity/src/worker/create_key.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/create_key.rs
@@ -6,6 +6,7 @@ use crate::{
     ProfileChangeProof, ProfileChangeType, ProfileEventAttributes, ProfileState, Signature,
     SignatureType,
 };
+use ockam_core::compat::vec::Vec;
 use ockam_vault::ockam_vault_core::{Hasher, SecretVault, Signer};
 use ockam_vault_core::Signature as OckamVaultSignature;
 use ockam_vault_core::{

--- a/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use core::result::Result::Ok;
-use ockam_core::{compat::collections::HashMap, Address, Result, Routed, Worker};
+use ockam_core::compat::{boxed::Box, collections::HashMap};
+use ockam_core::{Address, Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_vault_sync_core::VaultSync;
 

--- a/implementations/rust/ockam/ockam_entity/src/worker/request.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/request.rs
@@ -5,6 +5,7 @@ use crate::{
     Lease, OfferId, PresentationManifest, ProfileChangeEvent, ProfileIdentifier, ProofRequestId,
     TTL,
 };
+use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::{Address, Route};
 use serde::{Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam_entity/src/worker/response.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/response.rs
@@ -3,6 +3,7 @@ use crate::{
     CredentialOffer, CredentialPresentation, CredentialProof, CredentialPublicKey,
     CredentialRequestFragment, EntityCredential, Lease, ProfileIdentifier, ProofRequestId,
 };
+use ockam_core::compat::vec::Vec;
 use ockam_core::Address;
 use ockam_vault::{PublicKey, Secret};
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_entity/src/worker/rotate_key.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/rotate_key.rs
@@ -5,6 +5,7 @@ use crate::{
     ProfileChangeEvent, ProfileChangeProof, ProfileChangeType, ProfileEventAttributes,
     ProfileState, Signature, SignatureType,
 };
+use ockam_core::compat::vec::Vec;
 use ockam_vault::ockam_vault_core::Signature as OckamVaultSignature;
 use ockam_vault::ockam_vault_core::{Hasher, SecretVault, Signer};
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_entity/src/worker/trust_policy_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/trust_policy_worker.rs
@@ -1,5 +1,6 @@
 use crate::{Handle, SecureChannelTrustInfo, TrustPolicy};
 use async_trait::async_trait;
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Result, Routed, Worker};
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -788,7 +788,7 @@ dependencies = [
  "ockam_vault_sync_core",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
  "tracing",
 ]
 
@@ -801,7 +801,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
 ]
 
 [[package]]
@@ -824,7 +824,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde-big-array",
- "serde_bare 0.4.0",
+ "serde_bare",
  "sha2",
  "signature_bbs_plus",
  "signature_bls",
@@ -897,7 +897,7 @@ dependencies = [
  "ockam_transport_core",
  "rand 0.7.3",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tokio",
  "tracing",
 ]
@@ -1257,18 +1257,8 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
@@ -17,6 +17,6 @@ ockam = { version = "*", path = "../../../ockam" }
 rpassword = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_bare = "0.3"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 serde-big-array = "0.3"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
@@ -17,6 +17,6 @@ ockam = { version = "*", path = "../../../ockam" }
 rpassword = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 serde-big-array = "0.3"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
@@ -17,6 +17,6 @@ ockam = { version = "*", path = "../../../ockam" }
 rpassword = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 serde-big-array = "0.3"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
@@ -12,6 +12,6 @@ ockam_vault = {  path = "../../../ockam/ockam_vault" }
 okta-plugin = { path = "../" }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = "0.3"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 serde_json = "1.0"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
@@ -12,6 +12,6 @@ ockam_vault = {  path = "../../../ockam/ockam_vault" }
 okta-plugin = { path = "../" }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 serde_json = "1.0"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
@@ -12,6 +12,6 @@ ockam_vault = {  path = "../../../ockam/ockam_vault" }
 okta-plugin = { path = "../" }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 serde_json = "1.0"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
@@ -21,7 +21,7 @@ ockam_key_exchange_core = { path = "../../../ockam/ockam_key_exchange_core" }
 ockam_key_exchange_x3dh = { path = "../../../ockam/ockam_key_exchange_x3dh" }
 okta-plugin = { version = "0.1", path = "../" }
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = "0.3"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 serde_json = "1.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
@@ -21,7 +21,7 @@ ockam_key_exchange_core = { path = "../../../ockam/ockam_key_exchange_core" }
 ockam_key_exchange_x3dh = { path = "../../../ockam/ockam_key_exchange_x3dh" }
 okta-plugin = { version = "0.1", path = "../" }
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 serde_json = "1.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
@@ -21,7 +21,7 @@ ockam_key_exchange_core = { path = "../../../ockam/ockam_key_exchange_core" }
 ockam_key_exchange_x3dh = { path = "../../../ockam/ockam_key_exchange_x3dh" }
 okta-plugin = { version = "0.1", path = "../" }
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc" }
 serde_json = "1.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -757,8 +757,7 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_ffi/src/vault.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault.rs
@@ -63,7 +63,7 @@ pub extern "C" fn ockam_vault_sha256(
     check_buffer!(input);
     check_buffer!(digest);
 
-    let input = unsafe { std::slice::from_raw_parts(input, input_length as usize) };
+    let input = unsafe { core::slice::from_raw_parts(input, input_length as usize) };
 
     match call(context, |v| -> Result<(), FfiOckamError> {
         let d = v.sha256(input)?;
@@ -113,7 +113,7 @@ pub extern "C" fn ockam_vault_secret_import(
     *secret = match call(context, |v| -> Result<SecretKeyHandle, FfiOckamError> {
         let atts = attributes.try_into()?;
 
-        let secret_data = unsafe { std::slice::from_raw_parts(input, input_length as usize) };
+        let secret_data = unsafe { core::slice::from_raw_parts(input, input_length as usize) };
 
         let ctx = v.secret_import(secret_data, atts)?;
         Ok(ctx.index() as u64)
@@ -229,7 +229,7 @@ pub extern "C" fn ockam_vault_ecdh(
     check_buffer!(peer_publickey, peer_publickey_length);
 
     let peer_publickey =
-        unsafe { std::slice::from_raw_parts(peer_publickey, peer_publickey_length as usize) };
+        unsafe { core::slice::from_raw_parts(peer_publickey, peer_publickey_length as usize) };
     *shared_secret = match call(context, |v| -> Result<u64, FfiOckamError> {
         let ctx = Secret::new(secret as usize);
         let atts = v.secret_attributes_get(&ctx)?;
@@ -339,9 +339,9 @@ pub extern "C" fn ockam_vault_aead_aes_gcm_encrypt(
     *ciphertext_and_tag_length = 0;
 
     let additional_data =
-        unsafe { std::slice::from_raw_parts(additional_data, additional_data_length as usize) };
+        unsafe { core::slice::from_raw_parts(additional_data, additional_data_length as usize) };
 
-    let plaintext = unsafe { std::slice::from_raw_parts(plaintext, plaintext_length as usize) };
+    let plaintext = unsafe { core::slice::from_raw_parts(plaintext, plaintext_length as usize) };
     match call(context, |v| -> Result<(), FfiOckamError> {
         let ctx = Secret::new(secret as usize);
         let mut nonce_vec = vec![0; 12 - 2];
@@ -382,10 +382,10 @@ pub extern "C" fn ockam_vault_aead_aes_gcm_decrypt(
     *plaintext_length = 0;
 
     let additional_data =
-        unsafe { std::slice::from_raw_parts(additional_data, additional_data_length as usize) };
+        unsafe { core::slice::from_raw_parts(additional_data, additional_data_length as usize) };
 
     let ciphertext_and_tag = unsafe {
-        std::slice::from_raw_parts(ciphertext_and_tag, ciphertext_and_tag_length as usize)
+        core::slice::from_raw_parts(ciphertext_and_tag, ciphertext_and_tag_length as usize)
     };
     match call(context, |v| -> Result<(), FfiOckamError> {
         let ctx = Secret::new(secret as usize);

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -85,8 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
 ]
@@ -422,9 +421,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -85,6 +85,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -220,7 +228,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -421,9 +429,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -24,13 +24,6 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std"]
 # Feature: "alloc" enables support for heap allocation on "no_std" platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -24,6 +24,13 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std"]
 # Feature: "alloc" enables support for heap allocation on "no_std" platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc"]
 
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random"]
+
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -224,8 +224,15 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
 ]
@@ -650,7 +657,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -1009,9 +1016,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -224,8 +224,7 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
 ]
@@ -1009,9 +1008,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1256,19 +1255,7 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -224,6 +224,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -649,7 +657,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -1008,9 +1016,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 
@@ -1255,7 +1263,19 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -3,6 +3,7 @@ name = "ockam_key_exchange_xx"
 version = "0.23.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_xx"
@@ -26,6 +27,13 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_vault_co
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_vault_core/alloc"]
+
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random", "ockam_vault_core/unsafe_random", "ockam_key_exchange_core/unsafe_random"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -28,13 +28,6 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_vault_co
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_vault_core/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random", "ockam_vault_core/unsafe_random", "ockam_key_exchange_core/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -20,6 +20,7 @@
 extern crate core;
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 mod error;

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -14,14 +14,15 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-=======
+]
+
+[[package]]
 name = "aligned"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,7 +39,6 @@ checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
 dependencies = [
  "cortex-m 0.6.7",
  "linked_list_allocator",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -79,12 +79,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
-<<<<<<< HEAD
  "critical-section",
  "riscv-target",
-=======
- "cortex-m 0.7.3",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -159,6 +155,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -171,7 +175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
 dependencies = [
  "aligned",
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
  "cortex-m 0.7.3",
  "volatile-register",
@@ -190,17 +194,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-name = "critical-section"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if",
- "cortex-m",
- "riscv",
-=======
 name = "cortex-m-rt"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +224,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if",
+ "cortex-m 0.7.3",
+ "riscv",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,7 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -595,7 +599,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -609,10 +613,10 @@ dependencies = [
 [[package]]
 name = "ockam_core"
 version = "0.31.0"
-source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#29e2287e54199ffb335753f9665504b4c7612457"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -626,7 +630,7 @@ dependencies = [
 [[package]]
 name = "ockam_executor"
 version = "0.0.1"
-source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+source = "git+https://github.com/ockam-network/ockam_executor.git?rev=3daeffa#3daeffa593f2d55611a8e4229978bb6839f4c669"
 dependencies = [
  "alloc-cortex-m",
  "cortex-m 0.7.3",
@@ -910,9 +914,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -14,12 +14,31 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+=======
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "alloc-cortex-m"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
+dependencies = [
+ "cortex-m 0.6.7",
+ "linked_list_allocator",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -29,6 +48,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -48,8 +79,12 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
+<<<<<<< HEAD
  "critical-section",
  "riscv-target",
+=======
+ "cortex-m 0.7.3",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -124,10 +159,22 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -143,6 +190,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +200,54 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "riscv",
+=======
+name = "cortex-m-rt"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -185,6 +281,112 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+
+[[package]]
+name = "futures-task"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+
+[[package]]
+name = "futures-util"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -273,6 +475,12 @@ name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
 
 [[package]]
 name = "lock_api"
@@ -399,12 +607,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_core"
+version = "0.31.0"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+dependencies = [
+ "async-trait",
+ "core2",
+ "hashbrown",
+ "heapless",
+ "hex",
+ "rand",
+ "rand_pcg",
+ "serde",
+ "serde_bare",
+ "spin 0.9.2",
+]
+
+[[package]]
+name = "ockam_executor"
+version = "0.0.1"
+source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+dependencies = [
+ "alloc-cortex-m",
+ "cortex-m 0.7.3",
+ "cortex-m-rt",
+ "cortex-m-semihosting",
+ "crossbeam-queue",
+ "futures",
+ "heapless",
+ "ockam_core 0.31.0 (git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc)",
+ "panic-semihosting",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "ockam_node"
 version = "0.29.0"
 dependencies = [
  "async-trait",
  "heapless",
- "ockam_core",
+ "ockam_core 0.31.0",
+ "ockam_executor",
  "ockam_node_no_std",
  "tokio",
  "tracing",
@@ -423,6 +667,16 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "panic-semihosting"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
+dependencies = [
+ "cortex-m 0.7.3",
+ "cortex-m-semihosting",
+]
 
 [[package]]
 name = "parking_lot"
@@ -456,10 +710,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -478,6 +750,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
 name = "rand"
@@ -632,9 +910,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -818,6 +1096,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-xid"

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -15,26 +15,34 @@ default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "tokio", "tracing-subscriber"]
+std = ["ockam_core/std", "tokio/full", "tracing-subscriber"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
-no_std = ["ockam_core/no_std", "ockam_node_no_std/no_std", "heapless"]
+no_std = ["ockam_core/no_std", "ockam_executor/cortexm", "ockam_node_no_std/no_std", "heapless"]
 
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
-alloc = ["ockam_core/alloc", "ockam_node_no_std/alloc"]
+alloc = ["ockam_core/alloc", "ockam_executor/alloc", "ockam_node_no_std/alloc"]
 
-# Feature: "dump_internals" when set, will dump the internal state of workers at startup via the trace! macro.
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random"]
+
+# Option: "dump_internals" when set, will dump the internal state of workers at startup via the trace! macro.
 dump_internals = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
-tokio = {version = "1.8", features = ["full"], optional = true}
+tokio = {version = "1.8", default-features = false, optional = true}
 tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"], optional = true }
 heapless = { version = "0.7", features = [ "mpmc_large" ], optional = true }
 ockam_node_no_std = { path = "../ockam_node_no_std", version = "0.6.0"    , default-features = false, optional = true }
+ockam_executor = { git = "https://github.com/ockam-network/ockam_executor.git", default-features = false, optional = true }
 
 [dev-dependencies]
 async-trait =  { version = "0.1" }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -25,13 +25,6 @@ no_std = ["ockam_core/no_std", "ockam_executor/cortexm", "ockam_node_no_std/no_s
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_executor/alloc", "ockam_node_no_std/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random"]
-
 # Option: "dump_internals" when set, will dump the internal state of workers at startup via the trace! macro.
 dump_internals = []
 

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"], optional = true }
 heapless = { version = "0.7", features = [ "mpmc_large" ], optional = true }
 ockam_node_no_std = { path = "../ockam_node_no_std", version = "0.6.0"    , default-features = false, optional = true }
-ockam_executor = { git = "https://github.com/ockam-network/ockam_executor.git", default-features = false, optional = true }
+ockam_executor = { git = "https://github.com/ockam-network/ockam_executor.git", rev = "3daeffa", default-features = false, optional = true }
 
 [dev-dependencies]
 async-trait =  { version = "0.1" }

--- a/implementations/rust/ockam/ockam_node/src/address_record.rs
+++ b/implementations/rust/ockam/ockam_node/src/address_record.rs
@@ -1,6 +1,6 @@
 use crate::relay::RelayMessage;
+use crate::tokio::sync::mpsc::Sender;
 use ockam_core::AddressSet;
-use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct AddressRecord {

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -1,17 +1,17 @@
-use core::time::Duration;
-use ockam_core::compat::{sync::Arc, vec::Vec};
-use ockam_core::{
-    Address, AddressSet, LocalMessage, Message, Processor, Result, Route, TransportMessage, Worker,
-};
-use tokio::{
+use crate::relay::{ProcessorRelay, WorkerRelay};
+use crate::tokio::{
+    self,
     runtime::Runtime,
     sync::mpsc::{channel, Sender},
     time::timeout,
 };
-
-use crate::relay::{ProcessorRelay, WorkerRelay};
 use crate::{
     error::Error, node::NullWorker, parser, relay::RelayMessage, Cancel, Mailbox, NodeMessage,
+};
+use core::time::Duration;
+use ockam_core::compat::{sync::Arc, vec::Vec};
+use ockam_core::{
+    Address, AddressSet, LocalMessage, Message, Processor, Result, Route, TransportMessage, Worker,
 };
 
 /// A default timeout in seconds

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -1,5 +1,5 @@
+use crate::tokio::{self, sync::mpsc::error::SendError};
 use core::fmt::Debug;
-use tokio::{self, sync::mpsc::error::SendError};
 
 /// Error declarations.
 #[derive(Clone, Copy, Debug)]

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -3,9 +3,9 @@
 use crate::{relay::RelayMessage, router::Router, NodeMessage};
 use ockam_core::{Address, Result};
 
+use crate::tokio::{runtime::Runtime, sync::mpsc::Sender};
 use core::future::Future;
 use ockam_core::compat::sync::Arc;
-use tokio::{runtime::Runtime, sync::mpsc::Sender};
 
 /// Ockam node and worker executor
 pub struct Executor {
@@ -60,6 +60,12 @@ impl Executor {
 
         // Block this task executing the primary message router,
         // returning any critical failures that it encounters.
-        crate::block_future(&rt, self.router.run())
+        #[cfg(feature = "std")]
+        return crate::block_future(&rt, self.router.run());
+        #[cfg(not(feature = "std"))]
+        {
+            crate::tokio::runtime::execute(&rt, async move { self.router.run().await.unwrap() });
+            Ok(())
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -14,10 +14,16 @@
 extern crate core;
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 #[macro_use]
 extern crate tracing;
+
+#[cfg(not(feature = "std"))]
+pub use ockam_executor::{interrupt, tokio};
+#[cfg(feature = "std")]
+pub use tokio;
 
 mod address_record;
 mod context;
@@ -39,7 +45,9 @@ pub use messages::*;
 
 pub use node::{start_node, NullWorker};
 
+#[cfg(feature = "std")]
 use core::future::Future;
+#[cfg(feature = "std")]
 use tokio::{runtime::Runtime, task};
 
 /// Execute a future without blocking the executor
@@ -52,6 +60,7 @@ use tokio::{runtime::Runtime, task};
 /// as an implementation utility for other ockam utilities that use
 /// tokio.
 #[doc(hidden)]
+#[cfg(feature = "std")]
 pub fn block_future<'r, F>(rt: &'r Runtime, f: F) -> <F as Future>::Output
 where
     F: Future + Send,
@@ -64,6 +73,7 @@ where
 }
 
 #[doc(hidden)]
+#[cfg(feature = "std")]
 pub fn spawn<F: 'static>(f: F)
 where
     F: Future + Send,
@@ -71,3 +81,6 @@ where
 {
     task::spawn(f);
 }
+
+#[cfg(not(feature = "std"))]
+pub use crate::tokio::runtime::{block_future, spawn};

--- a/implementations/rust/ockam/ockam_node/src/mailbox.rs
+++ b/implementations/rust/ockam/ockam_node/src/mailbox.rs
@@ -1,7 +1,7 @@
+use crate::tokio::sync::mpsc::Receiver;
 use crate::{relay::RelayMessage, Context};
 use core::fmt::{self, Debug, Display, Formatter};
 use ockam_core::{Address, LocalMessage, Message, Routed};
-use tokio::sync::mpsc::Receiver;
 
 /// A mailbox for encoded messages
 ///

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -1,8 +1,8 @@
 use crate::relay::ShutdownHandle;
+use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{error::Error, relay::RelayMessage};
 use ockam_core::compat::vec::Vec;
 use ockam_core::{Address, AddressSet};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// Messages sent from the Node to the Executor
 #[derive(Debug)]

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -1,9 +1,10 @@
 use crate::relay::{RelayMessage, WorkerRelay};
+use crate::tokio::runtime::Runtime;
+use crate::tokio::sync::mpsc::{channel, Sender};
 use crate::{Context, Executor, Mailbox, NodeMessage};
 use ockam_core::compat::sync::Arc;
 use ockam_core::Address;
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc::{channel, Sender};
+#[cfg(feature = "std")]
 use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 /// A minimal worker implementation that does nothing

--- a/implementations/rust/ockam/ockam_node/src/relay/relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/relay.rs
@@ -1,5 +1,6 @@
+use crate::tokio::sync::mpsc::{Receiver, Sender};
+use ockam_core::compat::vec::Vec;
 use ockam_core::{Address, LocalMessage, Message, Route, RouterMessage};
-use tokio::sync::mpsc::{Receiver, Sender};
 
 /// A message addressed to a relay
 #[derive(Clone, Debug)]

--- a/implementations/rust/ockam/ockam_node/src/relay/shutdown_handle.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/shutdown_handle.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
+use crate::tokio::sync::oneshot;
 use ockam_core::Result;
-use tokio::sync::oneshot;
 
 pub struct ShutdownListener {
     rx_shutdown: oneshot::Receiver<()>,

--- a/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
@@ -16,12 +16,12 @@
 //! a type and notifying the companion actor.
 
 use crate::relay::{run_mailbox, RelayMessage, RelayPayload};
+use crate::tokio::runtime::Runtime;
+use crate::tokio::sync::mpsc::{channel, Sender};
 use crate::{parser, Context};
 use core::marker::PhantomData;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{Address, LocalMessage, Message, Result, Route, Routed, TransportMessage, Worker};
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc::{channel, Sender};
 
 pub struct WorkerRelay<W, M>
 where

--- a/implementations/rust/ockam/ockam_node/src/router.rs
+++ b/implementations/rust/ockam/ockam_node/src/router.rs
@@ -1,10 +1,10 @@
 use crate::relay::ShutdownHandle;
+use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{
     error::Error, relay::RelayMessage, AddressRecord, NodeMessage, NodeReply, NodeReplyResult,
 };
-use ockam_core::compat::collections::BTreeMap;
+use ockam_core::compat::{collections::BTreeMap, vec::Vec};
 use ockam_core::{Address, AddressSet, Result};
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// A combined address type and local worker router
 ///

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -161,8 +161,8 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
         #[inline(always)]
         #input_function
 
-        fn main() -> ockam_core::Result<()> {
-            let (#ctx_ident, mut executor) = ockam_node::start_node();
+        fn main() -> ockam::Result<()> {
+            let (#ctx_ident, mut executor) = ockam::start_node();
             executor.execute(async move {
                 #input_function_call
             })

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.lock
@@ -177,8 +177,7 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -76,6 +76,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,7 +374,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "serde",
- "serde_bare 0.4.0",
+ "serde_bare",
 ]
 
 [[package]]
@@ -399,7 +407,7 @@ dependencies = [
  "ockam_transport_core",
  "rand 0.7.3",
  "serde",
- "serde_bare 0.3.0",
+ "serde_bare",
  "tokio",
  "tracing",
  "trybuild",
@@ -621,19 +629,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01db2255aa98fb93ad74272d8b2e6fd4851860e733e944b9439cf148127164b2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -27,7 +27,7 @@ alloc = ["serde_bare/alloc"]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.5.0"    }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"] }
 futures = "0.3.10"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -20,13 +20,14 @@ autoexamples = false
 
 [features]
 default = ["std"]
-std = []
+std = ["serde_bare/std"]
+alloc = ["serde_bare/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.5.0"    }
-serde_bare = "0.3.0"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 tokio = {version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"]}
 futures = " 0.3.10"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -27,14 +27,14 @@ alloc = ["serde_bare/alloc"]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.5.0"    }
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
-serde = {version = "1.0", features = ["derive"]}
-tokio = {version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"]}
-futures = " 0.3.10"
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"] }
+futures = "0.3.10"
 async-trait = "0.1"
 rand = "0.7"
-hashbrown =  { version = "0.9"}
+hashbrown =  { version = "0.9" }
 tracing = "0.1"
 
 [dev-dependencies]
-trybuild = {version = "1.0", features = ["diff"]}
+trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
@@ -238,6 +238,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,9 +779,12 @@ dependencies = [
  "ockam_core",
  "ockam_entity",
  "ockam_key_exchange_core",
+ "ockam_key_exchange_xx",
  "ockam_node",
  "ockam_node_attribute",
+ "ockam_vault",
  "ockam_vault_core",
+ "ockam_vault_sync_core",
  "rand",
  "serde",
  "serde-big-array",
@@ -1242,9 +1253,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "0.3", default-features = false, features = ["tokio-i
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.5.0"    }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "c4630d2", default-features = false }
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"
 tracing = "0.1"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -19,7 +19,8 @@ exclude = [
 
 [features]
 default = ["std"]
-std = []
+std = ["serde_bare/std"]
+alloc = ["serde_bare/alloc"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -29,7 +30,7 @@ futures-util = { version = "0.3", default-features = false, features = ["tokio-i
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.5.0"    }
-serde_bare = "0.4.0"
+serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"
 tracing = "0.1"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "0.3", default-features = false, features = ["tokio-i
 ockam_core = { path = "../ockam_core", version = "0.31.0"    }
 ockam_node = { path = "../ockam_node", version = "0.29.0"    }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.5.0"    }
-serde_bare = { git = "ssh://git@github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
+serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", branch = "ockam-network/no_std+alloc", default-features = false }
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"
 tracing = "0.1"

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -186,6 +186,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -509,7 +517,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -791,9 +799,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 
@@ -963,7 +971,19 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -186,8 +186,7 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
 ]
@@ -792,9 +791,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -964,19 +963,7 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -3,6 +3,7 @@ name = "ockam_vault"
 version = "0.25.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault"
@@ -29,6 +30,13 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "rand_pcg", "x25519-da
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc",  "aes-gcm/alloc"]
+
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random", "signature_bls/unsafe_random"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -31,13 +31,6 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "rand_pcg", "x25519-da
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc",  "aes-gcm/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random", "signature_bls/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_vault/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate core;
 
 #[cfg(feature = "alloc")]
+#[macro_use]
 extern crate alloc;
 
 pub extern crate ockam_vault_core;

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -6,10 +6,14 @@ use ockam_vault_core::{
     KeyId, KeyIdVault, PublicKey, Secret, SecretAttributes, SecretKey, SecretPersistence,
     SecretType, SecretVault, AES128_SECRET_LENGTH, AES256_SECRET_LENGTH, CURVE25519_SECRET_LENGTH,
 };
-use rand::{thread_rng, RngCore};
 use signature_bbs_plus::PublicKey as BlsPublicKey;
 use signature_bbs_plus::SecretKey as BlsSecretKey;
 use zeroize::Zeroize;
+
+#[cfg(not(feature = "std"))]
+use ockam_core::compat::rand::{thread_rng, RngCore};
+#[cfg(feature = "std")]
+use rand::{thread_rng, RngCore};
 
 impl SoftwareVault {
     /// Compute key id from secret and attributes. Only Curve25519 and Buffer types are supported

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -2,6 +2,7 @@ use crate::software_vault::{SoftwareVault, VaultEntry};
 use crate::VaultError;
 use arrayref::array_ref;
 use core::convert::TryInto;
+use ockam_core::compat::rand::{thread_rng, RngCore};
 use ockam_vault_core::{
     KeyId, KeyIdVault, PublicKey, Secret, SecretAttributes, SecretKey, SecretPersistence,
     SecretType, SecretVault, AES128_SECRET_LENGTH, AES256_SECRET_LENGTH, CURVE25519_SECRET_LENGTH,
@@ -9,11 +10,6 @@ use ockam_vault_core::{
 use signature_bbs_plus::PublicKey as BlsPublicKey;
 use signature_bbs_plus::SecretKey as BlsSecretKey;
 use zeroize::Zeroize;
-
-#[cfg(not(feature = "std"))]
-use ockam_core::compat::rand::{thread_rng, RngCore};
-#[cfg(feature = "std")]
-use rand::{thread_rng, RngCore};
 
 impl SoftwareVault {
     /// Compute key id from secret and attributes. Only Curve25519 and Buffer types are supported

--- a/implementations/rust/ockam/ockam_vault/src/signer_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/signer_impl.rs
@@ -2,11 +2,8 @@ use crate::software_vault::SoftwareVault;
 use crate::xeddsa::XEddsaSigner;
 use crate::VaultError;
 use arrayref::array_ref;
-#[cfg(not(feature = "std"))]
 use ockam_core::compat::rand::{thread_rng, RngCore};
 use ockam_vault_core::{Secret, SecretType, Signature, Signer, CURVE25519_SECRET_LENGTH};
-#[cfg(feature = "std")]
-use rand::{thread_rng, RngCore};
 use signature_bbs_plus::{Issuer, MessageGenerators};
 use signature_bls::SecretKey;
 use signature_core::lib::Message;

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -85,8 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
 ]
@@ -413,9 +412,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -85,6 +85,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -220,7 +228,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -412,9 +420,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -27,10 +27,17 @@ no_std = ["ockam_core/no_std", "heapless"]
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "serde/alloc"]
 
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random"]
+
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 heapless = { version = "0.7", features = ["serde"], optional = true }
-serde = {version = "1.0", default-features = false,features = ["derive"]}
+serde = {version = "1.0", default-features = false, features = ["derive"]}
 serde-big-array = "0.3"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
 cfg-if = "1.0"

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -27,13 +27,6 @@ no_std = ["ockam_core/no_std", "heapless"]
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "serde/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 heapless = { version = "0.7", features = ["serde"], optional = true }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
@@ -51,14 +51,15 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-=======
+]
+
+[[package]]
 name = "aligned"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +76,6 @@ checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
 dependencies = [
  "cortex-m 0.6.7",
  "linked_list_allocator",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -122,12 +122,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
-<<<<<<< HEAD
  "critical-section",
  "riscv-target",
-=======
- "cortex-m 0.7.3",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -260,6 +256,14 @@ dependencies = [
 [[package]]
 name = "core2"
 version = "0.3.1"
+source = "git+https://github.com/technocreatives/core2.git?rev=57c84bc#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "core2"
+version = "0.3.1"
 source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
@@ -272,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
 dependencies = [
  "aligned",
- "bare-metal",
+ "bare-metal 0.2.5",
  "bitfield",
  "cortex-m 0.7.3",
  "volatile-register",
@@ -330,7 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,9 +341,11 @@ checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
- "cortex-m",
+ "cortex-m 0.7.3",
  "riscv",
-=======
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,7 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
->>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -875,7 +879,7 @@ name = "ockam_core"
 version = "0.31.0"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -889,10 +893,10 @@ dependencies = [
 [[package]]
 name = "ockam_core"
 version = "0.31.0"
-source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#29e2287e54199ffb335753f9665504b4c7612457"
 dependencies = [
  "async-trait",
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git?rev=57c84bc)",
  "hashbrown",
  "heapless",
  "hex",
@@ -906,7 +910,7 @@ dependencies = [
 [[package]]
 name = "ockam_executor"
 version = "0.0.1"
-source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+source = "git+https://github.com/ockam-network/ockam_executor.git?rev=3daeffa#3daeffa593f2d55611a8e4229978bb6839f4c669"
 dependencies = [
  "alloc-cortex-m",
  "cortex-m 0.7.3",
@@ -1312,9 +1316,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
- "core2",
+ "core2 0.3.1 (git+https://github.com/technocreatives/core2.git)",
  "serde",
 ]
 
@@ -1565,7 +1569,19 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "heapless",
  "rand_core 0.6.3",
 ]
@@ -51,12 +51,31 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+=======
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "alloc-cortex-m"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67ad0fe14be887ed94e5722d14861c1877b128edbda2dd372e64d5243d614ae"
+dependencies = [
+ "cortex-m 0.6.7",
+ "linked_list_allocator",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -75,6 +94,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,8 +122,12 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
 dependencies = [
+<<<<<<< HEAD
  "critical-section",
  "riscv-target",
+=======
+ "cortex-m 0.7.3",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -163,7 +198,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -219,16 +254,28 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "core2"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+source = "git+https://github.com/technocreatives/core2.git#57c84bc79b28fb42cca57f369f5eda0c0826b16f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal",
+ "bitfield",
+ "cortex-m 0.7.3",
+ "volatile-register",
 ]
 
 [[package]]
@@ -244,6 +291,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cortex-m-rt"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cortex-m-semihosting"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
+dependencies = [
+ "cortex-m 0.7.3",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +330,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "critical-section"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +340,24 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "riscv",
+=======
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+>>>>>>> 3f553db4 (feat(rust): eliminate unsafe_random feature)
 ]
 
 [[package]]
@@ -270,7 +366,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -280,7 +376,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -312,7 +408,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -385,6 +481,102 @@ name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "futures"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+
+[[package]]
+name = "futures-task"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+
+[[package]]
+name = "futures-util"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "generic-array"
@@ -524,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
 
@@ -557,6 +749,12 @@ name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822add9edb1860698b79522510da17bef885171f75aa395cff099d770c609c24"
 
 [[package]]
 name = "lock_api"
@@ -689,11 +887,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_core"
+version = "0.31.0"
+source = "git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc#de3b3bdd7ebec00ccdeeb0878804caaf96804042"
+dependencies = [
+ "async-trait",
+ "core2",
+ "hashbrown",
+ "heapless",
+ "hex",
+ "rand",
+ "rand_pcg",
+ "serde",
+ "serde_bare",
+ "spin 0.9.2",
+]
+
+[[package]]
+name = "ockam_executor"
+version = "0.0.1"
+source = "git+https://github.com/ockam-network/ockam_executor.git#e11a5068097a6f28658689dbee6545ad743df65d"
+dependencies = [
+ "alloc-cortex-m",
+ "cortex-m 0.7.3",
+ "cortex-m-rt",
+ "cortex-m-semihosting",
+ "crossbeam-queue",
+ "futures",
+ "heapless",
+ "ockam_core 0.31.0 (git+https://github.com/ockam-network/ockam.git?branch=antoinevg/nostd+alloc)",
+ "panic-semihosting",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "ockam_node"
 version = "0.29.0"
 dependencies = [
  "heapless",
- "ockam_core",
+ "ockam_core 0.31.0",
+ "ockam_executor",
  "ockam_node_no_std",
  "tokio",
  "tracing",
@@ -716,7 +950,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
  "rand",
  "rand_pcg",
@@ -736,7 +970,7 @@ version = "0.25.0"
 dependencies = [
  "cfg-if",
  "heapless",
- "ockam_core",
+ "ockam_core 0.31.0",
  "serde",
  "serde-big-array",
  "zeroize",
@@ -747,7 +981,7 @@ name = "ockam_vault_sync_core"
 version = "0.22.0"
 dependencies = [
  "async-trait",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_node",
  "ockam_vault",
  "ockam_vault_core",
@@ -774,7 +1008,7 @@ name = "ockam_vault_test_suite"
 version = "0.20.0"
 dependencies = [
  "arrayref",
- "ockam_core",
+ "ockam_core 0.31.0",
  "ockam_vault_core",
 ]
 
@@ -797,6 +1031,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "panic-semihosting"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
+dependencies = [
+ "cortex-m 0.7.3",
+ "cortex-m-semihosting",
 ]
 
 [[package]]
@@ -831,6 +1075,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "polyval"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +1099,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +1127,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
 name = "radium"
@@ -1044,9 +1312,9 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?branch=ockam-network/no_std+alloc#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
+ "core2",
  "serde",
 ]
 
@@ -1297,19 +1565,7 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1382,7 +1638,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -30,13 +30,6 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "ockam_vault/no_std", 
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/alloc"]
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = ["ockam_core/unsafe_random", "ockam_vault_core/unsafe_random", "ockam_vault/unsafe_random", "ockam_node/unsafe_random"]
-
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.25.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -3,6 +3,7 @@ name = "ockam_vault_sync_core"
 version = "0.22.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault_sync_core"
@@ -28,6 +29,13 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "ockam_vault/no_std", 
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/alloc"]
+
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = ["ockam_core/unsafe_random", "ockam_vault_core/unsafe_random", "ockam_vault/unsafe_random", "ockam_node/unsafe_random"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.31.0"    , default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_mutex.rs
@@ -16,11 +16,16 @@ pub struct VaultMutex<V>(Mutex<RefCell<Option<V>>>);
 #[cfg(not(feature = "std"))]
 use core::cell::RefCell;
 
+#[cfg(feature = "std")]
 impl<V> Clone for VaultMutex<V> {
     fn clone(&self) -> Self {
-        #[cfg(feature = "std")]
         return Self(self.0.clone());
-        #[cfg(not(feature = "std"))]
+    }
+}
+#[cfg(not(feature = "std"))]
+impl<V: Clone> Clone for VaultMutex<V> {
+    fn clone(&self) -> Self {
+        // TODO @antoinevg - use new no_std mutex wrapper
         return ockam_node::interrupt::free(|cs| {
             let clone = self.0.borrow(cs).borrow_mut().clone();
             Self(Mutex::new(RefCell::new(clone)))

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -1,10 +1,7 @@
 use crate::{Vault, VaultRequestMessage, VaultResponseMessage, VaultTrait};
-#[cfg(not(feature = "std"))]
 use ockam_core::compat::rand::random;
 use ockam_core::{Address, Result, ResultMessage, Route};
 use ockam_node::{block_future, Context};
-#[cfg(feature = "std")]
-use rand::random;
 use tracing::debug;
 use zeroize::Zeroize;
 

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
@@ -193,8 +193,7 @@ dependencies = [
 [[package]]
 name = "serde_bare"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbd09b1e0b45fadbc163e4ea1f4224b451146ba4f01963c69975780c33215fa"
+source = "git+https://github.com/ockam-network/serde_bare.git?rev=c4630d2#c4630d202018803efe4153f000fbe234ac3fe18a"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.lock
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.lock
@@ -258,7 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -3,6 +3,7 @@ name = "signature_bbs_plus"
 version = "0.23.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/blob/develop/implementations/rust/ockam/signature_bbs_plus"
@@ -13,18 +14,24 @@ description = """The Ockam BBS+ signature impementation.
 """
 
 [features]
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = []
 
 [dependencies]
-bls12_381_plus = "0.5"
+bls12_381_plus = { version = "0.5", default-features = false }
 blake2 = { version = "0.9", default-features = false }
 digest = { version = "0.9", default-features = false }
-ff = "0.10"
+ff = { version = "0.10", default-features = false }
 group = "0.10"
 hmac-drbg = "0.3"
-managed = { version = "0.8", features = ["map"] }
+managed = { version = "0.8", default-features = false, features = ["map"] }
 pairing = "0.20"
 rand_core = "0.6"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { version = "0.23.0"    , path = "../signature_core" }
 signature_bls = { version = "0.21.0"    , path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -13,14 +13,6 @@ keywords = ["ockam", "crypto", "signature", "signing", "bls"]
 description = """The Ockam BBS+ signature impementation.
 """
 
-[features]
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = []
-
 [dependencies]
 bls12_381_plus = { version = "0.5", default-features = false }
 blake2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/signature_bbs_plus/src/pok_signature.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/pok_signature.rs
@@ -4,6 +4,9 @@ use core::ops::Neg;
 use digest::Update;
 use ff::Field;
 use group::Curve;
+#[cfg(feature = "unsafe_random")]
+use rand_core::RngCore;
+#[cfg(not(feature = "unsafe_random"))]
 use rand_core::{CryptoRng, RngCore};
 use signature_core::{error::Error, lib::*};
 
@@ -33,7 +36,8 @@ impl PokSignature {
         signature: Signature,
         generators: &MessageGenerators,
         messages: &[ProofMessage],
-        mut rng: impl RngCore + CryptoRng,
+        #[cfg(not(feature = "unsafe_random"))] mut rng: impl RngCore + CryptoRng,
+        #[cfg(feature = "unsafe_random")] mut rng: impl RngCore,
     ) -> Result<Self, Error> {
         if messages.len() != generators.len() {
             return Err(Error::new(1, "mismatched messages with and generators"));

--- a/implementations/rust/ockam/signature_bbs_plus/src/pok_signature.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/pok_signature.rs
@@ -4,9 +4,6 @@ use core::ops::Neg;
 use digest::Update;
 use ff::Field;
 use group::Curve;
-#[cfg(feature = "unsafe_random")]
-use rand_core::RngCore;
-#[cfg(not(feature = "unsafe_random"))]
 use rand_core::{CryptoRng, RngCore};
 use signature_core::{error::Error, lib::*};
 
@@ -36,8 +33,7 @@ impl PokSignature {
         signature: Signature,
         generators: &MessageGenerators,
         messages: &[ProofMessage],
-        #[cfg(not(feature = "unsafe_random"))] mut rng: impl RngCore + CryptoRng,
-        #[cfg(feature = "unsafe_random")] mut rng: impl RngCore,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<Self, Error> {
         if messages.len() != generators.len() {
             return Err(Error::new(1, "mismatched messages with and generators"));

--- a/implementations/rust/ockam/signature_bbs_plus/src/prover.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/prover.rs
@@ -3,9 +3,6 @@ use blake2::VarBlake2b;
 use bls12_381_plus::{G1Affine, G1Projective, Scalar};
 use digest::{Update, VariableOutput};
 use group::Curve;
-#[cfg(feature = "unsafe_random")]
-use rand_core::RngCore;
-#[cfg(not(feature = "unsafe_random"))]
 use rand_core::{CryptoRng, RngCore};
 use signature_core::{error::Error, lib::*};
 
@@ -22,8 +19,7 @@ impl Prover {
         messages: &[(usize, Message)],
         generators: &MessageGenerators,
         nonce: Nonce,
-        #[cfg(not(feature = "unsafe_random"))] mut rng: impl RngCore + CryptoRng,
-        #[cfg(feature = "unsafe_random")] mut rng: impl RngCore,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<(BlindSignatureContext, SignatureBlinding), Error> {
         const BYTES: usize = 48;
         // Very uncommon to blind more than 1 or 2, so 16 should be plenty
@@ -95,24 +91,11 @@ impl Prover {
 
     /// Create a new signature proof of knowledge and selective disclosure proof
     /// from a verifier's request
-    #[cfg(not(feature = "unsafe_random"))]
     pub fn commit_signature_pok(
         signature: Signature,
         generators: &MessageGenerators,
         messages: &[ProofMessage],
         rng: impl RngCore + CryptoRng,
-    ) -> Result<PokSignature, Error> {
-        PokSignature::init(signature, generators, messages, rng)
-    }
-
-    /// Create a new signature proof of knowledge and selective disclosure proof
-    /// from a verifier's request
-    #[cfg(feature = "unsafe_random")]
-    pub fn commit_signature_pok(
-        signature: Signature,
-        generators: &MessageGenerators,
-        messages: &[ProofMessage],
-        rng: impl RngCore,
     ) -> Result<PokSignature, Error> {
         PokSignature::init(signature, generators, messages, rng)
     }

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -14,16 +14,23 @@ description = """The Ockam BLS signature impementation.
 
 [features]
 default = ["alloc"]
-alloc = ["bls12_381_plus/alloc"]
+alloc = []
+
+# Option: "unsafe_random" enables development support for random
+# number generation on no_std platforms that do not yet have
+# cryptographically secure implementations.
+# WARNING: Under no circumstances should this ever be enabled in
+#          production builds!
+unsafe_random = []
 
 [dependencies]
-bls12_381_plus = "0.5"
-ff = "0.10"
+bls12_381_plus = { version = "0.5", default-features = false, features = ["alloc", "hashing", "pairings"] }
+ff = { version = "0.10", default-features = false }
 group = "0.10"
-hkdf = "0.11"
+hkdf = { version = "0.11", default-features = false }
 pairing = "0.20"
 rand_core = "0.6"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.4", default-features = false }
 vsss-rs = { version = "1.0.0", default-features = false }

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -16,13 +16,6 @@ description = """The Ockam BLS signature impementation.
 default = ["alloc"]
 alloc = []
 
-# Option: "unsafe_random" enables development support for random
-# number generation on no_std platforms that do not yet have
-# cryptographically secure implementations.
-# WARNING: Under no circumstances should this ever be enabled in
-#          production builds!
-unsafe_random = []
-
 [dependencies]
 bls12_381_plus = { version = "0.5", default-features = false, features = ["alloc", "hashing", "pairings"] }
 ff = { version = "0.10", default-features = false }

--- a/implementations/rust/ockam/signature_bls/src/secret_key.rs
+++ b/implementations/rust/ockam/signature_bls/src/secret_key.rs
@@ -62,7 +62,16 @@ impl SecretKey {
     }
 
     /// Compute a secret key from a CS-PRNG
+    #[cfg(not(feature = "unsafe_random"))]
     pub fn random(mut rng: impl RngCore + CryptoRng) -> Option<Self> {
+        let mut data = [0u8; Self::BYTES];
+        rng.fill_bytes(&mut data);
+        generate_secret_key(&data)
+    }
+
+    /// Compute a secret key from a CS-PRNG
+    #[cfg(feature = "unsafe_random")]
+    pub fn random(mut rng: impl RngCore) -> Option<Self> {
         let mut data = [0u8; Self::BYTES];
         rng.fill_bytes(&mut data);
         generate_secret_key(&data)

--- a/implementations/rust/ockam/signature_bls/src/secret_key.rs
+++ b/implementations/rust/ockam/signature_bls/src/secret_key.rs
@@ -62,16 +62,7 @@ impl SecretKey {
     }
 
     /// Compute a secret key from a CS-PRNG
-    #[cfg(not(feature = "unsafe_random"))]
     pub fn random(mut rng: impl RngCore + CryptoRng) -> Option<Self> {
-        let mut data = [0u8; Self::BYTES];
-        rng.fill_bytes(&mut data);
-        generate_secret_key(&data)
-    }
-
-    /// Compute a secret key from a CS-PRNG
-    #[cfg(feature = "unsafe_random")]
-    pub fn random(mut rng: impl RngCore) -> Option<Self> {
         let mut data = [0u8; Self::BYTES];
         rng.fill_bytes(&mut data);
         generate_secret_key(&data)

--- a/implementations/rust/ockam/signature_core/Cargo.lock
+++ b/implementations/rust/ockam/signature_core/Cargo.lock
@@ -60,18 +60,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
-name = "bitvec"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,11 +76,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29fb62df98b3994d31d6ebb80607e75f784bc814bb801b4c75d6a595fcead26"
 dependencies = [
- "digest",
  "ff",
  "group",
  "heapless",
- "pairing",
  "rand_core",
  "serde",
  "subtle",
@@ -170,16 +156,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec",
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "generic-array"
@@ -230,7 +209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]
@@ -306,15 +284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "pairing"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
-dependencies = [
- "group",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,12 +306,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -552,12 +515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,15 +558,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wyz"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "zeroize"

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -3,6 +3,7 @@ name = "signature_core"
 version = "0.23.0"
 authors = ["Ockam Deveopers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/signatures_core"
@@ -19,15 +20,15 @@ exclude = [
 
 
 [dependencies]
-blake2 = "0.9"
-bls12_381_plus = "0.5"
-digest = "0.9"
-ff = "0.10"
+blake2 = { version = "0.9", default-features = false }
+bls12_381_plus = { version = "0.5", default-features = false, features = ["groups"] }
+digest = { version = "0.9", default-features = false }
+ff = { version = "0.10", default-features = false }
 group = "0.10"
-hashbrown = { version = "0.11", features = ["serde"] }
+hashbrown = { version = "0.11", default-features = false, features = ["ahash"] }
 heapless = "0.7"
 rand_core = "0.6"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 subtle = { version = "2.4", default_features = false }
 typenum = "1.13"
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/signature_core/src/error.rs
+++ b/implementations/rust/ockam/signature_core/src/error.rs
@@ -8,7 +8,6 @@ pub struct Error {
 }
 
 impl Error {
-    #[cfg(not(feature = "std"))]
     /// Create a new error
     pub fn new(code: u32, message: &str) -> Self {
         Self {

--- a/implementations/rust/ockam/signature_ps/Cargo.lock
+++ b/implementations/rust/ockam/signature_ps/Cargo.lock
@@ -258,7 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -3,6 +3,7 @@ name = "signature_ps"
 version = "0.21.0"
 authors = ["Ockam Developers"]
 edition = "2018"
+resolver = "2"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/signature_ps"
@@ -15,18 +16,18 @@ description = """The Ockam PS signature impementation.
 [features]
 
 [dependencies]
-blake2 = "0.9"
+blake2 = { version = "0.9", default-features = false }
 signature_bls = { version = "0.21.0"    , path = "../signature_bls" }
-bls12_381_plus = "0.5"
+bls12_381_plus = { version = "0.5", default-features = false }
 digest = { version = "0.9", default-features = false }
-ff = "0.10"
+ff = { version = "0.10", default-features = false }
 group = "0.10"
 hmac-drbg = "0.3"
-hkdf = "0.11"
+hkdf = { version = "0.11", default-features = false }
 pairing = "0.20"
 rand_core = "0.6"
 rand_chacha = { version = "0.3", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { version = "0.23.0"    , path = "../signature_core" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"


### PR DESCRIPTION
### Proposed Changes

* fix(rust): no_std version of thread_rng state does not advance with repeated instantiations 
* fix(rust): match no_std semantics of compat::mutex lock implementation to std
* fix(rust): fix crate compilation for no_std + alloc feature configuration
  - ockam
  - ockam_entity
  - ockam_channel
  - ockam_vault*
  - signature*
  - ockam_node
* chore(rust): add ockam_core::compat::task
* chore(rust): use forked version of crates core2 and serde_bare 