### PR TITLE
jared/release/nov15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "ockam-ffi"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "lazy_static",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "cortex-m",
  "cortex-m-semihosting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "cfg-if",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "futures 0.3.17",
  "hashbrown 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "async-trait",
  "core2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_test_attribute"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ockam",
  "ockam_node",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "ockam_core",
  "ockam_message_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "ockam_core",
  "ockam_vault_core",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.39.0 - 2021-11-15
+### Changed
+- Dependencies updated
+- change `Doesnt` to `DoesNot` for enum variants
+
 ## v0.38.0 - 2021-11-08
 ### Changed
 - handle failed fetch_intervals gracefully

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -80,7 +80,7 @@ ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.26.0" , 
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.34.0", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.33.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -83,7 +83,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features =
 ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.33.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.29.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
@@ -99,7 +99,7 @@ hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -73,7 +73,7 @@ no_main = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.37.0", default-features = false }
 ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.26.0" , default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -78,7 +78,7 @@ ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , d
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default-features = false }
 ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.26.0" , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.34.0", optional = true }
@@ -98,7 +98,7 @@ rand = { version = "0.8", default-features = false }
 hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -77,7 +77,7 @@ ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = f
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default-features = false }
 ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.26.0" , default_features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -84,7 +84,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.34.0", default_featur
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.33.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }
-ockam_entity = { path = "../ockam_entity", version = "^0.28.0", default_features = false }
+ockam_entity = { path = "../ockam_entity", version = "^0.29.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "0.29.0" , path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -81,7 +81,7 @@ ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.33.0", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.34.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.29.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -75,7 +75,7 @@ no_main = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.37.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.38.0", default-features = false }
 ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.26.0" , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -82,7 +82,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.33.0", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.29.0", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.38.0"
+version = "0.39.0"
 
 [features]
 default = ["std", "ockam_transport_tcp", "software_vault", "noise_xx"]

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -79,7 +79,7 @@ ockam_node = { path = "../ockam_node", version = "^0.38.0", default-features = f
 ockam_node_attribute = { path = "../ockam_node_attribute", version = "0.26.0" , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.35.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.34.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -69,7 +69,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.38.0"
+ockam = "0.39.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.35.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.34.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -36,7 +36,7 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false, optional = true }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
@@ -48,6 +48,6 @@ ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.31.0"}
 ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0"}
 trybuild = {version = "1.0", features = ["diff"]}
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -37,14 +37,14 @@ ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0"
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.31.0"}
 ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -33,7 +33,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchang
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
@@ -45,7 +45,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.31.0"}
 ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -46,7 +46,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0"}
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.30.0"}
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.31.0"}
 ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 trybuild = {version = "1.0", features = ["diff"]}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -30,7 +30,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_key_exch
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_core/alloc",  "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -47,7 +47,7 @@ tracing = { version = "0.1", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.30.0"}
-ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.3.0"}
+ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 trybuild = {version = "1.0", features = ["diff"]}
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -34,7 +34,7 @@ ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = f
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.37.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -32,7 +32,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchang
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -35,7 +35,7 @@ ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , d
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false, optional = true }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false, optional = true }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.34.0"
+ockam_channel = "0.35.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.39.0 - 2021-11-15
+### Changed
+- fix `no_std` breakage
+- Dependencies updated
+
 ## v0.38.0 - 2021-11-08
 ### Added
 - add proc macro to auto derive `AsyncTryClone` trait

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.38.0"
+version = "0.39.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.38.0"
+ockam_core = "0.39.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.38.0" , default-features = false }
+ockam_core = { version = "0.39.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.29.0 - 2021-11-15
+### Changed
+- Dependencies updated
+- change `Doesnt` to `DoesNot` for enum variants
+
 ## v0.28.0 - 2021-11-08
 ### Changed
 - replace `AsyncTryClone` trait impls with `#[derive(AsyncTryClone)]` wherever applicable

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -37,7 +37,7 @@ alloc = ["ockam_core/alloc","ockam_channel/alloc", "ockam_key_exchange_core/allo
 credentials = [ "ockam_vault/bls", "ockam_vault_core/bls", "signature_core", "signature_bbs_plus", "signature_bls", "bls12_381_plus"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default-features = false  }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = false  }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.37.0", default-features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -41,7 +41,7 @@ ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = f
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.38.0", default-features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default-features = false }
-ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0", default-features = false, optional = true}
+ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.31.0", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.33.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.35.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default-features = false, optional = true}
@@ -64,6 +64,6 @@ tracing = { version = "0.1", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}
 ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0"}
 rand_xorshift = "0"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -45,7 +45,7 @@ ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0",
 ockam_vault = {path = "../ockam_vault", version = "^0.32.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.35.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default-features = false, optional = true}
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -40,7 +40,7 @@ credentials = [ "ockam_vault/bls", "ockam_vault_core/bls", "signature_core", "si
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = false  }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.38.0", default-features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default-features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.33.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.35.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -62,7 +62,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}
-ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.3.0"}
+ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 rand_xorshift = "0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -39,7 +39,7 @@ credentials = [ "ockam_vault/bls", "ockam_vault_core/bls", "signature_core", "si
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default-features = false  }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
-ockam_node = {path = "../ockam_node", version = "^0.37.0", default-features = false }
+ockam_node = {path = "../ockam_node", version = "^0.38.0", default-features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.32.0", default-features = false, optional = true}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_entity"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -43,7 +43,7 @@ ockam_node = {path = "../ockam_node", version = "^0.38.0", default-features = fa
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.32.0", default-features = false, optional = true}
-ockam_channel = {path = "../ockam_channel", version = "^0.34.0", default-features = false }
+ockam_channel = {path = "../ockam_channel", version = "^0.35.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default-features = false, optional = true}
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -44,7 +44,7 @@ ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default-
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.32.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.35.0", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.31.0", default-features = false, optional = true}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default-features = false, optional = true}
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -42,7 +42,7 @@ ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , d
 ockam_node = {path = "../ockam_node", version = "^0.38.0", default-features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.30.0", default-features = false, optional = true}
-ockam_vault = {path = "../ockam_vault", version = "^0.32.0", default-features = false, optional = true}
+ockam_vault = {path = "../ockam_vault", version = "^0.33.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.35.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.32.0", default-features = false, optional = true}
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default-features = false }
@@ -63,7 +63,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}
 ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 rand_xorshift = "0"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_entity/README.md
+++ b/implementations/rust/ockam/ockam_entity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_entity = "0.28.0"
+ockam_entity = "0.29.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.8.0 - 2021-11-15
+### Changed
+- add warn log macro to no_std
+- avoid deadlocking the ockam_executor
+- Dependencies updated
+
 ## v0.7.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = ["std"]

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -28,6 +28,6 @@ no_std  = ["ockam_core/no_std"]
 crossbeam-queue = { version = "0.3.2", default_features = false, features = ["alloc"] }
 futures = { version = "0.3.15", default-features = false, features = [ "async-await" ] }
 heapless = { version = "0.7", features = [ "mpmc_large" ] }
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_executor = "0.7.0"
+ockam_executor = "0.8.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.30.0 - 2021-11-15
+### Changed
+- change `Doesnt` to `DoesNot` for enum variants
+- Dependencies updated
+
 ## v0.29.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -21,7 +21,7 @@ bls = ["ockam_vault_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0"}
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 lazy_static = "1.4"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 bls = ["ockam_vault_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0"}
+ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -22,7 +22,7 @@ bls = ["ockam_vault_core/bls"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 lazy_static = "1.4"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -23,6 +23,6 @@ bls = ["ockam_vault_core/bls"]
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0"}
 lazy_static = "1.4"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam-ffi = "0.29.0"
+ockam-ffi = "0.30.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.31.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.30.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -26,6 +26,6 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -27,5 +27,5 @@ alloc = ["ockam_core/alloc", "ockam_vault_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.30.0"
+ockam_key_exchange_core = "0.31.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.31.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.30.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -34,5 +34,5 @@ arrayref = "0.3"
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -28,7 +28,7 @@ alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_key_exchange_core/
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
-ockam_vault_core = { path = "../ockam_vault_core" , version = "^0.32.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core" , version = "^0.33.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.31.0", default_features = false }
 arrayref = "0.3"
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_key_exchange_core/
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core" , version = "^0.32.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.30.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.31.0", default_features = false }
 arrayref = "0.3"
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -27,7 +27,7 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "ockam_key_exchange_co
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core" , version = "^0.32.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.30.0", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -33,6 +33,6 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.
 arrayref = "0.3"
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,4 +35,4 @@ arrayref = "0.3"
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
-ockam_node = { path = "../ockam_node" , version = "^0.37.0"}
+ockam_node = { path = "../ockam_node" , version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.30.0"
+ockam_key_exchange_x3dh = "0.31.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.32.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.31.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -34,4 +34,4 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
-ockam_node = { path = "../ockam_node" , version = "^0.37.0"}
+ockam_node = { path = "../ockam_node" , version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -27,7 +27,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std", "ockam_vault_co
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_vault_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -33,5 +33,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -28,7 +28,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_vault_core/
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_vault_core/
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.30.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -32,6 +32,6 @@ ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.31.0", default_features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.30.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.31.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.31.0"
+ockam_key_exchange_xx = "0.32.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.38.0 - 2021-11-15
+### Changed
+- change `Doesnt` to `DoesNot` for enum variants
+- Dependencies updated
+
 ## v0.37.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc", "ockam_node_no_std/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 tokio = {version = "1.8", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"]}
 tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }
 heapless = { version = "0.7", features = [ "mpmc_large" ], optional = true }
 ockam_node_no_std = { path = "../ockam_node_no_std", version = "0.12.0" , default-features = false, optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.7.0", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.8.0", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "arm")'.dependencies]
 # TODO replace cortex-m-semihosting with 'log'

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "cryptography", "network-programming", "encryption"]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.37.0"
+version = "0.38.0"
 
 [features]
 default = ["std"]

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.37.0"
+ockam_node = "0.38.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node_test_attribute/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node_test_attribute/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.0 - 2021-11-15
+### Changed
+- fix unused variable warning in ockam_node_test_attribute
+- Dependencies updated
+
 ## v0.3.0 - 2021-11-08
 ### Added
 - add hygiene module

--- a/implementations/rust/ockam/ockam_node_test_attribute/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_test_attribute/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_node_test_attribute"
 categories = ["cryptography", "asynchronous", "authentication","network-programming"]
 authors = ["Ockam Developers"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"

--- a/implementations/rust/ockam/ockam_node_test_attribute/README.md
+++ b/implementations/rust/ockam/ockam_node_test_attribute/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node_test_attribute = "0.3.0"
+ockam_node_test_attribute = "0.4.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.13.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.12.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -39,5 +39,5 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false  }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false  }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_core = "0.12.0"
+ockam_transport_core = "0.13.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.34.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.33.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -25,7 +25,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
-ockam_node = { path = "../ockam_node", version = "^0.37.0"}
+ockam_node = { path = "../ockam_node", version = "^0.38.0"}
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.12.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -37,4 +37,4 @@ tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }
-ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.3.0"}
+ockam_node_test_attribute = { path = "../ockam_node_test_attribute", version = "^0.4.0"}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -27,7 +27,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_node = { path = "../ockam_node", version = "^0.38.0"}
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.12.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.13.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }
 futures = "0.3.10"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -24,7 +24,7 @@ std = []
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0"}
+ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_node = { path = "../ockam_node", version = "^0.37.0"}
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.12.0"}

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.33.0"
+ockam_transport_tcp = "0.34.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.28.0 - 2021-11-15
+### Changed
+- change `WebSocket` address type constant from 2 to 3
+- Dependencies updated
+
 ## v0.27.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -27,7 +27,7 @@ alloc = []
 [dependencies]
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
-ockam_core = { path = "../ockam_core", version = "^0.38.0"}
+ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_node = { path = "../ockam_node", version = "^0.37.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.12.0"}
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -28,7 +28,7 @@ alloc = []
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
-ockam_node = { path = "../ockam_node", version = "^0.37.0"}
+ockam_node = { path = "../ockam_node", version = "^0.38.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.12.0"}
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -29,7 +29,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
 ockam_core = { path = "../ockam_core", version = "^0.39.0"}
 ockam_node = { path = "../ockam_node", version = "^0.38.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.12.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.13.0"}
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.27.0"
+ockam_transport_websocket = "0.28.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.33.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.32.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -51,6 +51,6 @@ cfg-if = "1.0"
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.27.0"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.28.0"}
 ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.28.0"          }
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.32.0"
+version = "0.33.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -31,7 +31,7 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "rand_pcg", "x25519-da
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc",  "aes-gcm/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 signature_core = { path = "../signature_core", version = "0.29.0" , optional = true     }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -33,7 +33,7 @@ alloc = ["ockam_core/alloc", "ockam_vault_core/alloc",  "aes-gcm/alloc"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default-features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false }
 signature_core = { path = "../signature_core", version = "0.29.0" , optional = true     }
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "0.29.0" , optional = true     }
 signature_bls = { path = "../signature_bls", version = "0.27.0" , optional = true     }

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.32.0"
+ockam_vault = "0.33.0"
 ```
 
 ## Crate Features

--- a/implementations/rust/ockam/ockam_vault_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_core/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.33.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
+
 ## v0.32.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -28,7 +28,7 @@ no_std = ["ockam_core/no_std", "heapless"]
 alloc = ["ockam_core/alloc", "serde/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 heapless = { version = "0.7", features = ["serde"], optional = true }
 serde = {version = "1.0", default-features = false, features = ["derive"]}
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam_vault_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_core"
-version = "0.32.0"
+version = "0.33.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_core = "0.32.0"
+ockam_vault_core = "0.33.0"
 ```
 
 ## Crate Features
