### PR TITLE
chore: remove unnecessary core/heapless/hashbrown re-exports from signature_…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,7 +2155,6 @@ dependencies = [
  "digest",
  "ff",
  "group",
- "hashbrown 0.11.2",
  "heapless",
  "rand 0.8.4",
  "rand_core 0.6.3",

--- a/implementations/rust/ockam/signature_bbs_plus/examples/readme-source.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/examples/readme-source.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 use signature_bbs_plus::{Issuer, MessageGenerators, Prover};
-use signature_core::{error::Error, lib::*};
+use signature_core::error::Error;
 
 type ExampleResult = Result<(), Error>;
 

--- a/implementations/rust/ockam/signature_bbs_plus/src/lib.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/lib.rs
@@ -42,6 +42,7 @@ pub use pok_signature::*;
 pub use pok_signature_proof::*;
 pub use prover::*;
 pub use signature::*;
+pub use signature_core::error::Error;
 pub use signature_bls::{ProofOfPossession, PublicKey, SecretKey, Signature as BlsSignature};
 #[cfg(test)]
 pub use util::MockRng;

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -24,7 +24,6 @@ bls12_381_plus = { version = "0.5", default-features = false, features = ["group
 digest = { version = "0.9", default-features = false }
 ff = { version = "0.10", default-features = false }
 group = "0.10"
-hashbrown = { version = "0.11", default-features = false, features = ["ahash"] }
 heapless = "0.7"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/signature_core/src/lib.rs
+++ b/implementations/rust/ockam/signature_core/src/lib.rs
@@ -1,4 +1,4 @@
-//! A crate for common methods used by short group signatures
+//! A crate for common shared functionality used by other signature crates
 
 #![deny(
     trivial_casts,
@@ -8,13 +8,11 @@
     unused_qualifications,
     warnings
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 #[cfg(feature = "std")]
-extern crate core;
 
 #[cfg(feature = "alloc")]
-extern crate alloc;
 
 /// Common methods for signature schemes
 #[macro_use]
@@ -50,36 +48,3 @@ pub mod hidden_message;
 
 /// The blinding factor when hiding messages during signing
 pub mod signature_blinding;
-
-/// A facade around the various collections and primitives needed
-/// when using no alloc, alloc only, or std modes
-pub mod lib {
-    pub use core::cell::{Cell, RefCell};
-    pub use core::clone::{self, Clone};
-    pub use core::convert::{self, From, Into};
-    pub use core::default::{self, Default};
-    pub use core::fmt::{self, Debug, Display};
-    pub use core::marker::{self, PhantomData};
-    pub use core::num::Wrapping;
-    pub use core::ops::{Deref, DerefMut, Range};
-    pub use core::option::{self, Option};
-    pub use core::result::{self, Result};
-    pub use core::{cmp, iter, mem, num, slice, str};
-    pub use core::{f32, f64};
-    pub use core::{i16, i32, i64, i8, isize};
-    pub use core::{u16, u32, u64, u8, usize};
-
-    pub use heapless::String;
-    pub use heapless::Vec;
-
-    pub use super::challenge::Challenge;
-    pub use super::commitment::Commitment;
-    pub use super::hidden_message::HiddenMessage;
-    pub use super::message::Message;
-    pub use super::nonce::Nonce;
-    pub use super::proof_committed_builder::ProofCommittedBuilder;
-    pub use super::proof_message::ProofMessage;
-    pub use super::signature_blinding::SignatureBlinding;
-    pub use super::util::{sum_of_products, VecSerializer};
-    pub use hashbrown::{HashMap, HashSet};
-}


### PR DESCRIPTION
ockam/implementations/rust/ockam/signature...crates

<!-- Thank you for sending a pull request :heart: -->

#2162

## Proposed Changes
Remove unnecessary core/heapless/hashbrown re-exports from signature_core::lib, remove `extern crate` and make configuration attribute no_std and change the crate's comment. 

Remove hashbrown from signature_core's Cargo.toml

Remove import of lib from signature_bbs_plus/examples/readme-source.rs since it is no longer required



<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
