### PR TITLE
[WIP] ci: run action when workflow files are updated

### DIFF
--- a/tools/gradle/plugins/commands/src/main/groovy/network/ockam/gradle/commands/CommandsPlugin.groovy
+++ b/tools/gradle/plugins/commands/src/main/groovy/network/ockam/gradle/commands/CommandsPlugin.groovy
@@ -86,18 +86,21 @@ class CommandsPlugin implements Plugin<Project> {
           def p = Paths.get(Paths.get(projectDirPath, dirPath.toString()).toFile().getCanonicalPath())
           paths << Paths.get(rootDirPath.relativize(p).toString(), '**')
 
-          def templateEngine = new groovy.text.SimpleTemplateEngine()
-          def templateFile = Paths.get(rootDirPath.toString(), '.github', 'workflow_template.yml').toFile()
+          def workflowFileName = "${project.name}_${dirTaskName}.yml"
+          def workflowFile = Paths.get(rootDirPath.toString(), '.github', 'workflows', workflowFileName).toFile()
+          paths << rootDirPath.relativize(Paths.get(workflowFile.getCanonicalPath()))
+
           def data = [
             "name": "${project.name}_${dirTaskName.replaceAll('\\.\\.', '')}",
             "wd": "implementations/${project.name}",
             "command": "../../gradlew ${dirTaskName}",
             "paths": paths
           ]
+
+          def templateEngine = new groovy.text.SimpleTemplateEngine()
+          def templateFile = Paths.get(rootDirPath.toString(), '.github', 'workflow_template.yml').toFile()
           def rendered = templateEngine.createTemplate(templateFile.text).make(data).toString()
 
-          def workflowFileName = "${project.name}_${dirTaskName}.yml"
-          def workflowFile = Paths.get(rootDirPath.toString(), '.github', 'workflows', workflowFileName).toFile()
           // def workflowCheckTaskName = "check_workflow_exists_for_${dirTaskName}"
           def workflowGenerateTaskName = "generate_workflow_for_${dirTaskName}"
 


### PR DESCRIPTION
As discussed #1975, I believe that these are the changes needed to add the workflow file itself to the paths to watch for. 

However I'm not sure how I should update the workflow files. I tried `./gradlew :rust:delete_workflows && ./gradlew :rust:generate_workflows`, however it generated many workflow files that weren't tracked. Even in the tracked workflow files there are some unexpected changes, most notably the `Generate random key` and `Cache Gradle` steps are lost and I'm not sure how they were added in the first place.