@@ -30,7 +30,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault_core = { version = "0.32.0" , default-features = false }
+ockam_vault_core = { version = "0.33.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.31.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.30.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -33,7 +33,7 @@ ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = f
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.37.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = ["sync"], optional = true}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -31,7 +31,7 @@ alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_vault/alloc", "ock
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
-ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
+ockam_vault_core = { path = "../ockam_vault_core", version = "^0.33.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = ["sync"], optional = true}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -32,7 +32,7 @@ alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_vault/alloc", "ock
 ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.38.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = ["sync"], optional = true}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -42,6 +42,6 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.32.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
 ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.27.0"}
 ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.28.0"          }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -29,7 +29,7 @@ no_std = ["ockam_core/no_std", "ockam_vault_core/no_std", "ockam_vault/no_std", 
 alloc = ["ockam_core/alloc", "ockam_vault_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.38.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.39.0", default_features = false }
 ockam_message_derive = { path = "../ockam_message_derive", version = "0.1.0" , default_features = false }
 ockam_vault_core = { path = "../ockam_vault_core", version = "^0.32.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.32.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -43,5 +43,5 @@ rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.33.0"}
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.27.0"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.28.0"}
 ockam_vault_test_attribute = { path = "../ockam_vault_test_attribute", version = "0.28.0"          }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_sync_core"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_sync_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_sync_core = "0.30.0"
