### PR TITLE
Fix various issues in `ockam_ffi`.

### DIFF
--- a/implementations/elixir/ockam/ockam_vault_software/native/vault/software/common.c
+++ b/implementations/elixir/ockam/ockam_vault_software/native/vault/software/common.c
@@ -5,6 +5,12 @@ bool extern_error_has_error(const ockam_vault_extern_error_t* error) {
     return error->code != 0;
 }
 
+bool extern_error_check_and_free_error(ockam_vault_extern_error_t* error) {
+    bool result = extern_error_has_error(error);
+    ockam_vault_free_error(error);
+    return result;
+}
+
 ERL_NIF_TERM ok_void(ErlNifEnv *env) {
     return enif_make_atom(env, "ok");
 }

--- a/implementations/elixir/ockam/ockam_vault_software/native/vault/software/common.h
+++ b/implementations/elixir/ockam/ockam_vault_software/native/vault/software/common.h
@@ -6,7 +6,8 @@
 #include <ockam/vault.h>
 #include "erl_nif.h"
 
-bool extern_error_has_error(const ockam_vault_extern_error_t* error);
+bool extern_error_has_error(const ockam_vault_extern_error_t *error);
+bool extern_error_check_and_free_error(ockam_vault_extern_error_t *error);
 
 ERL_NIF_TERM ok_void(ErlNifEnv *env);
 

--- a/implementations/elixir/ockam/ockam_vault_software/native/vault/software/vault.c
+++ b/implementations/elixir/ockam/ockam_vault_software/native/vault/software/vault.c
@@ -146,7 +146,7 @@ ERL_NIF_TERM default_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     ockam_vault_t vault;
 
     ockam_vault_extern_error_t error = ockam_vault_default_init(&vault);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to create vault connection");
     }
 
@@ -183,7 +183,7 @@ ERL_NIF_TERM sha256(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     memset(digest, 0, 32);
 
     ockam_vault_extern_error_t error = ockam_vault_sha256(vault, input.data, input.size, digest);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env,  "failed to compute sha256 digest");
     }
 
@@ -207,7 +207,7 @@ ERL_NIF_TERM secret_generate(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
 
     ockam_vault_secret_t secret;
     ockam_vault_extern_error_t error = ockam_vault_secret_generate(vault, &secret, attributes);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "unable to generate the secret");
     }
 
@@ -238,7 +238,7 @@ ERL_NIF_TERM secret_import(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
 
     ockam_vault_secret_t secret;
     ockam_vault_extern_error_t error = ockam_vault_secret_import(vault, &secret, attributes, input.data, input.size);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "unable to import the secret");
     }
 
@@ -266,7 +266,7 @@ ERL_NIF_TERM secret_export(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
     uint32_t length = 0;
 
     ockam_vault_extern_error_t error = ockam_vault_secret_export(vault, secret_handle, buffer, MAX_SECRET_EXPORT_SIZE, &length);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to ockam_vault_secret_export");
     }
 
@@ -300,7 +300,7 @@ ERL_NIF_TERM secret_publickey_get(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
     uint32_t length = 0;
 
     ockam_vault_extern_error_t error = ockam_vault_secret_publickey_get(vault, secret_handle, buffer, MAX_SECRET_EXPORT_SIZE, &length);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to ockam_vault_secret_publickey_get");
     }
 
@@ -332,7 +332,7 @@ ERL_NIF_TERM secret_attributes_get(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 
     ockam_vault_secret_attributes_t attributes;
     ockam_vault_extern_error_t error = ockam_vault_secret_attributes_get(vault, secret_handle, &attributes);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to secret_attributes_get");
     }
 
@@ -355,7 +355,7 @@ ERL_NIF_TERM secret_destroy(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     }
 
     ockam_vault_extern_error_t error = ockam_vault_secret_destroy(vault, secret_handle);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to secret_destroy");
     }
 
@@ -384,7 +384,7 @@ ERL_NIF_TERM ecdh(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 
     ockam_vault_secret_t shared_secret;
     ockam_vault_extern_error_t error = ockam_vault_ecdh(vault, secret_handle, input.data,  input.size, &shared_secret);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to ecdh");
     }
 
@@ -449,7 +449,7 @@ ERL_NIF_TERM hkdf_sha256(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 
     ockam_vault_secret_t shared_secrets[MAX_DERIVED_OUTPUT_COUNT];
     ockam_vault_extern_error_t error = ockam_vault_hkdf_sha256(vault, salt_handle, ikm_handle_ptr, attributes, derived_outputs_count, shared_secrets);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to hkdf_sha256");
     }
 
@@ -516,7 +516,7 @@ ERL_NIF_TERM aead_aes_gcm_encrypt(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
                                                                         cipher_text,
                                                                         size,
                                                                         &length);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to aead_aes_gcm_encrypt");
     }
 
@@ -584,7 +584,7 @@ ERL_NIF_TERM aead_aes_gcm_decrypt(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
                                                                         plain_text,
                                                                         size,
                                                                         &length);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to aead_aes_gcm_decrypt");
     }
 
