### PR TITLE
fix(rust): fix no_std builds

### DIFF
--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -44,4 +44,4 @@ rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 core2 = { version = "0.3.2", default-features = false, optional = true }
 spin = { version = "0.9.1", default-features = false, features = ["mutex", "rwlock", "spin_mutex"], optional = true }
 ockam_macro = { version = "0.1.0" }
-futures-util = { version = "0.3.17" }
+futures-util = { version = "0.3.17", default-features = false, features = ["alloc", "async-await-macro", "sink"] }

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -81,7 +81,6 @@ macro_rules! println {
                 Err(_) => (),
             }
         }
-
     }};
 }
 

--- a/implementations/rust/ockam/ockam_executor/src/executor.rs
+++ b/implementations/rust/ockam/ockam_executor/src/executor.rs
@@ -70,8 +70,15 @@ impl<'a> Executor<'a> {
                 break result;
             }
 
+            let mut task_budget = self.task_queue.len();
+
             while let Some(task_id) = self.task_queue.pop() {
                 self.poll_task(task_id);
+
+                if task_budget == 0 {
+                    break;
+                }
+                task_budget -= 1;
             }
             self.sleep_if_idle();
         };

--- a/implementations/rust/ockam/ockam_executor/src/lib.rs
+++ b/implementations/rust/ockam/ockam_executor/src/lib.rs
@@ -57,20 +57,6 @@ pub use ockam_core::println;
 
 #[cfg(not(feature = "std"))]
 pub mod logging_no_std {
-    /// info!
-    #[macro_export]
-    macro_rules! info {
-        ($($arg:tt)*) => (
-            ockam_core::println!($($arg)*);
-        )
-    }
-    /// trace!
-    #[macro_export]
-    macro_rules! trace {
-        ($($arg:tt)*) => (
-            ockam_core::println!($($arg)*);
-        )
-    }
     /// error!
     #[macro_export]
     macro_rules! error {
@@ -78,9 +64,30 @@ pub mod logging_no_std {
             ockam_core::println!($($arg)*);
         )
     }
+    /// warn!
+    #[macro_export]
+    macro_rules! warn {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
+    /// info!
+    #[macro_export]
+    macro_rules! info {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
     /// debug!
     #[macro_export]
     macro_rules! debug {
+        ($($arg:tt)*) => (
+            ockam_core::println!($($arg)*);
+        )
+    }
+    /// trace!
+    #[macro_export]
+    macro_rules! trace {
         ($($arg:tt)*) => (
             ockam_core::println!($($arg)*);
         )

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -12,7 +12,7 @@ use crate::{
     Cancel, NodeMessage, ShutdownType,
 };
 use core::time::Duration;
-use ockam_core::compat::{sync::Arc, vec::Vec};
+use ockam_core::compat::{string::String, sync::Arc, vec::Vec};
 use ockam_core::{
     Address, AddressSet, LocalMessage, Message, Processor, Result, Route, TransportMessage, Worker,
 };

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -1,6 +1,6 @@
 use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{error::Error, relay::RelayMessage, router::SenderPair};
-use ockam_core::compat::vec::Vec;
+use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::{Address, AddressSet};
 
 /// Messages sent from the Node to the Executor

--- a/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
@@ -42,7 +42,6 @@ where
                     break;
                 }
             }
-
             Result::<()>::Ok(())
         };
 

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -2,7 +2,11 @@ use crate::relay::{CtrlSignal, RelayMessage};
 use crate::tokio::sync::mpsc::Sender;
 use crate::{error::Error, NodeError, NodeReply, NodeReplyResult};
 use ockam_core::{
-    compat::collections::{BTreeMap, BTreeSet},
+    compat::{
+        collections::{BTreeMap, BTreeSet},
+        string::String,
+        vec::Vec,
+    },
     Address, AddressSet, Result,
 };
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes various things that are currently breaking `no_std` builds:

* `ockam_executor` deadlocks inside the `ProcessorRelay` run loop.
* `ockam_executor` is missing an implementation of the `warn!` logging macro
* we don't (yet) have an implementation of `select!` for `ockam_executor`
* adding `futures-util` with default features enabled breaks `no_std` builds

## Checks

```
cd implementations/rust/ockam/ockam

cargo build --no-default-features --features "no_std alloc software_vault"
```

For bonus points arm cortex-m builds can be tested with:

```
cargo +nightly build --target thumbv7em-none-eabihf --no-default-features --features "no_std alloc software_vault"
```