### PR TITLE
chore(rust): transpose `Handle` component and implementation for `VaultSync`

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.lock
+++ b/implementations/rust/ockam/ockam/Cargo.lock
@@ -210,10 +210,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29fb62df98b3994d31d6ebb80607e75f784bc814bb801b4c75d6a595fcead26"
 dependencies = [
  "digest",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "heapless",
- "pairing",
+ "pairing 0.20.0",
+ "rand_core 0.6.3",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "bls12_381_plus"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9ca230350e9fa6d2bcbf2eec0dd805a8aa0996ee8884da282097ca7e50a29b"
+dependencies = [
+ "digest",
+ "ff 0.11.0",
+ "group 0.11.0",
+ "heapless",
+ "pairing 0.21.0",
  "rand_core 0.6.3",
  "serde",
  "subtle",
@@ -486,6 +503,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
 name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,7 +686,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "byteorder",
- "ff",
+ "ff 0.10.1",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "byteorder",
+ "ff 0.11.0",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -916,7 +956,7 @@ version = "0.32.0"
 dependencies = [
  "arrayref",
  "async-trait",
- "bls12_381_plus",
+ "bls12_381_plus 0.6.0",
  "hex",
  "ockam_channel",
  "ockam_core",
@@ -981,9 +1021,9 @@ name = "ockam_entity"
 version = "0.22.0"
 dependencies = [
  "async-trait",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.1",
  "cfg-if",
- "group",
+ "group 0.10.0",
  "heapless",
  "ockam_channel",
  "ockam_core",
@@ -1161,7 +1201,16 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
- "group",
+ "group 0.10.0",
+]
+
+[[package]]
+name = "pairing"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e415e349a3006dd7d9482cdab1c980a845bed1377777d768cb693a44540b42"
+dependencies = [
+ "group 0.11.0",
 ]
 
 [[package]]
@@ -1554,13 +1603,13 @@ name = "signature_bbs_plus"
 version = "0.25.0"
 dependencies = [
  "blake2",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.1",
  "digest",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hmac-drbg",
  "managed",
- "pairing",
+ "pairing 0.20.0",
  "rand_core 0.6.3",
  "serde",
  "signature_bls",
@@ -1574,11 +1623,11 @@ dependencies = [
 name = "signature_bls"
 version = "0.23.0"
 dependencies = [
- "bls12_381_plus",
- "ff",
- "group",
+ "bls12_381_plus 0.5.1",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hkdf",
- "pairing",
+ "pairing 0.20.0",
  "rand_core 0.6.3",
  "serde",
  "sha2",
@@ -1592,10 +1641,10 @@ name = "signature_core"
 version = "0.25.0"
 dependencies = [
  "blake2",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.1",
  "digest",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hashbrown 0.11.2",
  "heapless",
  "rand_core 0.6.3",
@@ -1610,13 +1659,13 @@ name = "signature_ps"
 version = "0.23.0"
 dependencies = [
  "blake2",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.1",
  "digest",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hkdf",
  "hmac-drbg",
- "pairing",
+ "pairing 0.20.0",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "serde",
@@ -1886,8 +1935,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ab2c37f12d35ff2f9b754e450a6e0930e1d2b7b9df6d6bf4494505e4b71071b"
 dependencies = [
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "serde",

--- a/implementations/rust/ockam/ockam_entity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel.rs
@@ -90,7 +90,7 @@ pub fn get_secure_channel_participant_id<T: Message>(msg: &Routed<T>) -> Result<
 mod test {
     use super::*;
     use crate::{Entity, SecureChannels};
-    use ockam_core::{route, Message};
+    use ockam_core::route;
     use ockam_vault_sync_core::Vault;
 
     #[test]

--- a/implementations/rust/ockam/ockam_entity/src/entity.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity.rs
@@ -4,8 +4,8 @@ use crate::{
     Credential, CredentialAttribute, CredentialFragment1, CredentialFragment2, CredentialOffer,
     CredentialPresentation, CredentialProof, CredentialProtocol, CredentialPublicKey,
     CredentialRequest, CredentialRequestFragment, CredentialSchema, EntityBuilder,
-    EntityCredential, Holder, HolderWorker, Identity, IdentityRequest, IdentityResponse,
-    Issuer, Lease, ListenerWorker, MaybeContact, OfferId, PresentationFinishedMessage,
+    EntityCredential, Holder, HolderWorker, Identity, IdentityRequest, IdentityResponse, Issuer,
+    Lease, ListenerWorker, MaybeContact, OfferId, PresentationFinishedMessage,
     PresentationManifest, PresenterWorker, ProfileChangeEvent, ProfileIdentifier, ProofRequestId,
     SecureChannels, SigningPublicKey, TrustPolicy, TrustPolicyImpl, VerifierWorker, TTL,
 };

--- a/implementations/rust/ockam/ockam_entity/src/entity_builder.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity_builder.rs
@@ -1,6 +1,6 @@
-use crate::{Entity, EntityWorker, Handle};
+use crate::{Entity, EntityWorker};
 use ockam_core::{Address, Result};
-use ockam_node::{block_future, Context};
+use ockam_node::{block_future, Context, Handle};
 
 /// Builder for `Entity`
 pub struct EntityBuilder {

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -8,7 +8,7 @@
     unsafe_code,
     unused_import_braces,
     unused_qualifications,
-    // warnings
+    warnings
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_entity/src/profile.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile.rs
@@ -21,7 +21,7 @@ use crate::{
     traits::Verifier, AuthenticationProof, BbsCredential, Changes, Contact, Credential,
     CredentialAttribute, CredentialFragment1, CredentialFragment2, CredentialOffer,
     CredentialPresentation, CredentialProof, CredentialPublicKey, CredentialRequest,
-    CredentialRequestFragment, CredentialSchema, Entity, EntityCredential, Handle, Holder,
+    CredentialRequestFragment, CredentialSchema, Entity, EntityCredential, Holder,
     Identity, IdentityRequest, IdentityResponse, Issuer, Lease, OfferId, PresentationManifest,
     ProfileChangeEvent, ProfileIdentifier, ProofRequestId, SecureChannels, SigningPublicKey,
     TrustPolicy, TTL,
@@ -31,6 +31,7 @@ use ockam_core::compat::{
     vec::Vec,
 };
 use ockam_core::{Address, Result, Route};
+use ockam_node::Handle;
 use ockam_vault::{PublicKey, Secret};
 use signature_bls::SecretKey;
 

--- a/implementations/rust/ockam/ockam_entity/src/profile.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile.rs
@@ -21,8 +21,8 @@ use crate::{
     traits::Verifier, AuthenticationProof, BbsCredential, Changes, Contact, Credential,
     CredentialAttribute, CredentialFragment1, CredentialFragment2, CredentialOffer,
     CredentialPresentation, CredentialProof, CredentialPublicKey, CredentialRequest,
-    CredentialRequestFragment, CredentialSchema, Entity, EntityCredential, Holder,
-    Identity, IdentityRequest, IdentityResponse, Issuer, Lease, OfferId, PresentationManifest,
+    CredentialRequestFragment, CredentialSchema, Entity, EntityCredential, Holder, Identity,
+    IdentityRequest, IdentityResponse, Issuer, Lease, OfferId, PresentationManifest,
     ProfileChangeEvent, ProfileIdentifier, ProofRequestId, SecureChannels, SigningPublicKey,
     TrustPolicy, TTL,
 };

--- a/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
@@ -1,13 +1,12 @@
 use crate::{
     CredentialHolder, CredentialIssuer, CredentialProof, CredentialPublicKey,
-    CredentialRequestFragment, CredentialVerifier, EntityError::IdentityApiFailed,
-    Identity, IdentityRequest, IdentityRequest::*, IdentityResponse as Res, MaybeContact, Profile,
+    CredentialRequestFragment, CredentialVerifier, EntityError::IdentityApiFailed, Identity,
+    IdentityRequest, IdentityRequest::*, IdentityResponse as Res, MaybeContact, Profile,
     ProfileIdentifier, ProfileState, SecureChannelTrait, TrustPolicyImpl,
 };
 use core::result::Result::Ok;
 use ockam_core::{
-    async_trait::async_trait, compat::collections::HashMap, Address, Result,
-    Routed, Worker
+    async_trait::async_trait, compat::collections::HashMap, Address, Result, Routed, Worker,
 };
 use ockam_node::{Context, Handle};
 use ockam_vault_sync_core::VaultSync;

--- a/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/entity_worker.rs
@@ -1,14 +1,15 @@
 use crate::{
     CredentialHolder, CredentialIssuer, CredentialProof, CredentialPublicKey,
-    CredentialRequestFragment, CredentialVerifier, EntityError::IdentityApiFailed, Handle,
+    CredentialRequestFragment, CredentialVerifier, EntityError::IdentityApiFailed,
     Identity, IdentityRequest, IdentityRequest::*, IdentityResponse as Res, MaybeContact, Profile,
     ProfileIdentifier, ProfileState, SecureChannelTrait, TrustPolicyImpl,
 };
-use async_trait::async_trait;
 use core::result::Result::Ok;
-use ockam_core::compat::{boxed::Box, collections::HashMap};
-use ockam_core::{Address, Result, Routed, Worker};
-use ockam_node::Context;
+use ockam_core::{
+    async_trait::async_trait, compat::collections::HashMap, Address, Result,
+    Routed, Worker
+};
+use ockam_node::{Context, Handle};
 use ockam_vault_sync_core::VaultSync;
 
 #[cfg(feature = "lease_proto_json")]

--- a/implementations/rust/ockam/ockam_entity/src/worker/trust_policy_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/trust_policy_worker.rs
@@ -1,8 +1,6 @@
-use crate::{Handle, SecureChannelTrustInfo, TrustPolicy};
-use async_trait::async_trait;
-use ockam_core::compat::boxed::Box;
-use ockam_core::{Address, Result, Routed, Worker};
-use ockam_node::Context;
+use crate::{SecureChannelTrustInfo, TrustPolicy};
+use ockam_core::{async_trait::async_trait, Address, Result, Routed, Worker};
+use ockam_node::{Context, Handle};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone)]

--- a/implementations/rust/ockam/ockam_node/src/handle.rs
+++ b/implementations/rust/ockam/ockam_node/src/handle.rs
@@ -1,0 +1,93 @@
+use ockam_core::{Address, Message, Result};
+
+use crate::{block_future, Context};
+
+/// Wrapper for `Context` and `Address`
+pub struct Handle {
+    ctx: Context,
+    address: Address,
+}
+
+impl Clone for Handle {
+    fn clone(&self) -> Self {
+        block_future(&self.ctx.runtime(), async move {
+            Handle {
+                ctx: self
+                    .ctx
+                    .new_context(Address::random(0))
+                    .await
+                    .expect("new_context failed"),
+                address: self.address.clone(),
+            }
+        })
+    }
+}
+
+impl Handle {
+    /// Create a new `Handle` from a `Context` and `Address`
+    pub fn new(ctx: Context, address: Address) -> Self {
+        Handle { ctx, address }
+    }
+
+    /// Asynchronously sends a message
+    pub async fn async_cast<M: Message + Send + 'static>(&self, msg: M) -> Result<()> {
+        self.ctx.send(self.address.clone(), msg).await
+    }
+
+    /// Sends a message that blocks current `Worker` without blocking the executor.
+    pub fn cast<M: Message + Send + 'static>(&self, msg: M) -> Result<()> {
+        block_future(
+            &self.ctx.runtime(),
+            async move { self.async_cast(msg).await },
+        )
+    }
+
+    /// Asynchronously sends and receiving a message using a new `Context`
+    pub async fn async_call<I: Message + Send + 'static, O: Message + Send + 'static>(
+        &self,
+        msg: I,
+    ) -> Result<O> {
+        let mut ctx = self
+            .ctx
+            .new_context(Address::random(0))
+            .await
+            .expect("new_context failed");
+        ctx.send(self.address.clone(), msg).await?;
+        let msg = ctx.receive::<O>().await?;
+        Ok(msg.take().body())
+    }
+
+    /// Send and receiving a message that blocks current `Worker` without blocking the executor.
+    pub fn call<I: Message + Send + 'static, O: Message + Send + 'static>(
+        &self,
+        msg: I,
+    ) -> Result<O> {
+        block_future(
+            &self.ctx.runtime(),
+            async move { self.async_call(msg).await },
+        )
+    }
+}
+
+// Author : Martin <mcodesmith@gmail.com>
+impl Handle {
+    /// Gets inner `Context` as reference
+    pub fn ctx(&self) -> &Context {
+        &self.ctx
+    }
+
+    /// Gets inner `Context` as mutable reference
+    pub fn ctx_mut(&mut self) -> &mut Context {
+        &mut self.ctx
+    }
+
+    /// Gets inner `Address` as reference
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    /// Gets inner `Address` as mutable reference
+    pub fn address_mut(&mut self) -> &mut Address {
+        &mut self.address
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -29,6 +29,7 @@ mod address_record;
 mod context;
 mod error;
 mod executor;
+mod handle;
 mod mailbox;
 mod messages;
 mod node;
@@ -40,6 +41,7 @@ mod tests;
 pub(crate) use address_record::*;
 pub use context::*;
 pub use executor::*;
+pub use handle::*;
 pub use mailbox::*;
 pub use messages::*;
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -1,7 +1,7 @@
 use crate::{Vault, VaultRequestMessage, VaultResponseMessage, VaultTrait};
 use ockam_core::compat::rand::random;
 use ockam_core::{async_trait::async_trait, Address, AsyncTryClone, Result, ResultMessage, Route};
-use ockam_node::{block_future, Context};
+use ockam_node::{block_future, Context, Handle};
 use tracing::debug;
 use zeroize::Zeroize;
 
@@ -23,24 +23,38 @@ pub use verifier::*;
 
 /// Vault sync wrapper
 pub struct VaultSync {
-    ctx: Context,
-    vault_worker_address: Address,
+    // ctx: Context,
+    // vault_worker_address: Address,
+    handle: Handle
 }
 
 impl VaultSync {
+    // Todo: mark as deprecated
+    // #[deprecated]
+    #[allow(unused)]
     pub(crate) async fn send_message(&self, m: VaultRequestMessage) -> Result<()> {
-        self.ctx
-            .send(Route::new().append(self.vault_worker_address.clone()), m)
+        self.handle.ctx()
+            .send(Route::new().append(self.handle.address().clone()), m)
             .await
     }
 
+    // Todo: mark as deprecated
+    // #[deprecated]
+    #[allow(unused)]
     pub(crate) async fn receive_message(&mut self) -> Result<VaultResponseMessage> {
-        self.ctx
+        self.handle.ctx_mut()
             .receive::<ResultMessage<VaultResponseMessage>>()
             .await?
             .take()
             .body()
             .into()
+    }
+
+    pub(crate) fn call(&mut self, msg: VaultRequestMessage) -> Result<VaultResponseMessage> {
+        self.handle
+            .call::<VaultRequestMessage, ResultMessage<VaultResponseMessage>>(
+                msg
+            )?.into()
     }
 }
 
@@ -60,9 +74,9 @@ impl AsyncTryClone for VaultSync {
 impl VaultSync {
     /// Start another Vault at the same address.
     pub fn start_another(&self) -> Result<Self> {
-        let vault_worker_address = self.vault_worker_address.clone();
+        let vault_worker_address = self.handle.address().clone();
 
-        let clone = VaultSync::create_with_worker(&self.ctx, &vault_worker_address)?;
+        let clone = VaultSync::create_with_worker(&self.handle.ctx(), &vault_worker_address)?;
 
         Ok(clone)
     }
@@ -84,9 +98,9 @@ impl VaultSync {
             async move { ctx.new_context(address).await },
         )?;
 
+
         Ok(Self {
-            ctx,
-            vault_worker_address: vault.clone(),
+            handle: Handle::new(ctx, vault.clone())
         })
     }
 
@@ -99,6 +113,6 @@ impl VaultSync {
 
     /// Return the Vault worker address
     pub fn address(&self) -> Address {
-        self.vault_worker_address.clone()
+        self.handle.address().clone()
     }
 }

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync.rs
@@ -25,7 +25,7 @@ pub use verifier::*;
 pub struct VaultSync {
     // ctx: Context,
     // vault_worker_address: Address,
-    handle: Handle
+    handle: Handle,
 }
 
 impl VaultSync {
@@ -33,7 +33,8 @@ impl VaultSync {
     // #[deprecated]
     #[allow(unused)]
     pub(crate) async fn send_message(&self, m: VaultRequestMessage) -> Result<()> {
-        self.handle.ctx()
+        self.handle
+            .ctx()
             .send(Route::new().append(self.handle.address().clone()), m)
             .await
     }
@@ -42,7 +43,8 @@ impl VaultSync {
     // #[deprecated]
     #[allow(unused)]
     pub(crate) async fn receive_message(&mut self) -> Result<VaultResponseMessage> {
-        self.handle.ctx_mut()
+        self.handle
+            .ctx_mut()
             .receive::<ResultMessage<VaultResponseMessage>>()
             .await?
             .take()
@@ -52,9 +54,8 @@ impl VaultSync {
 
     pub(crate) fn call(&mut self, msg: VaultRequestMessage) -> Result<VaultResponseMessage> {
         self.handle
-            .call::<VaultRequestMessage, ResultMessage<VaultResponseMessage>>(
-                msg
-            )?.into()
+            .call::<VaultRequestMessage, ResultMessage<VaultResponseMessage>>(msg)?
+            .into()
     }
 }
 
@@ -98,9 +99,8 @@ impl VaultSync {
             async move { ctx.new_context(address).await },
         )?;
 
-
         Ok(Self {
-            handle: Handle::new(ctx, vault.clone())
+            handle: Handle::new(ctx, vault.clone()),
         })
     }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/asymmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/asymmetric_vault.rs
@@ -1,6 +1,5 @@
 use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{AsymmetricVault, PublicKey, Secret};
 
 impl AsymmetricVault for VaultSync {
@@ -9,21 +8,16 @@ impl AsymmetricVault for VaultSync {
         context: &Secret,
         peer_public_key: &PublicKey,
     ) -> Result<Secret> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::EcDiffieHellman {
+        let resp = self.call(VaultRequestMessage::EcDiffieHellman {
                 context: context.clone(),
-                peer_public_key: peer_public_key.clone(),
-            })
-            .await?;
+                peer_public_key: peer_public_key.clone(),}
+            )?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::EcDiffieHellman(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::EcDiffieHellman(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/asymmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/asymmetric_vault.rs
@@ -9,9 +9,9 @@ impl AsymmetricVault for VaultSync {
         peer_public_key: &PublicKey,
     ) -> Result<Secret> {
         let resp = self.call(VaultRequestMessage::EcDiffieHellman {
-                context: context.clone(),
-                peer_public_key: peer_public_key.clone(),}
-            )?;
+            context: context.clone(),
+            peer_public_key: peer_public_key.clone(),
+        })?;
 
         if let VaultResponseMessage::EcDiffieHellman(s) = resp {
             Ok(s)

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/hasher.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/hasher.rs
@@ -1,22 +1,19 @@
-use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{Hasher, Secret, SecretAttributes, SmallBuffer};
+
+use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 
 impl Hasher for VaultSync {
     fn sha256(&mut self, data: &[u8]) -> Result<[u8; 32]> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::Sha256 { data: data.into() })
-                .await?;
+        let resp = self.call(VaultRequestMessage::Sha256 {
+            data: data.into()
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::Sha256(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::Sha256(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn hkdf_sha256(
@@ -26,29 +23,26 @@ impl Hasher for VaultSync {
         ikm: Option<&Secret>,
         output_attributes: SmallBuffer<SecretAttributes>,
     ) -> Result<SmallBuffer<Secret>> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::HkdfSha256 {
-                salt: salt.clone(),
-                info: info.into(),
-                ikm: ikm.cloned(),
-                output_attributes,
-            })
-            .await?;
+        let resp = self.call(
+                VaultRequestMessage::HkdfSha256 {
+                    salt: salt.clone(),
+                    info: info.into(),
+                    ikm: ikm.cloned(),
+                    output_attributes,
+                })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::HkdfSha256(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::HkdfSha256(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use ockam_vault::SoftwareVault;
+
     use ockam_vault_test_attribute::*;
 
     fn new_vault() -> SoftwareVault {

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/hasher.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/hasher.rs
@@ -5,9 +5,7 @@ use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreE
 
 impl Hasher for VaultSync {
     fn sha256(&mut self, data: &[u8]) -> Result<[u8; 32]> {
-        let resp = self.call(VaultRequestMessage::Sha256 {
-            data: data.into()
-        })?;
+        let resp = self.call(VaultRequestMessage::Sha256 { data: data.into() })?;
 
         if let VaultResponseMessage::Sha256(s) = resp {
             Ok(s)
@@ -23,13 +21,12 @@ impl Hasher for VaultSync {
         ikm: Option<&Secret>,
         output_attributes: SmallBuffer<SecretAttributes>,
     ) -> Result<SmallBuffer<Secret>> {
-        let resp = self.call(
-                VaultRequestMessage::HkdfSha256 {
-                    salt: salt.clone(),
-                    info: info.into(),
-                    ikm: ikm.cloned(),
-                    output_attributes,
-                })?;
+        let resp = self.call(VaultRequestMessage::HkdfSha256 {
+            salt: salt.clone(),
+            info: info.into(),
+            ikm: ikm.cloned(),
+            output_attributes,
+        })?;
 
         if let VaultResponseMessage::HkdfSha256(s) = resp {
             Ok(s)

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/key_id_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/key_id_vault.rs
@@ -1,48 +1,39 @@
-use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::compat::string::ToString;
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{KeyId, KeyIdVault, PublicKey, Secret};
+
+use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 
 impl KeyIdVault for VaultSync {
     fn get_secret_by_key_id(&mut self, key_id: &str) -> Result<Secret> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::GetSecretByKeyId {
-                key_id: key_id.to_string(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::GetSecretByKeyId {
+            key_id: key_id.to_string(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::GetSecretByKeyId(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::GetSecretByKeyId(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn compute_key_id_for_public_key(&mut self, public_key: &PublicKey) -> Result<KeyId> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::ComputeKeyIdForPublicKey {
-                public_key: public_key.clone(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::ComputeKeyIdForPublicKey {
+            public_key: public_key.clone(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::ComputeKeyIdForPublicKey(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::ComputeKeyIdForPublicKey(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use ockam_vault::SoftwareVault;
+
     use ockam_vault_test_attribute::*;
 
     fn new_vault() -> SoftwareVault {

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/secret_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/secret_vault.rs
@@ -1,114 +1,85 @@
-use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{PublicKey, Secret, SecretAttributes, SecretKey, SecretVault};
+
+use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 
 impl SecretVault for VaultSync {
     fn secret_generate(&mut self, attributes: SecretAttributes) -> Result<Secret> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::SecretGenerate { attributes })
-                .await?;
+        let resp = self.call(VaultRequestMessage::SecretGenerate { attributes })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::SecretGenerate(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::SecretGenerate(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn secret_import(&mut self, secret: &[u8], attributes: SecretAttributes) -> Result<Secret> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::SecretImport {
-                secret: secret.into(),
-                attributes,
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::SecretImport {
+            secret: secret.into(),
+            attributes,
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::SecretImport(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::SecretImport(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn secret_export(&mut self, context: &Secret) -> Result<SecretKey> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::SecretExport {
-                context: context.clone(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::SecretExport {
+            context: context.clone(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::SecretExport(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::SecretExport(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn secret_attributes_get(&mut self, context: &Secret) -> Result<SecretAttributes> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::SecretAttributesGet {
-                context: context.clone(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::SecretAttributesGet {
+            context: context.clone(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::SecretAttributesGet(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::SecretAttributesGet(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn secret_public_key_get(&mut self, context: &Secret) -> Result<PublicKey> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::SecretPublicKeyGet {
-                context: context.clone(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::SecretPublicKeyGet {
+            context: context.clone(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::SecretPublicKeyGet(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::SecretPublicKeyGet(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn secret_destroy(&mut self, context: Secret) -> Result<()> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::SecretDestroy {
-                context: context.clone(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::SecretDestroy {
+            context: context.clone(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::SecretDestroy = resp {
-                Ok(())
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::SecretDestroy = resp {
+            Ok(())
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use ockam_vault::SoftwareVault;
+
     use ockam_vault_test_attribute::*;
 
     fn new_vault() -> SoftwareVault {

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/signer.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/signer.rs
@@ -1,31 +1,27 @@
-use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{Secret, Signature, Signer};
+
+use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 
 impl Signer for VaultSync {
     fn sign(&mut self, secret_key: &Secret, data: &[u8]) -> Result<Signature> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::Sign {
-                secret_key: secret_key.clone(),
-                data: data.into(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::Sign {
+            secret_key: secret_key.clone(),
+            data: data.into(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::Sign(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::Sign(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use ockam_vault::SoftwareVault;
+
     use ockam_vault_test_attribute::*;
 
     fn new_vault() -> SoftwareVault {

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/symmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/symmetric_vault.rs
@@ -1,6 +1,5 @@
 use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{Buffer, Secret, SymmetricVault};
 
 impl SymmetricVault for VaultSync {
@@ -11,23 +10,18 @@ impl SymmetricVault for VaultSync {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Buffer<u8>> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::AeadAesGcmEncrypt {
-                context: context.clone(),
-                plaintext: plaintext.into(),
-                nonce: nonce.into(),
-                aad: aad.into(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::AeadAesGcmEncrypt {
+            context: context.clone(),
+            plaintext: plaintext.into(),
+            nonce: nonce.into(),
+            aad: aad.into(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::AeadAesGcmEncrypt(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::AeadAesGcmEncrypt(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 
     fn aead_aes_gcm_decrypt(
@@ -37,23 +31,18 @@ impl SymmetricVault for VaultSync {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Buffer<u8>> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::AeadAesGcmDecrypt {
-                context: context.clone(),
-                cipher_text: cipher_text.into(),
-                nonce: nonce.into(),
-                aad: aad.into(),
-            })
-            .await?;
+        let resp = self.call(VaultRequestMessage::AeadAesGcmDecrypt {
+            context: context.clone(),
+            cipher_text: cipher_text.into(),
+            nonce: nonce.into(),
+            aad: aad.into(),
+        })?;
 
-            let resp = self.receive_message().await?;
-
-            if let VaultResponseMessage::AeadAesGcmDecrypt(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
+        if let VaultResponseMessage::AeadAesGcmDecrypt(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/verifier.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/verifier.rs
@@ -1,6 +1,5 @@
 use crate::{VaultRequestMessage, VaultResponseMessage, VaultSync, VaultSyncCoreError};
 use ockam_core::Result;
-use ockam_node::block_future;
 use ockam_vault_core::{PublicKey, Signature, Verifier};
 
 impl Verifier for VaultSync {
@@ -10,21 +9,17 @@ impl Verifier for VaultSync {
         public_key: &PublicKey,
         data: &[u8],
     ) -> Result<bool> {
-        block_future(&self.ctx.runtime(), async move {
-            self.send_message(VaultRequestMessage::Verify {
+        let resp = self.call(VaultRequestMessage::Verify {
                 signature: signature.clone(),
                 public_key: public_key.clone(),
                 data: data.into(),
-            })
-            .await?;
+            })?;
 
-            let resp = self.receive_message().await?;
+        if let VaultResponseMessage::Verify(s) = resp {
+            Ok(s)
+        } else {
+            Err(VaultSyncCoreError::InvalidResponseType.into())
+        }
 
-            if let VaultResponseMessage::Verify(s) = resp {
-                Ok(s)
-            } else {
-                Err(VaultSyncCoreError::InvalidResponseType.into())
-            }
-        })
     }
 }

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/verifier.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/vault_sync/verifier.rs
@@ -10,16 +10,15 @@ impl Verifier for VaultSync {
         data: &[u8],
     ) -> Result<bool> {
         let resp = self.call(VaultRequestMessage::Verify {
-                signature: signature.clone(),
-                public_key: public_key.clone(),
-                data: data.into(),
-            })?;
+            signature: signature.clone(),
+            public_key: public_key.clone(),
+            data: data.into(),
+        })?;
 
         if let VaultResponseMessage::Verify(s) = resp {
             Ok(s)
         } else {
             Err(VaultSyncCoreError::InvalidResponseType.into())
         }
-
     }
 }


### PR DESCRIPTION
This PR is for issue  #1848

`Handle` component moved into `ockam_node::handle`  in an addition `ockam_vault_sync_core::VaultSync` 
has been converted to use the `Handle` component.

These two parts are separate branches on my fork so if it's preferable I can opt to make two PR. 

@SanjoDeundiak if you can verify that this is to spec and that the way I converted `VaultSync` is suitable