@@ -606,7 +606,7 @@ ERL_NIF_TERM deinit(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     }
 
     ockam_vault_extern_error_t error = ockam_vault_deinit(vault);
-    if (extern_error_has_error(&error)) {
+    if (extern_error_check_and_free_error(&error)) {
         return err(env, "failed to deinit vault");
     }
 

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -15,6 +15,10 @@ description = """FFI layer for ockam_vault.
 [lib]
 crate-type = ["staticlib"]
 
+[features]
+default = []
+bls = ["ockam_vault_core/bls"]
+
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "0.36.0"         }
 ockam_vault_core = { path = "../ockam_vault_core", version = "0.30.0"         }

--- a/implementations/rust/ockam/ockam_ffi/include/vault.h
+++ b/implementations/rust/ockam/ockam_ffi/include/vault.h
@@ -17,6 +17,14 @@ typedef struct {
 
 typedef uint64_t ockam_vault_secret_t;
 
+/**
+ * @struct ockam_vault_extern_error_t
+ * @brief Represents an error that occured in one of the `ockam_vault` functions.
+ *
+ * In the case of an error, resources associated with this error (the `domain` string)
+ * must be released using @ref ockam_vault_free_error (which is a no-op if an error did
+ * not occur) in order to avoid a memory leak.
+ */
 typedef struct {
     int32_t code;
     const char *domain;
@@ -55,7 +63,7 @@ typedef struct {
 /**
  * @brief   Initialize the specified ockam vault object
  * @param   vault[out] The ockam vault object to initialize with the default vault.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_default_init(ockam_vault_t* vault);
 
@@ -65,7 +73,7 @@ ockam_vault_extern_error_t ockam_vault_default_init(ockam_vault_t* vault);
  * @param   input[in]           Buffer containing data to run through SHA-256.
  * @param   input_length[in]    Length of the data to run through SHA-256.
  * @param   digest[out]         Buffer to place the resulting SHA-256 hash in. Must be 32 bytes.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_sha256(ockam_vault_t  vault,
                                               const uint8_t* input,
@@ -78,7 +86,7 @@ ockam_vault_extern_error_t ockam_vault_sha256(ockam_vault_t  vault,
  * @param   vault[in]       Vault object to use for generating a secret key.
  * @param   secret[out]     Pointer to an ockam secret object to be populated with a handle to the secret
  * @param   attributes[in]  Desired attribtes for the secret to be generated.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_secret_generate(ockam_vault_t                   vault,
                                                        ockam_vault_secret_t*           secret,
@@ -91,7 +99,7 @@ ockam_vault_extern_error_t ockam_vault_secret_generate(ockam_vault_t            
  * @param   attributes[in]    Desired attributes for the secret being imported.
  * @param   input[in]         Data to load into the supplied secret.
  * @param   input_length[in]  Length of data to load into the secret.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 
 ockam_vault_extern_error_t ockam_vault_secret_import(ockam_vault_t                   vault,
@@ -107,7 +115,7 @@ ockam_vault_extern_error_t ockam_vault_secret_import(ockam_vault_t              
  * @param   output_buffer[out]        Buffer to place the exported secret data in.
  * @param   output_buffer_size[in]    Size of the output buffer.
  * @param   output_buffer_length[out] Amount of data placed in the output buffer.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_secret_export(ockam_vault_t        vault,
                                                      ockam_vault_secret_t secret,
@@ -122,7 +130,7 @@ ockam_vault_extern_error_t ockam_vault_secret_export(ockam_vault_t        vault,
  * @param   output_buffer[out]        Buffer to place the public key in.
  * @param   output_buffer_size[in]    Size of the output buffer.
  * @param   output_buffer_length[out] Amount of data placed in the output buffer.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_secret_publickey_get(ockam_vault_t        vault,
                                                             ockam_vault_secret_t secret,
@@ -135,7 +143,7 @@ ockam_vault_extern_error_t ockam_vault_secret_publickey_get(ockam_vault_t       
  * @param   vault[in]               Vault object to use for retrieving ockam vault secret attributes.
  * @param   secret[in]              Ockam vault secret to get attributes for.
  * @param   secret_attributes[out]  Pointer to the attributes for the specified secret.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_secret_attributes_get(ockam_vault_t                    vault,
                                                              uint64_t                         secret,
@@ -145,7 +153,7 @@ ockam_vault_extern_error_t ockam_vault_secret_attributes_get(ockam_vault_t      
  * @brief   Delete an ockam vault secret.
  * @param   vault[in]   Vault object to use for deleting the ockam vault secret.
  * @param   secret[in]  Ockam vault secret to delete.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_secret_destroy(ockam_vault_t vault, ockam_vault_secret_t secret);
 
@@ -157,7 +165,7 @@ ockam_vault_extern_error_t ockam_vault_secret_destroy(ockam_vault_t vault, ockam
 * @param   peer_publickey[in]        Public key data to use for ECDH.
 * @param   peer_publickey_length[in] Length of the public key.
 * @param   shared_secret[out]        Resulting shared secret from a sucessful ECDH operation. Invalid if ECDH failed.
-* @return  error.
+* @return  an error, which should be freed using @ref ockam_vault_free_error.
 */
 ockam_vault_extern_error_t ockam_vault_ecdh(ockam_vault_t         vault,
                                             ockam_vault_secret_t  privatekey,
@@ -173,7 +181,7 @@ ockam_vault_extern_error_t ockam_vault_ecdh(ockam_vault_t         vault,
  * @param   derived_outputs_attributes[in] Attibutes of output secrets.
  * @param   derived_outputs_count[in]      Length of outputs attributes array.
  * @param   derived_outputs[out]           Array of ockam vault secrets resulting from HKDF.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_hkdf_sha256(ockam_vault_t                          vault,
                                                    ockam_vault_secret_t                   salt,
@@ -194,7 +202,7 @@ ockam_vault_extern_error_t ockam_vault_hkdf_sha256(ockam_vault_t                
  * @param   ciphertext_and_tag[in]          Buffer containing the generated ciphertext and tag data.
  * @param   ciphertext_and_tag_size[in]     Size of the ciphertext + tag buffer. Must be plaintext_size + 16.
  * @param   ciphertext_and_tag_length[out]  Amount of data placed in the ciphertext + tag buffer.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_encrypt(ockam_vault_t        vault,
                                                             ockam_vault_secret_t key,
@@ -219,7 +227,7 @@ ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_encrypt(ockam_vault_t       
  * @param   plaintext[out]                Buffer to place the decrypted data in.
  * @param   plaintext_size[in]            Size of the plaintext buffer. Must be ciphertext_tag_size - 16.
  * @param   plaintext_length[out]         Amount of data placed in the plaintext buffer.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_decrypt(ockam_vault_t       vault,
                                                             ockam_vault_secret_t key,
@@ -235,10 +243,15 @@ ockam_vault_extern_error_t ockam_vault_aead_aes_gcm_decrypt(ockam_vault_t       
 /**
  * @brief   Deinitialize the specified ockam vault object
  * @param   vault[in] The ockam vault object to deinitialize.
- * @return  error.
+ * @return  an error, which should be freed using @ref ockam_vault_free_error.
  */
 ockam_vault_extern_error_t ockam_vault_deinit(ockam_vault_t vault);
 
+/**
+ * @brief   Free any resources associated with a @ref ockam_vault_extern_error_t.
+ * @param   error[in] the error to free.
+ */
+void ockam_vault_free_error(ockam_vault_extern_error_t *error);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/implementations/rust/ockam/ockam_ffi/src/error.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/error.rs
@@ -95,3 +95,13 @@ impl From<FfiError> for FfiOckamError {
         Self::from(err)
     }
 }
+
+/// # Safety
+/// frees `FfiOckamError::domain` if it's non-null
+#[no_mangle]
+pub unsafe extern "C" fn ockam_vault_free_error(context: &mut FfiOckamError) {
+    if !context.domain.is_null() {
+        let _ = CString::from_raw(context.domain as *mut _);
+        context.domain = core::ptr::null();
+    }
+}

--- a/implementations/rust/ockam/ockam_ffi/src/error.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/error.rs
@@ -74,6 +74,9 @@ pub enum FfiError {
 
     /// Ownership error.
     OwnershipError,
+
+    /// Caught a panic (which would be UB if we let it unwind across the FFI).
+    UnexpectedPanic,
 }
 
 impl FfiError {

--- a/implementations/rust/ockam/ockam_ffi/src/macros.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/macros.rs
@@ -3,12 +3,12 @@
 macro_rules! check_buffer {
     ($buffer:expr) => {
         if $buffer.is_null() {
-            return FfiError::InvalidParam.into();
+            return Err(FfiError::InvalidParam.into());
         }
     };
     ($buffer:expr, $length:expr) => {
         if $buffer.is_null() || $length == 0 {
-            return FfiError::InvalidParam.into();
+            return Err(FfiError::InvalidParam.into());
         }
     };
 }


### PR DESCRIPTION
I had some computer issues this morning that I fixed by updating the OS, which meant that I wasn't on my primary dev machine for the day (I forgot to switch back after the update completed).

As a result of this, I decided to do my audit of the FFI code, which I had been meaning to do for a while (since at Mozilla, this kind of FFI code was my responsibility, so I know some non-obvious pitfalls to watch out for, and the solutions to them).

Fixes #1562, as well as the fact that we unwind from `extern "C"` fns, which is UB (fixing this robustly is a bit tricky, but not *too* bad — doing this correctly is a bit involved, but the implementation here should be robust.

I also cleaned up a use of `#[cfg(feature = "bls")]` when there's no `bls` feature, which is not that important, but caused a false positive error in my editor.

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.