### PR TITLE
impl core::str::FromStr for Address

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -78,7 +78,46 @@ pub struct Address {
     pub tt: u8,
     inner: Vec<u8>,
 }
+/// An error which is returned when address parsing from string fails
+#[derive(Debug)]
+pub struct AddressParseError {
+    kind: AddressParseErrorKind,
+}
+/// Enum to store the cause of address parsing failure
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddressParseErrorKind {
+    /// Unable to parse address num in the address string
+    InvalidAddr(std::num::ParseIntError),
+    /// Address string has more than one '#' separator
+    MultipleSep,
+}
 
+impl AddressParseError {
+    /// Create new instance
+    pub fn new(kind: AddressParseErrorKind) -> Self {
+        Self { kind }
+    }
+    /// Gets the cause of address parsing failure.
+    pub fn kind(&self) -> &AddressParseErrorKind {
+        &self.kind
+    }
+}
+impl Display for AddressParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            AddressParseErrorKind::InvalidAddr(e) => {
+                write!(f, "Failed to parse address type: '{}'", e)
+            }
+            AddressParseErrorKind::MultipleSep => {
+                write!(
+                    f,
+                    "Invalid address string: more than one '#' separator found"
+                )
+            }
+        }
+    }
+}
+impl std::error::Error for AddressParseError {}
 impl Address {
     /// Create a new address from separate type and data parts
     pub fn new<S: Into<String>>(tt: u8, inner: S) -> Self {
@@ -92,38 +131,52 @@ impl Address {
     ///
     /// See type documentation for more detail
     pub fn from_string<S: Into<String>>(s: S) -> Self {
-        let buf: String = s.into();
-        let mut vec: Vec<_> = buf.split('#').collect();
-
-        // If after the split we only have one element, there was no
-        // `#` separator, so the type needs to be implicitly `= 0`
-        let (tt, inner) = if vec.len() == 1 {
-            (0, vec.remove(0).as_bytes().to_vec())
+        match s.into().parse::<Address>() {
+            Ok(a) => a,
+            Err(e) => {
+                panic!("Invalid address string {}", e)
+            }
         }
-        // If after the split we have 2 elements, we extract the type
-        // value from the string, and use the rest as the address
-        else if vec.len() == 2 {
-            let tt = match str::parse(vec.remove(0)) {
-                Ok(tt) => tt,
-                Err(e) => {
-                    panic!("Failed to parse address type: '{}'", e);
-                }
-            };
-
-            (tt, vec.remove(0).as_bytes().to_vec())
-        } else {
-            panic!("Invalid address string: more than one `#` separator found");
-        };
-
-        Self { tt, inner }
     }
-
     /// Generate a random address with a specific type
     pub fn random(tt: u8) -> Self {
         Self { tt, ..random() }
     }
 }
+impl core::str::FromStr for Address {
+    type Err = AddressParseError;
+    /// Parse an address from a string
+    ///
+    /// See type documentation for more detail
+    fn from_str(s: &str) -> Result<Address, Self::Err> {
+        let buf: String = s.into();
+        let mut vec: Vec<_> = buf.split('#').collect();
 
+        // If after the split we only have one element, there was no
+        // `#` separator, so the type needs to be implicitly `= 0`
+        if vec.len() == 1 {
+            Ok(Address {
+                tt: 0,
+                inner: vec.remove(0).as_bytes().to_vec(),
+            })
+        }
+        // If after the split we have 2 elements, we extract the type
+        // value from the string, and use the rest as the address
+        else if vec.len() == 2 {
+            match str::parse(vec.remove(0)) {
+                Ok(tt) => Ok(Address {
+                    tt,
+                    inner: vec.remove(0).as_bytes().to_vec(),
+                }),
+                Err(e) => Err(AddressParseError::new(AddressParseErrorKind::InvalidAddr(
+                    e,
+                ))),
+            }
+        } else {
+            Err(AddressParseError::new(AddressParseErrorKind::MultipleSep))
+        }
+    }
+}
 impl Display for Address {
     fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
         let inner: &'a str = from_utf8(self.inner.as_slice()).unwrap_or("Invalid UTF-8");


### PR DESCRIPTION
<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->
Fixes #1926
1. Moved parsing logic from ```Address::from_string``` to ```impl core::str::FromStr for Address```.
2. Created an error type ```AddressParseError``` which is returned from ```core::str::FromStr::from_str``` impl for Address when parsing fails.
3. Modified ```Address::from_string``` to use the above change.