### PR TITLE
docs(rust): Fix doc comment for `Initiator` and `Responder`

### DIFF
--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
@@ -20,8 +20,8 @@ enum InitiatorState {
     Done,
 }
 
-/// The responder of X3DH receives a prekey bundle and computes the shared secret
-/// to communicate the first message to the initiator
+/// The initiator of X3DH receives a prekey bundle and computes the shared secret
+/// to communicate the first message to the responder
 pub struct Initiator<V: X3dhVault> {
     identity_key: Option<Secret>,
     ephemeral_identity_key: Option<Secret>,


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->

Please let me know if I've missed something, or we can improve the comment. Found this what seems like a typo while going through the code today and understanding how X3DH works.