### PR TITLE
Narrow triggers for `cargo_update_check` and `documentation_examples_check` actions

### DIFF
--- a/.github/workflows/cargo_update_check.yml
+++ b/.github/workflows/cargo_update_check.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 23 * * *'
 
 jobs:
   cargo_update_check:

--- a/.github/workflows/documentation_examples_check.yml
+++ b/.github/workflows/documentation_examples_check.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 23 * * *'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Current Behaviour

The following GitHub Actions are run once every 2 hours:
- `cargo_update_check`
- `documentation_examples_check`

## Proposed Changes

Change the schedule of the above GitHub Actions to run once per day at 23:00.
Fixes #2020.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.