### PR TITLE
chore(rust): replace `colored` with `owo-colors` in `ockam-hub-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,17 +286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,7 +1182,7 @@ dependencies = [
 name = "ockam-hub-cli"
 version = "0.1.0"
 dependencies = [
- "colored",
+ "owo-colors",
  "reqwest",
  "serde",
  "serde_json",
@@ -1552,6 +1541,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ad6d222cdc2351ccabb7af4f68bfaecd601b33c5f10d410ec89d2a273f6fff"
 
 [[package]]
 name = "pairing"

--- a/NOTICE
+++ b/NOTICE
@@ -44,7 +44,6 @@ This file contains attributions for any 3rd-party open source code used in this 
 | chrono                        | Apache-2.0 OR MIT                                    | https://github.com/chronotope/chrono                                      |
 | cipher                        | Apache-2.0 OR MIT                                    | https://github.com/RustCrypto/traits                                      |
 | clap                          | MIT                                                  | https://github.com/clap-rs/clap                                           |
-| colored                       | MPL-2.0                                              | https://github.com/mackwic/colored                                        |
 | concurrent-queue              | Apache-2.0 OR MIT                                    | https://github.com/stjepang/concurrent-queue                              |
 | core-foundation               | Apache-2.0 OR MIT                                    | https://github.com/servo/core-foundation-rs                               |
 | core-foundation-sys           | Apache-2.0 OR MIT                                    | https://github.com/servo/core-foundation-rs                               |
@@ -138,6 +137,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | openssl-probe                 | Apache-2.0 OR MIT                                    | https://github.com/alexcrichton/openssl-probe                             |
 | openssl-sys                   | MIT                                                  | https://github.com/sfackler/rust-openssl                                  |
 | os_pipe                       | MIT                                                  | https://github.com/oconnor663/os_pipe.rs                                  |
+| owo-colors                    | MIT                                                  | https://github.com/jam1garner/owo-colors                                  |
 | pairing                       | Apache-2.0 OR MIT                                    | https://github.com/zkcrypto/pairing                                       |
 | parking                       | Apache-2.0 OR MIT                                    | https://github.com/stjepang/parking                                       |
 | parking_lot                   | Apache-2.0 OR MIT                                    | https://github.com/Amanieu/parking_lot                                    |

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 arrayref = "0.3"
 base64-url = "1.4"
-colored = "2.0"
+owo-colors = "3"
 isahc = "0.9"
 lazy_static = "1.4"
 percent-encoding = "2.1"

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/src/main.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/src/main.rs
@@ -8,7 +8,7 @@ mod macros;
 mod config;
 mod objects;
 
-use colored::Colorize;
+use owo_colors::OwoColorize;
 use isahc::prelude::*;
 // use objects::UsersInGroup;
 use ockam::{CredentialAttributeSchema, CredentialAttributeType, CredentialSchema};

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/truck/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/truck/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-colored = "2.0"
+owo-colors = "3"
 rand = "0.7"
 ockam = { path = "../../../../ockam" }
 ockam_vault = { path = "../../../../ockam_vault"}

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/truck/src/main.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/truck/src/main.rs
@@ -1,5 +1,5 @@
-use colored::Colorize;
 use ockam::*;
+use owo_colors::OwoColorize;
 use ockam_key_exchange_core::{KeyExchanger, NewKeyExchanger};
 use ockam_key_exchange_x3dh::*;
 use ockam_vault::{ockam_vault_core::*, SoftwareVault};

--- a/tools/ockam-hub-cli/Cargo.toml
+++ b/tools/ockam-hub-cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "ockam-hub-cli"
 version = "0.1.0"
-authors = ["piiih <piih_@live.com>"]
+authors = ["Ockam Developers"]
+license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
@@ -12,4 +13,4 @@ serde = { version = "1.0.125", features = ["derive"]  }
 serde_json = "1.0.59"
 url = "2.2.1"
 webbrowser = "0.5.5"
-colored = "2.0.0"
+owo-colors = "3"

--- a/tools/ockam-hub-cli/src/auth/github.rs
+++ b/tools/ockam-hub-cli/src/auth/github.rs
@@ -1,4 +1,4 @@
-use colored::*;
+use owo_colors::OwoColorize;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;

--- a/tools/ockam-hub-cli/src/main.rs
+++ b/tools/ockam-hub-cli/src/main.rs
@@ -1,7 +1,7 @@
 mod auth;
 
 use auth::github;
-use colored::Colorize;
+use owo_colors::OwoColorize;
 use std::process;
 use structopt::StructOpt;
 


### PR DESCRIPTION
Specifically `colored`, which is used by `ockam-hub-cli` (and some largely-bitrotted example code that we need to move to a branch).

I replaced it with `owo-colors` (MIT licensed), which is almost a drop-in replacement and is probably the most popular lib for this for new code. That said, I don't love that library (it spews garbage on certain terminals), but it's fairly widely used and is fine for now[^1]

[^1]: Terminal coloring (particularly doing it in a way that doesn't have a terrible UX for an unsupported terminal) is actually an area that's very [near](https://shift.click/dump/ansi-palette) and [dear](https://gitlab.com/thomcc/near-ansi) to my heart, and I have a WIP project I'll try and finish up this week (or this evening?) that should be usable as a longer term replacement.

This also makes a couple changes to `ockam-hub-cli`'s Cargo.toml so that we successfully pass `cargo deny check licenses` when run on the whole workspace. I'll leave it to @metaclips to integrate that into our CI.

Oh, and the update to the NOTICE file was done by hand. I have no clue how it was generated, TBH.