### PR TITLE
Updated ockam_core::Result alias to allow generic error type

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_core/src/error.rs
@@ -31,7 +31,7 @@ pub struct Error {
 }
 
 /// The type returned by Ockam functions.
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// Produces Ok(false), which reads confusingly in auth code.
 pub fn deny() -> Result<bool> {


### PR DESCRIPTION
<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
Fixes #1925
Enable generic error kind after importing ```ockam_core::Result ```