### PR TITLE
Define custom `Clone` trait for Async objects.

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod traits {
     /// Clone trait for async structs.
     #[async_trait]
     pub trait AsyncTryClone: Sized {
-        /// Try cloning a object and return an `Err` in case of failure.
+        /// Try cloning an object and return an `Err` in case of failure.
         async fn async_try_clone(&self) -> Result<Self>;
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -66,3 +66,15 @@ macro_rules! println {
         cortex_m_semihosting::hprintln!($($arg)*).unwrap();
     }};
 }
+
+/// Module for custom implementation of standard traits.
+pub mod traits {
+    use crate::error::Result;
+
+    /// Clone trait for async structs.
+    #[async_trait]
+    pub trait AsyncTryClone: Sized {
+        /// Try cloning a object and return an `Err` if anything panics.
+        async fn async_try_clone(&self) -> Result<Self>;
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -52,6 +52,7 @@ pub use error::*;
 pub use message::*;
 pub use processor::*;
 pub use routing::*;
+pub use traits::*;
 pub use uint::*;
 pub use worker::*;
 

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod traits {
     /// Clone trait for async structs.
     #[async_trait]
     pub trait AsyncTryClone: Sized {
-        /// Try cloning a object and return an `Err` if anything panics.
+        /// Try cloning a object and return an `Err` in case of failure.
         async fn async_try_clone(&self) -> Result<Self>;
     }
 }

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -1,6 +1,6 @@
 use crate::{Vault, VaultRequestMessage, VaultResponseMessage, VaultTrait};
 use ockam_core::compat::rand::random;
-use ockam_core::{async_trait::async_trait, Address, AsyncTryClone, Result, ResultMessage, Route};
+use ockam_core::{Address, Result, ResultMessage, Route};
 use ockam_node::{block_future, Context};
 use tracing::debug;
 use zeroize::Zeroize;
@@ -47,13 +47,6 @@ impl VaultSync {
 impl Clone for VaultSync {
     fn clone(&self) -> Self {
         self.start_another().unwrap()
-    }
-}
-
-#[async_trait]
-impl AsyncTryClone for VaultSync {
-    async fn async_try_clone(&self) -> Result<Self> {
-        self.start_another()
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -1,6 +1,6 @@
 use crate::{Vault, VaultRequestMessage, VaultResponseMessage, VaultTrait};
 use ockam_core::compat::rand::random;
-use ockam_core::{Address, Result, ResultMessage, Route};
+use ockam_core::{async_trait::async_trait, Address, AsyncTryClone, Result, ResultMessage, Route};
 use ockam_node::{block_future, Context};
 use tracing::debug;
 use zeroize::Zeroize;
@@ -47,6 +47,13 @@ impl VaultSync {
 impl Clone for VaultSync {
     fn clone(&self) -> Self {
         self.start_another().unwrap()
+    }
+}
+
+#[async_trait]
+impl AsyncTryClone for VaultSync {
+    async fn async_try_clone(&self) -> Result<Self> {
+        self.start_another()
     }
 }
 


### PR DESCRIPTION
Fixes #1850.

Adding custom trait for `Clone`.

Pending tasks:
- [ ] Implement this trait in a couple of places.
- [ ] Add tests.
- [x] Better documentation.