+ockam_vault_sync_core = "0.31.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this crate will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.28.0 - 2021-11-15
+### Changed
+- Dependencies updated
+
 ## v0.27.0 - 2021-11-08
 ### Changed
 - Dependencies updated

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -13,6 +13,6 @@ homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault_test_suite"
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "^0.38.0"}
+ockam_core = {path = "../ockam_core", version = "^0.39.0"}
 ockam_vault_core = {path = "../ockam_vault_core", version = "^0.32.0"}
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -3,7 +3,7 @@ name = "ockam_vault_test_suite"
 categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded"]
 description = """Ockam Vault test suite.
 """
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -14,5 +14,5 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 
 [dependencies]
 ockam_core = {path = "../ockam_core", version = "^0.39.0"}
-ockam_vault_core = {path = "../ockam_vault_core", version = "^0.32.0"}
+ockam_vault_core = {path = "../ockam_vault_core", version = "^0.33.0"}
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault_test_suite/README.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_test_suite = "0.27.0"
+ockam_vault_test_suite = "0.28.0"
 ```
 
 ## License


### PR DESCRIPTION
- ci: ockam_core crate release 0.39.0
- ci: ockam_executor crate release 0.8.0
- ci: ockam_entity crate release 0.29.0
- ci: ockam_node crate release 0.38.0
- ci: ockam-ffi crate release 0.30.0
- ci: ockam_transport_websocket crate release 0.28.0
- ci: ockam crate release 0.39.0
- ci: ockam_node_test_attribute crate release 0.4.0
- ci: ockam_channel crate release 0.35.0
- ci: ockam_key_exchange_core crate release 0.31.0
- ci: ockam_key_exchange_x3dh crate release 0.31.0
- ci: ockam_key_exchange_xx crate release 0.32.0
- ci: ockam_transport_core crate release 0.13.0
- ci: ockam_transport_tcp crate release 0.34.0
- ci: ockam_vault crate release 0.33.0
- ci: ockam_vault_core crate release 0.33.0
- ci: ockam_vault_sync_core crate release 0.31.0
- ci: ockam_vault_test_suite crate release 0.28.0
- ci: readme and changelog updates for nov 15 release
