### PR TITLE
jared/plaxi0s/macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ version = "0.37.0"
 dependencies = [
  "async-trait",
  "core2",
+ "futures-util",
  "hashbrown 0.11.2",
  "heapless",
  "hex",
@@ -1229,7 +1230,6 @@ dependencies = [
  "serde",
  "serde_bare",
  "spin 0.9.2",
- "tokio",
 ]
 
 [[package]]
@@ -1329,7 +1329,6 @@ dependencies = [
 name = "ockam_macro"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "ockam_core",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "hashbrown 0.11.2",
  "heapless",
  "hex",
+ "ockam_macro",
  "ockam_message_derive",
  "rand 0.8.4",
  "rand_pcg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arrayref"
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053f1ab4712fe8c55de46932b46ecc774ae7906278ddf7fc2fbaaaa663b84392"
+checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
 dependencies = [
  "critical-section",
  "riscv-target",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673b836c1c5a73bd981805236f46dfddbe1092a6a829b22464bd40d7ceefd2f9"
+checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -1229,6 +1229,7 @@ dependencies = [
  "serde",
  "serde_bare",
  "spin 0.9.2",
+ "tokio",
 ]
 
 [[package]]
@@ -1322,6 +1323,18 @@ dependencies = [
  "ockam_vault",
  "ockam_vault_core",
  "ockam_vault_sync_core",
+]
+
+[[package]]
+name = "ockam_macro"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ockam_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -2027,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -2872,18 +2885,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -43,4 +43,5 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 core2 = { version = "0.3.2", default-features = false, optional = true }
 spin = { version = "0.9.1", default-features = false, features = ["mutex", "rwlock", "spin_mutex"], optional = true }
+ockam_macro = {path = "../ockam_macro/"}
 futures-util = { version = "0.3.17" }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -43,3 +43,4 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 core2 = { version = "0.3.2", default-features = false, optional = true }
 spin = { version = "0.9.1", default-features = false, features = ["mutex", "rwlock", "spin_mutex"], optional = true }
+tokio = {version = "1", default-features = false, features = ["macros"]}

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -43,4 +43,4 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 core2 = { version = "0.3.2", default-features = false, optional = true }
 spin = { version = "0.9.1", default-features = false, features = ["mutex", "rwlock", "spin_mutex"], optional = true }
-tokio = {version = "1", default-features = false, features = ["macros"]}
+futures-util = { version = "0.3.17" }

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -15,6 +15,9 @@
 #[cfg(feature = "alloc")]
 pub use alloc::borrow;
 
+#[doc(hidden)]
+pub use futures_util::try_join;
+
 /// std::boxed
 pub mod boxed {
     #[cfg(feature = "alloc")]

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -39,6 +39,9 @@ pub extern crate hex;
 pub extern crate async_trait;
 pub use async_trait::async_trait as worker;
 
+pub extern crate tokio;
+pub use tokio::try_join;
+
 pub mod compat;
 mod error;
 mod message;
@@ -91,7 +94,6 @@ pub mod traits {
         /// Try cloning a object and return an `Err` in case of failure.
         async fn async_try_clone(&self) -> Result<Self>;
     }
-
     #[async_trait]
     impl<D> AsyncTryClone for D
     where

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -39,6 +39,8 @@ pub extern crate hex;
 pub extern crate async_trait;
 pub use async_trait::async_trait as worker;
 
+pub extern crate ockam_macro;
+pub use ockam_macro::AsyncTryClone;
 pub extern crate futures_util;
 pub use futures_util::try_join;
 
@@ -54,12 +56,11 @@ pub use error::*;
 pub use message::*;
 pub use processor::*;
 pub use routing::*;
+#[cfg(feature = "std")]
+pub use std::println;
 pub use traits::*;
 pub use uint::*;
 pub use worker::*;
-
-#[cfg(feature = "std")]
-pub use std::println;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 /// println macro for no_std
 #[macro_export]

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -39,10 +39,10 @@ pub extern crate hex;
 pub extern crate async_trait;
 pub use async_trait::async_trait as worker;
 
-pub extern crate ockam_macro;
+extern crate ockam_macro;
 pub use ockam_macro::AsyncTryClone;
-pub extern crate futures_util;
-pub use futures_util::try_join;
+
+extern crate futures_util;
 
 pub mod compat;
 mod error;
@@ -56,11 +56,12 @@ pub use error::*;
 pub use message::*;
 pub use processor::*;
 pub use routing::*;
-#[cfg(feature = "std")]
-pub use std::println;
 pub use traits::*;
 pub use uint::*;
 pub use worker::*;
+
+#[cfg(feature = "std")]
+pub use std::println;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 /// println macro for no_std
 #[macro_export]

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -39,8 +39,8 @@ pub extern crate hex;
 pub extern crate async_trait;
 pub use async_trait::async_trait as worker;
 
-pub extern crate tokio;
-pub use tokio::try_join;
+pub extern crate futures_util;
+pub use futures_util::try_join;
 
 pub mod compat;
 mod error;

--- a/implementations/rust/ockam/ockam_entity/src/channel/trust_policy/all_trust_policy.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/trust_policy/all_trust_policy.rs
@@ -2,6 +2,7 @@ use crate::{SecureChannelTrustInfo, TrustPolicy};
 use ockam_core::{async_trait, compat::boxed::Box};
 use ockam_core::{AsyncTryClone, Result};
 
+#[derive(AsyncTryClone)]
 pub struct AllTrustPolicy<F: TrustPolicy, S: TrustPolicy> {
     // TODO: Extend for more than 2 policies
     first: F,
@@ -11,16 +12,6 @@ pub struct AllTrustPolicy<F: TrustPolicy, S: TrustPolicy> {
 impl<F: TrustPolicy, S: TrustPolicy> AllTrustPolicy<F, S> {
     pub fn new(first: F, second: S) -> Self {
         AllTrustPolicy { first, second }
-    }
-}
-
-#[async_trait]
-impl<F: TrustPolicy, S: TrustPolicy> AsyncTryClone for AllTrustPolicy<F, S> {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            first: self.first.async_try_clone().await?,
-            second: self.second.async_try_clone().await?,
-        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_entity/src/channel/trust_policy/any_trust_policy.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel/trust_policy/any_trust_policy.rs
@@ -2,6 +2,7 @@ use crate::{SecureChannelTrustInfo, TrustPolicy};
 use ockam_core::{async_trait, compat::boxed::Box};
 use ockam_core::{AsyncTryClone, Result};
 
+#[derive(AsyncTryClone)]
 pub struct AnyTrustPolicy<F: TrustPolicy, S: TrustPolicy> {
     // TODO: Extend for more than 2 policies
     first: F,
@@ -11,16 +12,6 @@ pub struct AnyTrustPolicy<F: TrustPolicy, S: TrustPolicy> {
 impl<F: TrustPolicy, S: TrustPolicy> AnyTrustPolicy<F, S> {
     pub fn new(first: F, second: S) -> Self {
         AnyTrustPolicy { first, second }
-    }
-}
-
-#[async_trait]
-impl<F: TrustPolicy, S: TrustPolicy> AsyncTryClone for AnyTrustPolicy<F, S> {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            first: self.first.async_try_clone().await?,
-            second: self.second.async_try_clone().await?,
-        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_entity/src/entity.rs
+++ b/implementations/rust/ockam/ockam_entity/src/entity.rs
@@ -14,20 +14,10 @@ use ockam_node::{Context, Handle};
 use ockam_vault::ockam_vault_core::{PublicKey, Secret};
 use IdentityRequest::*;
 use IdentityResponse as Res;
-
+#[derive(AsyncTryClone)]
 pub struct Entity {
     pub(crate) handle: Handle,
     current_profile_id: Option<ProfileIdentifier>,
-}
-
-#[async_trait]
-impl AsyncTryClone for Entity {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            handle: self.handle.async_try_clone().await?,
-            current_profile_id: self.current_profile_id.clone(),
-        })
-    }
 }
 
 impl Entity {

--- a/implementations/rust/ockam/ockam_entity/src/profile.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile.rs
@@ -27,19 +27,10 @@ use ockam_core::{Result, Route};
 use ockam_node::Handle;
 use ockam_vault::{PublicKey, Secret};
 
+#[derive(AsyncTryClone)]
 pub struct Profile {
     id: ProfileIdentifier,
     handle: Handle,
-}
-
-#[async_trait]
-impl AsyncTryClone for Profile {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            id: self.id.clone(),
-            handle: self.handle.async_try_clone().await?,
-        })
-    }
 }
 
 impl Entity {

--- a/implementations/rust/ockam/ockam_entity/src/profile_state.rs
+++ b/implementations/rust/ockam/ockam_entity/src/profile_state.rs
@@ -27,6 +27,7 @@ cfg_if! {
 }
 
 /// Profile implementation
+#[derive(AsyncTryClone)]
 pub struct ProfileState {
     id: ProfileIdentifier,
     change_history: ProfileChangeHistory,
@@ -37,23 +38,6 @@ pub struct ProfileState {
     #[cfg(feature = "credentials")]
     pub(crate) credentials: Vec<EntityCredential>,
     lease: Option<Lease>,
-}
-
-#[async_trait]
-impl AsyncTryClone for ProfileState {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            id: self.id.clone(),
-            change_history: self.change_history.clone(),
-            contacts: self.contacts.clone(),
-            vault: self.vault.async_try_clone().await?,
-            #[cfg(feature = "credentials")]
-            rand_msg: self.rand_msg.clone(),
-            #[cfg(feature = "credentials")]
-            credentials: self.credentials.clone(),
-            lease: self.lease.clone(),
-        })
-    }
 }
 
 impl ProfileState {

--- a/implementations/rust/ockam/ockam_entity/src/worker/trust_policy_worker.rs
+++ b/implementations/rust/ockam/ockam_entity/src/worker/trust_policy_worker.rs
@@ -6,18 +6,9 @@ use ockam_core::{
 use ockam_message_derive::Message;
 use ockam_node::{Context, Handle};
 use serde::{Deserialize, Serialize};
-
+#[derive(AsyncTryClone)]
 pub struct TrustPolicyImpl {
     handle: Handle,
-}
-
-#[async_trait]
-impl AsyncTryClone for TrustPolicyImpl {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            handle: self.handle.async_try_clone().await?,
-        })
-    }
 }
 
 impl TrustPolicyImpl {

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/new_key_exchanger.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/new_key_exchanger.rs
@@ -4,17 +4,9 @@ use ockam_core::{AsyncTryClone, Result};
 use ockam_key_exchange_core::NewKeyExchanger;
 
 /// Represents an XX NewKeyExchanger
+#[derive(AsyncTryClone)]
 pub struct X3dhNewKeyExchanger<V: X3dhVault> {
     vault: V,
-}
-
-#[async_trait]
-impl<V: X3dhVault> AsyncTryClone for X3dhNewKeyExchanger<V> {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            vault: self.vault.async_try_clone().await?,
-        })
-    }
 }
 
 impl<V: X3dhVault> core::fmt::Debug for X3dhNewKeyExchanger<V> {

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/new_key_exchanger.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/new_key_exchanger.rs
@@ -5,6 +5,7 @@ use ockam_core::{AsyncTryClone, Result};
 use ockam_key_exchange_core::NewKeyExchanger;
 
 /// Represents an XX NewKeyExchanger
+#[derive(AsyncTryClone)]
 pub struct XXNewKeyExchanger<V: XXVault> {
     vault: V,
 }
@@ -13,15 +14,6 @@ impl<V: XXVault> XXNewKeyExchanger<V> {
     /// Create a new XXNewKeyExchanger
     pub fn new(vault: V) -> Self {
         Self { vault }
-    }
-}
-
-#[async_trait]
-impl<V: XXVault> AsyncTryClone for XXNewKeyExchanger<V> {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            vault: self.vault.async_try_clone().await?,
-        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_macro/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macro/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ockam_macro"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dev-dependencies]
+async-trait = "0.1.42"
+trybuild = "1.0"
+ockam_core = { path = "../ockam_core", version = "0.37.0"}
+
+[[test]]
+name="tests"
+path = "tests/main.rs"
+
+[dependencies]
+proc-macro2= "1.0.30"
+syn = "1.0.80"
+quote = "1.0.10"

--- a/implementations/rust/ockam/ockam_macro/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macro/Cargo.toml
@@ -2,6 +2,14 @@
 name = "ockam_macro"
 version = "0.1.0"
 edition = "2018"
+license = "Apache-2.0"
+authors = ["Ockam Developers"]
+categories = ["cryptography", "asynchronous", "authentication", "network-programming", "embedded"]
+description = "End-to-end encryption and mutual authentication for distributed applications."
+homepage = "https://github.com/ockam-network/ockam"
+keywords = ["ockam", "crypto", "cryptography", "network-programming", "encryption"]
+readme = "README.md"
+repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_macro"
 
 [lib]
 proc-macro = true

--- a/implementations/rust/ockam/ockam_macro/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macro/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 proc-macro = true
 
 [dev-dependencies]
-async-trait = "0.1.42"
 trybuild = "1.0"
 ockam_core = { path = "../ockam_core", version = "0.37.0"}
 

--- a/implementations/rust/ockam/ockam_macro/src/lib.rs
+++ b/implementations/rust/ockam/ockam_macro/src/lib.rs
@@ -1,0 +1,179 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, parse_quote, Attribute, Data::Struct, DeriveInput, GenericParam, Ident, Type,
+};
+// Gets the outer of a type Outer<SomeType> or Type
+fn get_outer(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(tp) if tp.qself.is_none() => {
+            let segments = &tp.path.segments;
+            let outer_type = if segments.len() == 1 {
+                segments.first().unwrap().ident.to_string()
+            } else {
+                segments.iter().fold(String::new(), |mut acc, s| {
+                    acc.push_str("::");
+                    acc.push_str(&s.ident.to_string());
+                    acc
+                })
+            };
+            Some(outer_type)
+        }
+        _ => None,
+    }
+}
+// Gets the inner of a type SomeType<Inner> or none if it doesn't exist
+fn get_inner(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Path(tp) if tp.qself.is_none() => {
+            let mut tp = tp
+                .path
+                .segments
+                .iter()
+                .skip_while(|s| s.arguments.is_empty());
+            if let Some(segment) = tp.next() {
+                match &segment.arguments {
+                    syn::PathArguments::AngleBracketed(ab) if ab.args.len() == 1 => {
+                        if let Some(syn::GenericArgument::Type(t)) = ab.args.first() {
+                            return Some(t);
+                        }
+                        return None;
+                    }
+                    _ => return None,
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn has_generic(ty: &Type, generics_list: &[&Ident]) -> bool {
+    if let Some(inner) = get_inner(ty) {
+        return has_generic(inner, generics_list);
+    }
+    if let Type::Path(tp) = ty {
+        if generics_list.contains(&&tp.path.segments[0].ident) {
+            return true;
+        }
+    }
+    false
+}
+
+#[proc_macro_derive(AsyncTryClone)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let struct_data = match ast.data {
+        Struct(s) => s,
+        _ => {
+            panic!("currently only works for structs");
+        }
+    };
+    let struct_ident = ast.ident;
+    let named_fields = match struct_data.fields {
+        syn::Fields::Named(f) => f.named,
+        _ => {
+            panic!("currently only works for named fields");
+        }
+    };
+
+    // Get generic type params from struct definition
+    let generic_tys = ast
+        .generics
+        .type_params()
+        .map(|t| &t.ident)
+        .collect::<Vec<_>>();
+
+    // Types for form name: T where T is a generic type
+    let simple_generic_fields = named_fields
+        .iter()
+        .filter_map(|f| {
+            let outer = get_outer(&f.ty).unwrap();
+            if generic_tys.iter().any(|id| id.to_string() == outer) {
+                return Some(outer);
+            }
+            None
+        })
+        .collect::<Vec<_>>();
+
+    // Types which have a generic and are not simple
+    let complex_generic_fields = named_fields
+        .iter()
+        .filter_map(|f| {
+            if has_generic(&f.ty, &generic_tys) && get_inner(&f.ty).is_some() {
+                return Some(&f.ty);
+            }
+            None
+        })
+        .collect::<Vec<_>>();
+
+    let mut generics = ast.generics;
+
+    // Add trait bounds on generic type params
+    for p in &mut generics.params {
+        if let GenericParam::Type(ref mut t) = *p {
+            // Every generic type must be Send + Sync
+            t.bounds.push(parse_quote!(::std::marker::Send));
+            t.bounds.push(parse_quote!(::std::marker::Sync));
+
+            // Generic simple type must also be AsyncTryClone
+            if simple_generic_fields
+                .iter()
+                .any(|s| s == &t.ident.to_string())
+            {
+                t.bounds
+                    .push(parse_quote!(ockam_core::traits::AsyncTryClone));
+            }
+        }
+    }
+
+    // Add where bounds
+    let where_clause = generics.make_where_clause();
+    for ty in complex_generic_fields {
+        where_clause
+            .predicates
+            .push(parse_quote!(#ty: ockam_core::traits::AsyncTryClone));
+    }
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let async_trait: Attribute = parse_quote!(#[async_trait]);
+    let fields = named_fields.iter().map(|f| {
+        let field_name = &f.ident;
+        quote! {
+            #field_name
+        }
+    });
+    let fields_clone = fields.clone();
+    let fields_async_impls = named_fields.iter().map(|f| {
+        let field_name = &f.ident;
+        quote! {
+            self.#field_name.async_try_clone()
+        }
+    });
+    let trait_fn = quote! {
+        async fn async_try_clone(&self) -> ockam_core::Result<Self>{
+            let results = ockam_core::try_join!(
+                #(#fields_async_impls),*
+            );
+            match results {
+                Ok((#(#fields),*))=> {
+                    Ok(
+                        Self{
+                            #(#fields_clone),*
+                        }
+                    )
+                }
+                Err(e) => {
+                    Err(e)
+                }
+            }
+        }
+    };
+    let output = quote! {
+        #async_trait
+        impl #impl_generics ockam_core::traits::AsyncTryClone for #struct_ident #ty_generics #where_clause {
+            #trait_fn
+        }
+    };
+    TokenStream::from(output)
+}

--- a/implementations/rust/ockam/ockam_macro/src/lib.rs
+++ b/implementations/rust/ockam/ockam_macro/src/lib.rs
@@ -113,8 +113,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
     for p in &mut generics.params {
         if let GenericParam::Type(ref mut t) = *p {
             // Every generic type must be Send + Sync
-            t.bounds.push(parse_quote!(::std::marker::Send));
-            t.bounds.push(parse_quote!(::std::marker::Sync));
+            t.bounds.push(parse_quote!(::core::marker::Send));
+            t.bounds.push(parse_quote!(::core::marker::Sync));
 
             // Generic simple type must also be AsyncTryClone
             if simple_generic_fields
@@ -136,7 +136,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     }
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let async_trait: Attribute = parse_quote!(#[async_trait]);
+    let async_trait: Attribute = parse_quote!(#[ockam_core::async_trait]);
     let fields = named_fields.iter().map(|f| {
         let field_name = &f.ident;
         quote! {
@@ -156,10 +156,10 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 #(#fields_async_impls),*
             );
             match results {
-                Ok((#(#fields),*))=> {
+                Ok((#(#fields_clone),* ,))=> {
                     Ok(
                         Self{
-                            #(#fields_clone),*
+                            #(#fields),*
                         }
                     )
                 }

--- a/implementations/rust/ockam/ockam_macro/src/lib.rs
+++ b/implementations/rust/ockam/ockam_macro/src/lib.rs
@@ -152,7 +152,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     });
     let trait_fn = quote! {
         async fn async_try_clone(&self) -> ockam_core::Result<Self>{
-            let results = ockam_core::try_join!(
+            let results = ockam_core::compat::try_join!(
                 #(#fields_async_impls),*
             );
             match results {

--- a/implementations/rust/ockam/ockam_macro/tests/main.rs
+++ b/implementations/rust/ockam/ockam_macro/tests/main.rs
@@ -1,0 +1,5 @@
+#[test]
+fn tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/test.rs");
+}

--- a/implementations/rust/ockam/ockam_macro/tests/test.rs
+++ b/implementations/rust/ockam/ockam_macro/tests/test.rs
@@ -1,6 +1,8 @@
-use async_trait::async_trait;
 use ockam_macro::AsyncTryClone;
-pub struct Error;
+#[derive(AsyncTryClone)]
+pub struct Tmp1 {
+    a: u32,
+}
 #[derive(AsyncTryClone)]
 pub struct Tmp<T> {
     a: u32,

--- a/implementations/rust/ockam/ockam_macro/tests/test.rs
+++ b/implementations/rust/ockam/ockam_macro/tests/test.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+use ockam_macro::AsyncTryClone;
+pub struct Error;
+#[derive(AsyncTryClone)]
+pub struct Tmp<T> {
+    a: u32,
+    b: Vec<T>,
+}
+
+#[derive(AsyncTryClone)]
+pub struct Tmp2<T> {
+    a: u32,
+    b: T,
+}
+fn assert_impl<T: ockam_core::traits::AsyncTryClone>() {}
+fn main() {
+    assert_impl::<String>();
+    assert_impl::<Tmp2<Tmp<String>>>();
+}

--- a/implementations/rust/ockam/ockam_macro/tests/test.rs
+++ b/implementations/rust/ockam/ockam_macro/tests/test.rs
@@ -17,5 +17,8 @@ pub struct Tmp2<T> {
 fn assert_impl<T: ockam_core::traits::AsyncTryClone>() {}
 fn main() {
     assert_impl::<String>();
+    assert_impl::<Tmp1>();
+    assert_impl::<Tmp<usize>>();
+    assert_impl::<Tmp2<Tmp1>>();
     assert_impl::<Tmp2<Tmp<String>>>();
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -1,5 +1,5 @@
 use crate::{parse_socket_addr, TcpOutletListenWorker, TcpRouter, TcpRouterHandle};
-use ockam_core::{async_trait, compat::boxed::Box};
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, AsyncTryClone, Result, Route};
 use ockam_node::Context;
 
@@ -41,17 +41,9 @@ use ockam_node::Context;
 /// tcp.listen("127.0.0.1:9000").await?; // Listen on port 9000
 /// # Ok(()) }
 /// ```
+#[derive(AsyncTryClone)]
 pub struct TcpTransport {
     router_handle: TcpRouterHandle,
-}
-
-#[async_trait]
-impl AsyncTryClone for TcpTransport {
-    async fn async_try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            router_handle: self.router_handle.async_try_clone().await?,
-        })
-    }
 }
 
 impl TcpTransport {


### PR DESCRIPTION
- feat(rust): add proc macro to auto derive `AsyncTryClone` trait
- feat(rust): replaced tokio::try_join with futures_util::try_join, removed unused imports, fixed single-field struct derive
- feat(rust): replace `AsyncTryClone` trait impls with `#[derive(AsyncTryClone)]` wherever applicable
- feat(rust): fix imports
