### PR TITLE
fix(rust): fix unused variable warning in ockam_node_test_attribute

### DIFF
--- a/implementations/rust/ockam/ockam_node_test_attribute/tests/trybuild.rs
+++ b/implementations/rust/ockam/ockam_node_test_attribute/tests/trybuild.rs
@@ -1,9 +1,9 @@
 #[test]
 fn trybuild() {
-    let t = trybuild::TestCases::new();
     #[cfg(feature = "std")]
     {
         // `node` macro tests
+        let t = trybuild::TestCases::new();
         t.compile_fail("tests/node/fail*.rs");
         t.pass("tests/node/pass*.rs");
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour
https://github.com/ockam-network/ockam/pull/2156 changed this test harness to execute under the  `#[cfg(feature = "std")]` macro. `cargo test` by default does not execute the tests under this block, so the variable is then unused.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

This change moves the variable instantiation to the same code block. This will only instantiate the variable then when it is needed for this block upon execution. In the future, if this behavior is no longer wanted, the instantiation of `trybuild::TestCases` can be moved.

Closes  #2188

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
