### PR TITLE
feat(elixir): resend pipe prototype for reliable delivery

### DIFF
--- a/implementations/elixir/build.gradle
+++ b/implementations/elixir/build.gradle
@@ -44,6 +44,7 @@ commands {
       'mix local.hex --force --if-missing',
       'mix local.rebar --force',
       'mix deps.get',
+      'mix dialyzer.clean',
       'mix dialyzer'
     ],
     veryClean: [

--- a/implementations/elixir/ockam/ockam/config/config.exs
+++ b/implementations/elixir/ockam/ockam/config/config.exs
@@ -3,4 +3,6 @@
 
 import Config
 
+config :logger, :console, metadata: [:module, :line, :pid]
+
 import_config "#{Mix.env()}.exs"

--- a/implementations/elixir/ockam/ockam/lib/ockam/asymmetric_worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/asymmetric_worker.ex
@@ -13,6 +13,7 @@ defmodule Ockam.AsymmetricWorker do
   `inner_setup/2` - same as `Ockam.Worker.setup/2`, but `state` would have already registered `inner_address`
   `handle_inner_message/2` - handle message received on `inner_address`
   `handle_outer_message/2` - handle message received on `address`
+  `handle_other_message/2` - handle message received on a different address, other than `inner_address` or `address`
   """
 
   @callback inner_setup(Keyword.t(), map()) :: {:ok, state :: map()} | {:error, reason :: any()}
@@ -26,19 +27,32 @@ defmodule Ockam.AsymmetricWorker do
               | {:error, reason :: any()}
               | {:stop, reason :: any(), state :: map()}
 
+  @callback handle_other_message(message :: any(), state :: map()) ::
+              {:ok, state :: map()}
+              | {:error, reason :: any()}
+              | {:stop, reason :: any(), state :: map()}
+
+  ## TODO: remove that after refactoring Ockam.Worker to not call handle_message for non-messages
+  @callback handle_non_message(message :: any(), state :: map()) ::
+              {:ok, state :: map()}
+              | {:error, reason :: any()}
+              | {:stop, reason :: any(), state :: map()}
+
   defmacro __using__(_options) do
     quote do
       use Ockam.Worker
 
       alias Ockam.Message
 
+      require Logger
+
       @behaviour Ockam.AsymmetricWorker
 
       @impl true
       def setup(options, state) do
-        state = register_inner_address(state)
-
-        inner_setup(options, state)
+        with {:ok, inner_address} <- register_inner_address(options) do
+          inner_setup(options, Map.put(state, :inner_address, inner_address))
+        end
       end
 
       @impl true
@@ -49,17 +63,31 @@ defmodule Ockam.AsymmetricWorker do
 
           :outer ->
             handle_outer_message(message, state)
+
+          :other ->
+            handle_other_message(message, state)
+
+          :non_message ->
+            handle_non_message(message, state)
         end
       end
 
       @doc false
-      def register_inner_address(state) do
-        {:ok, inner_address} = Ockam.Node.register_random_address()
-        Map.put(state, :inner_address, inner_address)
+      def register_inner_address(options) do
+        case Keyword.get(options, :inner_address) do
+          nil ->
+            Ockam.Node.register_random_address()
+
+          inner_address ->
+            case Ockam.Node.register_address(inner_address) do
+              :yes -> {:ok, inner_address}
+              :no -> {:error, :inner_address_already_taken}
+            end
+        end
       end
 
       @doc false
-      def message_type(message, state) do
+      def message_type(%{onward_route: _} = message, state) do
         [me | _] = Message.onward_route(message)
         outer_address = state.address
         inner_address = state.inner_address
@@ -70,12 +98,27 @@ defmodule Ockam.AsymmetricWorker do
 
           ^inner_address ->
             :inner
+
+          _other ->
+            :other
         end
+      end
+
+      def message_type(_message, _state) do
+        :non_message
       end
 
       def inner_setup(options, state), do: {:ok, state}
 
-      defoverridable inner_setup: 2
+      def handle_other_message(message, state) do
+        {:error, {:unknown_self_address, message, state}}
+      end
+
+      def handle_non_message(non_message, state) do
+        {:error, {:not_ockam_message, non_message, state}}
+      end
+
+      defoverridable inner_setup: 2, handle_other_message: 2, handle_non_message: 2
     end
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/delivery.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/delivery.ex
@@ -1,0 +1,87 @@
+defmodule Ockam.Examples.Delivery do
+  @moduledoc """
+  Examples of using delivery pipe
+
+  Creates a filter worker to lose messages
+  Sends messages through filter and through filter wrapped in a delivery pipe
+
+  Returns a sequence of messages received with unreliable delivety (through filter)
+  and reliable delivery (through pipe)
+  """
+
+  alias Ockam.Examples.Messaging.Filter
+
+  def run() do
+    pipe_mod = Ockam.Messaging.Delivery.ResendPipe
+
+    {:ok, filter} = Filter.create([])
+    {:ok, receiver} = pipe_mod.receiver().create([])
+    ## Local delivery is fast, set lower confirm timeout
+    {:ok, sender} =
+      pipe_mod.sender().create(receiver_route: [filter, receiver], confirm_timeout: 200)
+
+    {:ok, me} = Ockam.Node.register_random_address()
+
+    ## Seng 100 messages to self through filter
+
+    Enum.each(1..100, fn n ->
+      Ockam.Router.route(%{
+        onward_route: [filter, me],
+        return_route: [me],
+        payload: "unreliable #{n}"
+      })
+    end)
+
+    unreliable =
+      1..100
+      |> Enum.map(fn n ->
+        expected_payload = "unreliable #{n}"
+
+        receive do
+          %{onward_route: [^me], payload: ^expected_payload} ->
+            expected_payload
+        after
+          200 ->
+            nil
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+
+    ## Send 100 messages to self through reliable pipe
+
+    Enum.each(1..100, fn n ->
+      Ockam.Router.route(%{
+        onward_route: [sender, me],
+        return_route: [me],
+        payload: "reliable #{n}"
+      })
+    end)
+
+    ## Wait for message #100
+
+    expected_100 = "reliable 100"
+
+    receive do
+      %{onward_route: [^me], payload: ^expected_100} ->
+        :ok
+        ## Fail in 10 minutes
+    after
+      600_000 ->
+        raise "Message #100 was not received in 10 minutes"
+    end
+
+    reliable = receive_all()
+
+    %{unreliable: unreliable, reliable: reliable}
+  end
+
+  def receive_all(msgs \\ []) do
+    receive do
+      %{payload: pl} ->
+        receive_all(msgs ++ [pl])
+    after
+      0 ->
+        msgs
+    end
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/filter.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/filter.ex
@@ -1,0 +1,31 @@
+defmodule Ockam.Examples.Messaging.Filter do
+  @moduledoc """
+  Filter worker
+
+  Randomly drops 5% of messages, forwards the rest to onward_route
+  Adds itself to return_route
+  """
+
+  use Ockam.Worker
+
+  alias Ockam.Message
+
+  @impl true
+  def handle_message(message, state) do
+    if :rand.uniform(100) > 5 do
+      forward_message(message)
+    end
+
+    {:ok, state}
+  end
+
+  def forward_message(message) do
+    [me | onward_route] = Message.onward_route(message)
+
+    Ockam.Router.route(%{
+      onward_route: onward_route,
+      return_route: [me | Message.return_route(message)],
+      payload: Message.payload(message)
+    })
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/reliable_deduplication.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/reliable_deduplication.ex
@@ -1,0 +1,166 @@
+defmodule Ockam.Examples.Messaging.ReliableDeduplication do
+  @moduledoc """
+  Example of combining reliable delivery with index-ordering deduplication.
+
+  Such combination allows to get low message loss with high uniqness of messages
+  as long as pipes and channels are available and have no errors
+  """
+
+  alias Ockam.Examples.Messaging.Filter
+  alias Ockam.Examples.Messaging.Shuffle
+
+  alias Ockam.Examples.Ping
+  alias Ockam.Examples.Pong
+
+  alias Ockam.Messaging.Delivery.ResendPipe
+  alias Ockam.Messaging.Ordering.Strict.IndexPipe
+
+  alias Ockam.Messaging.PipeChannel
+
+  alias Ockam.PubSubSubscriber
+
+  alias Ockam.Transport.TCP.RecoverableClient
+
+  ## Local examole
+  ## Create filter and shuffle forwarders
+  ## Run reliable delivery channel over filter and shuffle
+  ## Wrap reliable channel into index ordering channel to deduplicate messages
+  ## Send ping-pong through this combined channel
+  def local() do
+    ## Intermediate
+    {:ok, filter} = Filter.create(address: "filter")
+    {:ok, shuffle} = Shuffle.create(address: "shuffle")
+
+    Ockam.Node.register_address("me")
+
+    ## Pong
+    {:ok, resend_spawner} =
+      PipeChannel.Spawner.create(
+        responder_options: [pipe_mod: ResendPipe, sender_options: [confirm_timeout: 200]]
+      )
+
+    {:ok, ord_spawner} = PipeChannel.Spawner.create(responder_options: [pipe_mod: IndexPipe])
+    {:ok, "pong"} = Pong.create(address: "pong", delay: 500)
+
+    ## Create resend channel through filter and shuffle
+    {:ok, "ping"} = Ping.create(address: "ping", delay: 500)
+
+    {:ok, resend_channel} =
+      PipeChannel.Initiator.create(
+        pipe_mod: ResendPipe,
+        spawner_route: [filter, shuffle, resend_spawner],
+        sender_options: [confirm_timeout: 200]
+      )
+
+    {:ok, _ord_channel} =
+      PipeChannel.Initiator.create(
+        pipe_mod: IndexPipe,
+        spawner_route: [resend_channel, ord_spawner]
+      )
+  end
+
+  def run_local() do
+    {:ok, channel} = local()
+    start_ping_pong(channel)
+  end
+
+  def hub_responder() do
+    Ockam.Transport.TCP.start()
+
+    Ockam.Node.register_address("me")
+
+    {:ok, "pong"} = Pong.create(address: "pong", delay: 500)
+
+    {:ok, client} = RecoverableClient.create(destination: {"localhost", 4000})
+
+    {:ok, _subscription} =
+      PubSubSubscriber.create(
+        pub_sub_route: [client, "pub_sub_service"],
+        name: "responder",
+        topic: "responder"
+      )
+
+    {:ok, "resend_receiver"} = ResendPipe.receiver().create(address: "resend_receiver")
+
+    {:ok, "resend_sender"} =
+      ResendPipe.sender().create(
+        address: "resend_sender",
+        confirm_timeout: 200,
+        receiver_route: [client, "pub_sub_t_initiator", "resend_receiver"]
+      )
+
+    {:ok, "resend_channel"} =
+      PipeChannel.Simple.create(
+        address: "resend_channel",
+        inner_address: "resend_channel_inner",
+        sender: "resend_sender",
+        channel_route: ["resend_channel_inner"]
+      )
+
+    {:ok, "ord_spawner"} =
+      PipeChannel.Spawner.create(
+        address: "ord_spawner",
+        responder_options: [pipe_mod: IndexPipe]
+      )
+  end
+
+  def hub_initiator() do
+    {:ok, "ping"} = Ping.create(address: "ping", delay: 500)
+
+    {:ok, client} = RecoverableClient.create(destination: {"localhost", 4000})
+
+    {:ok, _subscription} =
+      PubSubSubscriber.create(
+        pub_sub_route: [client, "pub_sub_service"],
+        name: "initiator",
+        topic: "initiator"
+      )
+
+    {:ok, "resend_receiver"} = ResendPipe.receiver().create(address: "resend_receiver")
+
+    {:ok, "resend_sender"} =
+      ResendPipe.sender().create(
+        address: "resend_sender",
+        confirm_timeout: 200,
+        receiver_route: [client, "pub_sub_t_responder", "resend_receiver"]
+      )
+
+    {:ok, "resend_channel"} =
+      PipeChannel.Simple.create(
+        address: "resend_channel",
+        inner_address: "resend_channel_inner",
+        sender: "resend_sender",
+        channel_route: ["resend_channel_inner"]
+      )
+
+    {:ok, _ord_channel} =
+      PipeChannel.Initiator.create(
+        pipe_mod: IndexPipe,
+        spawner_route: ["resend_channel", "ord_spawner"]
+      )
+  end
+
+  def run_hub_initiator() do
+    {:ok, channel} = hub_initiator()
+    start_ping_pong(channel)
+  end
+
+  def send_messages(route, n_messages \\ 20) do
+    Enum.each(1..n_messages, fn n ->
+      Ockam.Router.route(%{
+        onward_route: route ++ ["me"],
+        return_route: ["me"],
+        payload: "Msg #{n}"
+      })
+    end)
+  end
+
+  def start_ping_pong(channel) do
+    ## Start ping-pong
+    Ockam.Router.route(%{
+      onward_route: [channel, "pong"],
+      return_route: ["ping"],
+      payload: "0"
+    })
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/shuffle.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/shuffle.ex
@@ -21,7 +21,6 @@ defmodule Ockam.Examples.Messaging.Shuffle do
 
   def forward_message(message, _state) do
     :timer.sleep(10)
-    Logger.info("Forward #{inspect(message)}")
     [_me | onward_route] = Message.onward_route(message)
 
     Ockam.Router.route(%{

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
@@ -88,7 +88,7 @@ defmodule Ockam.Examples.Stream.BiDirectional.SecureChannel do
     ## Create ordered channel spawner
     {:ok, "ord_channel_spawner"} =
       PipeChannel.Spawner.create(
-        responder_options: [pipe_mods: IndexPipe],
+        responder_options: [pipe_mod: IndexPipe],
         address: "ord_channel_spawner"
       )
 
@@ -115,7 +115,7 @@ defmodule Ockam.Examples.Stream.BiDirectional.SecureChannel do
     ## Strictly ordered channel would de-duplicate messages
     {:ok, ord_channel} =
       PipeChannel.Initiator.create(
-        pipe_mods: IndexPipe,
+        pipe_mod: IndexPipe,
         spawner_route: [publisher, "ord_channel_spawner"]
       )
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/receiver.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/receiver.ex
@@ -1,0 +1,46 @@
+defmodule Ockam.Messaging.ConfirmPipe.Receiver do
+  @moduledoc """
+  Receiver part of the confirm pipes.
+
+  Receives wrapped messages with confirm refs
+  Unwraps and forwards messages
+  Sends confirm messages with confirm ref to the message sender
+  """
+  use Ockam.Worker
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  alias Ockam.Messaging.ConfirmPipe.Wrapper
+
+  require Logger
+
+  @impl true
+  def handle_message(message, state) do
+    return_route = Message.return_route(message)
+    wrapped_message = Message.payload(message)
+
+    case Wrapper.unwrap_message(wrapped_message) do
+      {:ok, ref, message} ->
+        Router.route(message)
+        send_confirm(ref, return_route, state)
+        {:ok, state}
+
+      {:error, err} ->
+        Logger.error("Error unwrapping message: #{inspect(err)}")
+        {:error, err}
+    end
+  end
+
+  def send_confirm(ref, return_route, state) do
+    Router.route(%{
+      onward_route: return_route,
+      return_route: [state.address],
+      payload: ref_payload(ref)
+    })
+  end
+
+  def ref_payload(ref) do
+    :bare.encode(ref, :uint)
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/wrapper.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/wrapper.ex
@@ -1,0 +1,34 @@
+defmodule Ockam.Messaging.ConfirmPipe.Wrapper do
+  @moduledoc """
+  Resend pipe message wrapper.
+
+  Wraps message with a send reference (integer)
+  """
+
+  ## Message is encoded with ockam wire protocol
+  ## and combined with the ref using the following BARE schema
+  @bare_schema {:struct, [ref: :uint, data: :data]}
+
+  def wrap_message(message, ref) do
+    case Ockam.Wire.encode(message) do
+      {:ok, encoded_message} ->
+        {:ok, :bare.encode(%{ref: ref, data: encoded_message}, @bare_schema)}
+
+      error ->
+        error
+    end
+  end
+
+  def unwrap_message(wrapped) do
+    with {:ok, %{ref: ref, data: encoded_message}, ""} <- :bare.decode(wrapped, @bare_schema),
+         {:ok, message} <- Ockam.Wire.decode(encoded_message) do
+      {:ok, ref, message}
+    else
+      {:ok, _decoded, _rest} = bare_result ->
+        {:error, {:bare_decode_error, wrapped, bare_result}}
+
+      {:error, err} ->
+        {:error, err}
+    end
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/delivery/resend_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/delivery/resend_pipe.ex
@@ -1,0 +1,197 @@
+defmodule Ockam.Messaging.Delivery.ResendPipe do
+  @moduledoc """
+  Reliable delivery pipe in which a sender will resend
+  the message if it was not confirmed by the receiver
+  """
+
+  @behaviour Ockam.Messaging.Pipe
+
+  @impl true
+  def sender() do
+    __MODULE__.Sender
+  end
+
+  @impl true
+  def receiver() do
+    Ockam.Messaging.ConfirmPipe.Receiver
+  end
+end
+
+defmodule Ockam.Messaging.Delivery.ResendPipe.Sender do
+  @moduledoc """
+  Resend pipe sender
+
+  Forwards messages to receiver with a send ref and waits for each message
+  to be conformed before sending a next one.
+  If a message is not confirmed within confirm_timeout - it's resent with a new ref.
+
+  Options:
+
+  `receiver_route` - a route to receiver
+  `confirm_timeout` - time to wait for confirm, default is 5_000
+  """
+  use Ockam.AsymmetricWorker
+
+  alias Ockam.Messaging.ConfirmPipe.Wrapper
+
+  require Logger
+
+  @default_confirm_timeout 5_000
+
+  @impl true
+  def inner_setup(options, state) do
+    receiver_route = Keyword.get(options, :receiver_route)
+    confirm_timeout = Keyword.get(options, :confirm_timeout, @default_confirm_timeout)
+
+    {:ok,
+     Map.merge(state, %{
+       receiver_route: receiver_route,
+       queue: [],
+       confirm_timer: nil,
+       confirm_timeout: confirm_timeout
+     })}
+  end
+
+  ## TODO: batch send
+  @impl true
+  def handle_outer_message(message, state) do
+    case waiting_confirm?(state) do
+      true -> enqueue_message(message, state)
+      false -> forward_to_receiver(message, state)
+    end
+  end
+
+  @impl true
+  def handle_inner_message(message, state) do
+    case is_valid_confirm?(message, state) do
+      true ->
+        confirm(state)
+
+      false ->
+        ## Ignore unknown confirms
+        {:ok, state}
+    end
+  end
+
+  @impl true
+  def handle_non_message(:confirm_timeout, state) do
+    resend_unconfirmed(state)
+  end
+
+  def resend_unconfirmed(state) do
+    ## TODO: do we want to resend with an old ref instead?
+    case Map.get(state, :unconfirmed) do
+      nil ->
+        {:stop, :cannot_resend_unconfirmed, state}
+
+      message ->
+        clear_confirm_timeout(state)
+        forward_to_receiver(message, state)
+    end
+  end
+
+  def forward_to_receiver(message, state) do
+    forwarded_message = make_forwarded_message(message)
+
+    {ref, state} = bump_send_ref(state)
+    {:ok, wrapped_message} = Wrapper.wrap_message(forwarded_message, ref)
+
+    receiver_route = Map.get(state, :receiver_route)
+
+    Ockam.Router.route(%{
+      onward_route: receiver_route,
+      return_route: [state.inner_address],
+      payload: wrapped_message
+    })
+
+    {:ok, set_confirm_timeout(message, state)}
+  end
+
+  def bump_send_ref(state) do
+    ref = Map.get(state, :send_ref, 0) + 1
+    {ref, Map.put(state, :send_ref, ref)}
+  end
+
+  def make_forwarded_message(message) do
+    [_me | onward_route] = Message.onward_route(message)
+
+    %{
+      onward_route: onward_route,
+      return_route: Message.return_route(message),
+      payload: Message.payload(message)
+    }
+  end
+
+  def set_confirm_timeout(message, state) do
+    timeout = Map.get(state, :confirm_timeout)
+    timer_ref = Process.send_after(self(), :confirm_timeout, timeout)
+
+    state
+    |> Map.put(:confirm_timer, timer_ref)
+    |> Map.put(:unconfirmed, message)
+  end
+
+  def clear_confirm_timeout(state) do
+    case Map.get(state, :confirm_timer) do
+      nil ->
+        state
+
+      ref ->
+        Process.cancel_timer(ref)
+        ## Flush the timeout message if it's already received
+        receive do
+          :confirm_timeout -> :ok
+        after
+          0 -> :ok
+        end
+
+        state
+        |> Map.put(:confirm_timer, nil)
+        |> Map.put(:unconfirmed, nil)
+    end
+  end
+
+  def waiting_confirm?(state) do
+    ## TODO: should we use confirm_timer or unconfirmed?
+    case Map.get(state, :confirm_timer, nil) do
+      nil -> false
+      _timer -> true
+    end
+  end
+
+  def is_valid_confirm?(message, state) do
+    payload = Message.payload(message)
+    {:ok, ref, ""} = :bare.decode(payload, :uint)
+
+    case Map.get(state, :send_ref) do
+      current_ref when current_ref == ref ->
+        true
+
+      other_ref ->
+        Logger.warn(
+          "Received confirm for ref #{inspect(ref)}, current ref is #{inspect(other_ref)}"
+        )
+
+        false
+    end
+  end
+
+  def enqueue_message(message, state) do
+    queue = Map.get(state, :queue, [])
+    {:ok, Map.put(state, :queue, queue ++ [message])}
+  end
+
+  def confirm(state) do
+    queue = Map.get(state, :queue, [])
+
+    state = clear_confirm_timeout(state)
+
+    case queue do
+      [message | rest] ->
+        forward_to_receiver(message, Map.put(state, :queue, rest))
+
+      [] ->
+        {:ok, state}
+    end
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/sender.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/sender.ex
@@ -1,6 +1,6 @@
-defmodule Ockam.Messaging.Ordering.IndexPipe.Sender do
+defmodule Ockam.Messaging.IndexPipe.Sender do
   @moduledoc """
-  Sender side of ordered pipe using indexing to enforce ordering
+  Sender side of indexed pipe
   Each incoming message is assigned an monotonic index, wrapped and sent to receiver
 
   Options:
@@ -12,7 +12,7 @@ defmodule Ockam.Messaging.Ordering.IndexPipe.Sender do
 
   alias Ockam.Message
 
-  alias Ockam.Messaging.Ordering.IndexPipe.Wrapper
+  alias Ockam.Messaging.IndexPipe.Wrapper
 
   @impl true
   def setup(options, state) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/wrapper.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/wrapper.ex
@@ -1,8 +1,10 @@
-defmodule Ockam.Messaging.Ordering.IndexPipe.Wrapper do
+defmodule Ockam.Messaging.IndexPipe.Wrapper do
   @moduledoc """
   Message wrapper for indexed pipes
   """
 
+  ## Message is encoded with ockam wire protocol
+  ## and combined with the index using the following BARE schema
   @schema {:struct, [index: :uint, message: :data]}
 
   @doc """
@@ -23,6 +25,12 @@ defmodule Ockam.Messaging.Ordering.IndexPipe.Wrapper do
            :bare.decode(payload, @schema),
          {:ok, message} <- Ockam.Wire.decode(Ockam.Wire.Binary.V2, encoded_message) do
       {:ok, index, message}
+    else
+      {:ok, _decoded, _rest} = bare_result ->
+        {:error, {:bare_decode_error, payload, bare_result}}
+
+      {:error, err} ->
+        {:error, err}
     end
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/monotonic/index_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/monotonic/index_pipe.ex
@@ -9,7 +9,7 @@ defmodule Ockam.Messaging.Ordering.Monotonic.IndexPipe do
 
   @doc "Get sender module"
   def sender() do
-    Ockam.Messaging.Ordering.IndexPipe.Sender
+    Ockam.Messaging.IndexPipe.Sender
   end
 
   @doc "Get receiver module"
@@ -30,7 +30,7 @@ defmodule Ockam.Messaging.Ordering.Monotonic.IndexPipe.Receiver do
   """
   use Ockam.Worker
 
-  alias Ockam.Messaging.Ordering.IndexPipe.Wrapper
+  alias Ockam.Messaging.IndexPipe.Wrapper
 
   require Logger
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/strict/index_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/strict/index_pipe.ex
@@ -10,7 +10,7 @@ defmodule Ockam.Messaging.Ordering.Strict.IndexPipe do
 
   @doc "Get sender module"
   def sender() do
-    Ockam.Messaging.Ordering.IndexPipe.Sender
+    Ockam.Messaging.IndexPipe.Sender
   end
 
   @doc "Get receiver module"
@@ -36,7 +36,7 @@ defmodule Ockam.Messaging.Ordering.Strict.IndexPipe.Receiver do
   """
   use Ockam.Worker
 
-  alias Ockam.Messaging.Ordering.IndexPipe.Wrapper
+  alias Ockam.Messaging.IndexPipe.Wrapper
 
   require Logger
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/pub_sub_subscriber.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/pub_sub_subscriber.ex
@@ -1,0 +1,79 @@
+defmodule Ockam.PubSubSubscriber do
+  @moduledoc """
+  Worker to maintain Ockam.Hub pub_sub_service subscription
+
+  Refreshes subscription to pub_sup service every interval milliseconds
+
+  Can be used to maintain resilient subscription to a topic
+  even if the connection or pub_sub service restarts
+
+  Options:
+
+  `pub_sub_route` - route to pub_sub service
+  `name` - subscription name
+  `topic` - subscription topic
+  `interval` - interval to refresh subscription, defaults to 10 seconds
+  """
+
+  use Ockam.Worker
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  @impl true
+  def setup(options, state) do
+    pub_sub_route = Keyword.fetch!(options, :pub_sub_route)
+    topic = Keyword.fetch!(options, :topic)
+    name = Keyword.fetch!(options, :name)
+    interval = Keyword.get(options, :interval, 10_000)
+
+    state =
+      Map.merge(state, %{
+        pub_sub_route: pub_sub_route,
+        interval: interval,
+        topic: topic,
+        name: name
+      })
+
+    {:ok, refresh_subscription(state)}
+  end
+
+  @impl true
+  def handle_message(%{payload: _} = message, state) do
+    [_me | onward_route] = Message.onward_route(message)
+
+    case onward_route do
+      [] ->
+        :ok
+
+      route ->
+        Router.route(%{
+          onward_route: route,
+          return_route: Message.return_route(message),
+          payload: Message.payload(message)
+        })
+    end
+
+    {:ok, state}
+  end
+
+  def handle_message(:refresh, state) do
+    {:ok, refresh_subscription(state)}
+  end
+
+  def refresh_subscription(state) do
+    pub_sub_route = Map.fetch!(state, :pub_sub_route)
+    topic = Map.fetch!(state, :topic)
+    name = Map.fetch!(state, :name)
+    interval = Map.fetch!(state, :interval)
+
+    Router.route(%{
+      onward_route: pub_sub_route,
+      return_route: [state.address],
+      payload: :bare.encode(name <> ":" <> topic, :string)
+    })
+
+    Process.send_after(self(), :refresh, interval)
+    state
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/pub_sub_subscriber.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/pub_sub_subscriber.ex
@@ -21,6 +21,9 @@ defmodule Ockam.PubSubSubscriber do
   alias Ockam.Router
 
   @impl true
+  def address_prefix(_options), do: "PS_"
+
+  @impl true
   def setup(options, state) do
     pub_sub_route = Keyword.fetch!(options, :pub_sub_route)
     topic = Keyword.fetch!(options, :topic)

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
@@ -1,0 +1,117 @@
+defmodule Ockam.Transport.TCP.RecoverableClient do
+  @moduledoc """
+  TCP client wrapper to recover connections.
+
+  Creates and monitors Ockam.Transport.TCP.CLient
+  If client stops, it's restarted after `refresh_timeout`
+
+  Options:
+
+  `desination` - {host, port} tuple to connect to
+  `refresh_timeout` - time to wait between client restarts
+  """
+  use Ockam.AsymmetricWorker
+
+  alias Ockam.Transport.TCP.Client
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  require Logger
+
+  @impl true
+  def inner_setup(options, state) do
+    destination = Keyword.fetch!(options, :destination)
+    refresh_timeout = Keyword.get(options, :refresh_timeout, 5_000)
+
+    state = Map.merge(state, %{destination: destination, refresh_timeout: refresh_timeout})
+
+    {:ok, refresh_client(state)}
+  end
+
+  @impl true
+  def handle_inner_message(message, state) do
+    [_me | onward_route] = Message.onward_route(message)
+    [_client | return_route] = Message.return_route(message)
+    payload = Message.payload(message)
+
+    Router.route(%{
+      onward_route: onward_route,
+      return_route: [state.address | return_route],
+      payload: payload
+    })
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_outer_message(message, %{client: client} = state) when client != nil do
+    [_me | onward_route] = Message.onward_route(message)
+
+    Router.route(%{
+      onward_route: [client | onward_route],
+      return_route: [state.inner_address | Message.return_route(message)],
+      payload: Message.payload(message)
+    })
+
+    {:ok, state}
+  end
+
+  ## Ignore messages when client doesn't exist
+  def handle_outer_message(_message, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_non_message(:refresh_client, state) do
+    {:ok, refresh_client(state)}
+  end
+
+  def handle_non_message({:DOWN, ref, :process, _pid, _} = down, %{monitor_ref: ref} = state) do
+    Logger.debug("DOWN for current client: #{inspect(down)} state: #{inspect(state)}")
+    {:ok, schedule_refresh_client(state)}
+  end
+
+  def handle_non_message({:DOWN, _, _, _, _} = down, state) do
+    Logger.debug("DOWN for old client: #{inspect(down)} state: #{inspect(state)}")
+    {:ok, state}
+  end
+
+  def refresh_client(state) do
+    case Map.get(state, :client) do
+      nil ->
+        :ok
+
+      client ->
+        Ockam.Node.stop(client)
+    end
+
+    destination = Map.get(state, :destination)
+
+    case Client.create(destination: destination) do
+      {:ok, client} ->
+        monitor_client(client, state)
+
+      {:error, _reason} ->
+        schedule_refresh_client(state)
+    end
+  end
+
+  def monitor_client(client, state) do
+    case Ockam.Node.whereis(client) do
+      nil ->
+        schedule_refresh_client(state)
+
+      pid ->
+        monitor_ref = Process.monitor(pid)
+        Map.merge(state, %{client: client, monitor_ref: monitor_ref})
+    end
+  end
+
+  def schedule_refresh_client(state) do
+    refresh_timeout = Map.fetch!(state, :refresh_timeout)
+    timer_ref = Process.send_after(self(), :refresh_client, refresh_timeout)
+
+    Map.put(state, :refresh_timer, timer_ref)
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
@@ -20,6 +20,9 @@ defmodule Ockam.Transport.TCP.RecoverableClient do
   require Logger
 
   @impl true
+  def address_prefix(_options), do: "TCP_C_R_"
+
+  @impl true
   def inner_setup(options, state) do
     destination = Keyword.fetch!(options, :destination)
     refresh_timeout = Keyword.get(options, :refresh_timeout, 5_000)

--- a/implementations/elixir/ockam/ockam/test/ockam/helpers/filter.ex
+++ b/implementations/elixir/ockam/ockam/test/ockam/helpers/filter.ex
@@ -1,0 +1,26 @@
+defmodule Ockam.Messaging.Delivery.Tests.Filter do
+  @moduledoc false
+
+  use Ockam.Worker
+
+  alias Ockam.Message
+
+  @impl true
+  def handle_message(message, state) do
+    if :rand.uniform(100) > 5 do
+      forward_message(message)
+    end
+
+    {:ok, state}
+  end
+
+  def forward_message(message) do
+    [me | onward_route] = Message.onward_route(message)
+
+    Ockam.Router.route(%{
+      onward_route: onward_route,
+      return_route: [me | Message.return_route(message)],
+      payload: Message.payload(message)
+    })
+  end
+end

--- a/implementations/elixir/ockam/ockam/test/ockam/messaging/delivery_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/messaging/delivery_test.exs
@@ -1,0 +1,96 @@
+defmodule Ockam.Messaging.Delivery.Tests do
+  use ExUnit.Case, async: true
+
+  alias Ockam.Messaging.Delivery.Tests.Filter
+
+  delivery_pipes = [Ockam.Messaging.Delivery.ResendPipe]
+
+  Enum.each(delivery_pipes, fn pipe ->
+    test "Pipe #{pipe} is delivers all messages" do
+      pipe_mod = unquote(pipe)
+
+      {:ok, me} = Ockam.Node.register_random_address()
+
+      {:ok, filter} = Filter.create([])
+
+      {:ok, re_receiver} = pipe_mod.receiver().create([])
+
+      {:ok, re_sender} =
+        pipe_mod.sender().create(receiver_route: [filter, re_receiver], confirm_timeout: 50)
+
+      Enum.each(1..100, fn n ->
+        Ockam.Router.route(%{
+          onward_route: [re_sender, me],
+          return_route: [me],
+          payload: "HI #{n}!"
+        })
+      end)
+
+      Enum.each(1..100, fn n ->
+        expected_payload = "HI #{n}!"
+
+        receive do
+          %{onward_route: [^me], payload: ^expected_payload} ->
+            :ok
+        after
+          60_000 ->
+            raise "Message not delivered #{n}"
+        end
+      end)
+    end
+  end)
+
+  Enum.each(delivery_pipes, fn pipe ->
+    test "Pipe #{pipe} can be deduplicated with indexed pipe" do
+      pipe_mod = unquote(pipe)
+
+      index_pipe_mod = Ockam.Messaging.Ordering.Strict.IndexPipe
+
+      {:ok, me} = Ockam.Node.register_random_address()
+
+      {:ok, filter} = Filter.create([])
+
+      {:ok, re_receiver} = pipe_mod.receiver().create([])
+
+      {:ok, re_sender} =
+        pipe_mod.sender().create(receiver_route: [filter, re_receiver], confirm_timeout: 50)
+
+      {:ok, ord_receiver} = index_pipe_mod.receiver().create([])
+
+      {:ok, ord_sender} =
+        index_pipe_mod.sender().create(receiver_route: [re_sender, ord_receiver])
+
+      Enum.each(1..100, fn n ->
+        Ockam.Router.route(%{
+          onward_route: [ord_sender, me],
+          return_route: [me],
+          payload: "HI #{n}!"
+        })
+      end)
+
+      Enum.each(1..100, fn n ->
+        expected_payload = "HI #{n}!"
+
+        receive do
+          %{onward_route: [^me], payload: ^expected_payload} ->
+            :ok
+        after
+          60_000 ->
+            raise "Message not delivered #{n}"
+        end
+      end)
+
+      assert [] == collect_rest_msgs(me)
+    end
+  end)
+
+  def collect_rest_msgs(me, msgs \\ [], timeout \\ 5_000) do
+    receive do
+      %{onward_route: [^me], payload: payload} ->
+        collect_rest_msgs(me, [payload | msgs], timeout)
+    after
+      timeout ->
+        msgs
+    end
+  end
+end

--- a/implementations/elixir/ockam/ockam_hub/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/runtime.exs
@@ -189,6 +189,7 @@ config :ockam_hub,
   services: [
     :echo,
     :forwarding,
+    :pub_sub,
     :stream,
     :stream_index,
     :secure_channel

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
@@ -8,8 +8,9 @@ defmodule Ockam.Hub.Service.Provider.Routing do
 
   alias Ockam.Hub.Service.Echo, as: EchoService
   alias Ockam.Hub.Service.Forwarding, as: ForwardingService
+  alias Ockam.Hub.Service.PubSub, as: PubSubService
 
-  @services [:echo, :forwarding]
+  @services [:echo, :forwarding, :pub_sub]
 
   @impl true
   def services() do
@@ -26,6 +27,10 @@ defmodule Ockam.Hub.Service.Provider.Routing do
     ForwardingService.create(Keyword.merge([address: "forwarding_service"], args))
   end
 
+  def start_service(:pub_sub, args) do
+    PubSubService.create(Keyword.merge([address: "pub_sub_service", prefix: "pub_sub_t"], args))
+  end
+
   @impl true
   def child_spec(:echo, args) do
     {EchoService, Keyword.merge([address: "echo_service"], args)}
@@ -33,5 +38,9 @@ defmodule Ockam.Hub.Service.Provider.Routing do
 
   def child_spec(:forwarding, args) do
     {ForwardingService, Keyword.merge([address: "forwarding_service"], args)}
+  end
+
+  def child_spec(:pub_sub, args) do
+    {PubSubService, Keyword.merge([address: "pub_sub_service", prefix: "pub_sub_t"], args)}
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/pub_sub.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/pub_sub.ex
@@ -1,0 +1,119 @@
+defmodule Ockam.Hub.Service.PubSub do
+  @moduledoc """
+  PubSub service
+
+  Subscribes workers (by return route) to a string topic
+
+  Each topic can have multiple subscrtiptions
+  Each subscription has a unique name and topic
+
+  Name and topic are parsed from the payload as a BARE `string` type
+  with the following format "name:topic".
+  Name cannot contain `:` symbol
+
+  New subscriptions with the same name replace previous ones.
+
+  Topic address is created from topic prefix and topic as <prefix>_<topic>
+  e.g. if prefix is `pub_sub_t` and topic is `my_topic`, topic address will be: `pub_sub_t_my_topic`
+
+  Messages sent to the topic address will be forwarded to all subscribers routes
+
+  Options:
+
+  `prefix` - topic address prefix
+  """
+  use Ockam.Worker
+
+  alias __MODULE__.Topic
+  alias Ockam.Message
+
+  require Logger
+
+  @impl true
+  def setup(options, state) do
+    prefix = Keyword.get(options, :prefix, state.address)
+    {:ok, Map.put(state, :prefix, prefix)}
+  end
+
+  @impl true
+  def handle_message(message, state) do
+    payload = Message.payload(message)
+
+    with {:ok, name_topic, ""} <- :bare.decode(payload, :string),
+         [name, topic] <- String.split(name_topic, ":") do
+      return_route = Message.return_route(message)
+      subscribe(name, topic, return_route, state)
+    else
+      err ->
+        Logger.error("Invalid message format: #{inspect(payload)}, reason #{inspect(err)}")
+    end
+  end
+
+  def subscribe(name, topic, route, state) do
+    with {:ok, worker} <- ensure_topic_worker(topic, state) do
+      ## NOTE: Non-ockam message routing here
+      Topic.subscribe(worker, name, route)
+      {:ok, state}
+    end
+  end
+
+  def ensure_topic_worker(topic, state) do
+    topic_address = topic_address(topic, state)
+
+    case Ockam.Node.whereis(topic_address) do
+      nil -> Topic.create(topic: topic, address: topic_address)
+      _pid -> {:ok, topic_address}
+    end
+  end
+
+  def topic_address(topic, state) do
+    Map.get(state, :prefix, "") <> "_" <> topic
+  end
+end
+
+defmodule Ockam.Hub.Service.PubSub.Topic do
+  @moduledoc """
+  Topic subscription for pub_sub service
+
+  Forwards all messages to all subscribed routes
+
+  Subscribe API is internal, it adds a route to the subscribers set
+  """
+  use Ockam.Worker
+
+  alias Ockam.Message
+
+  def subscribe(worker, name, route) do
+    ## TODO: reply to the subscriber?
+    Ockam.Worker.call(worker, {:subscribe, name, route})
+  end
+
+  @impl true
+  def setup(options, state) do
+    topic = Keyword.get(options, :topic)
+    {:ok, Map.merge(state, %{topic: topic, routes: %{}})}
+  end
+
+  @impl true
+  def handle_call({:subscribe, name, route}, _from, state) do
+    {:reply, :ok,
+     Map.update(state, :routes, %{name => route}, fn routes -> Map.put(routes, name, route) end)}
+  end
+
+  @impl true
+  def handle_message(message, state) do
+    [_me | onward_route] = Message.onward_route(message)
+
+    state
+    |> Map.get(:routes, MapSet.new())
+    |> Enum.each(fn {_name, route} ->
+      Ockam.Router.route(%{
+        onward_route: route ++ onward_route,
+        return_route: Message.return_route(message),
+        payload: Message.payload(message)
+      })
+    end)
+
+    {:ok, state}
+  end
+end


### PR DESCRIPTION
## Current Behaviour

Currently messaging pipelines rely on the underlying protocols for message delivery guarantees (e.g. TCP).
Those intermediate workers or transports may or may not implement reliable delivery.

## Proposed Changes

Resend pipe is implementing confirms and resends in order to ensure end-to-end reliable delivery
Please see `implementations/elixir/ockam/ockam/test/ockam/messaging/delivery_test.exs` for example usage

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
