### PR TITLE
chore(rust): update serde_bare git dependency to released crate

### DIFF
--- a/examples/rust/get_started/Cargo.lock
+++ b/examples/rust/get_started/Cargo.lock
@@ -1383,8 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -1487,10 +1487,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -86,7 +86,7 @@ bls12_381_plus = { version = "0.5", default-features = false }
 signature_core = { version = "0.24.0"     , path = "../signature_core" }
 signature_bbs_plus = { version = "0.24.0"     , path = "../signature_bbs_plus", package = "signature_bbs_plus" }
 signature_bls = { version = "0.22.0"     , path = "../signature_bls", package = "signature_bls" }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.lock
+++ b/implementations/rust/ockam/ockam_channel/Cargo.lock
@@ -1334,10 +1334,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -39,7 +39,7 @@ ockam_node = { path = "../ockam_node", version = "0.30.0"     , default_features
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.26.0"     , default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "0.23.0"     , default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "0.26.0"     , default_features = false, optional = true }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 async-trait = "0.1"

--- a/implementations/rust/ockam/ockam_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_core/Cargo.lock
@@ -389,10 +389,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -35,7 +35,7 @@ alloc = ["core2/alloc", "core2/nightly", "heapless", "hex/alloc", "serde/alloc",
 
 [dependencies]
 async-trait = "0.1.42"
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 hashbrown =  { version = "0.11", default-features = false, features = ["ahash", "serde"] }
 heapless = { version = "0.7.1", optional = true }
 hex = { version = "0.4", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -76,8 +76,8 @@ where
     }
 }
 
-impl From<serde_bare::Error> for crate::Error {
-    fn from(_: serde_bare::Error) -> Self {
+impl From<serde_bare::error::Error> for crate::Error {
+    fn from(_: serde_bare::error::Error) -> Self {
         Self::new(1, "serde_bare")
     }
 }

--- a/implementations/rust/ockam/ockam_entity/Cargo.lock
+++ b/implementations/rust/ockam/ockam_entity/Cargo.lock
@@ -1437,10 +1437,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -53,7 +53,7 @@ signature_bbs_plus = { path = "../signature_bbs_plus", version = "0.24.0"     }
 serde_json = { version ="1.0", optional = true }
 sha2 = { version = "0.9", default-features = false }
 serde-big-array = "0.3"
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 rand = { version = "0.8", default-features = false }
 tracing = { version = "0.1", default_features = false }
 

--- a/implementations/rust/ockam/ockam_examples/Cargo.lock
+++ b/implementations/rust/ockam/ockam_examples/Cargo.lock
@@ -1257,8 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
@@ -17,6 +17,6 @@ ockam = { version = "*", path = "../../../ockam" }
 rpassword = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 serde-big-array = "0.3"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
@@ -12,6 +12,6 @@ ockam_vault = {  path = "../../../ockam/ockam_vault" }
 okta-plugin = { path = "../" }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 serde_json = "1.0"
 structopt = "0.3"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
@@ -21,7 +21,7 @@ ockam_key_exchange_core = { path = "../../../ockam/ockam_key_exchange_core" }
 ockam_key_exchange_x3dh = { path = "../../../ockam/ockam_key_exchange_x3dh" }
 okta-plugin = { version = "0.1", path = "../" }
 serde = { version = "1.0", features = ["derive"] }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 serde_json = "1.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.lock
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.lock
@@ -756,8 +756,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.lock
@@ -421,10 +421,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.lock
@@ -1008,10 +1008,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.lock
@@ -1008,10 +1008,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_node/Cargo.lock
+++ b/implementations/rust/ockam/ockam_node/Cargo.lock
@@ -888,10 +888,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.lock
@@ -170,8 +170,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
  "serde",
 ]

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.lock
@@ -76,15 +76,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf12d2dad3ed124aa116f59561428478993d69ab81ae4d30e5349c9c5b5a5f6"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "dissimilar"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,10 +621,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -27,7 +27,7 @@ alloc = ["serde_bare/alloc"]
 ockam_core = { path = "../ockam_core", version = "0.32.0"     }
 ockam_node = { path = "../ockam_node", version = "0.30.0"     }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.6.0"     }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time"] }
 futures = "0.3.10"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.lock
@@ -238,15 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf12d2dad3ed124aa116f59561428478993d69ab81ae4d30e5349c9c5b5a5f6"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,10 +1244,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -30,7 +30,7 @@ futures-util = { version = "0.3", default-features = false, features = ["tokio-i
 ockam_core = { path = "../ockam_core", version = "0.32.0"     }
 ockam_node = { path = "../ockam_node", version = "0.30.0"     }
 ockam_transport_core = { path = "../ockam_transport_core", version = "0.6.0"     }
-serde_bare = { git = "https://github.com/ockam-network/serde_bare.git", rev = "fdbb431", default-features = false }
+serde_bare = { version = "0.5.0", default-features = false }
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_vault/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault/Cargo.lock
@@ -791,10 +791,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.lock
@@ -412,10 +412,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.lock
@@ -1290,10 +1290,10 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
- "core2",
  "serde",
 ]
 

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.lock
@@ -192,8 +192,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bare"
-version = "0.4.0"
-source = "git+https://github.com/ockam-network/serde_bare.git?rev=fdbb431#fdbb431d706c0062718e74e1e8ef5a78f8cd8f58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
### Proposed Changes

This pull request replaces all Cargo references to our git repo of `serde_bare` with the newly published version `0.5.0` of the crate.