### PR TITLE
chore(rust): deny warnings in ci, not local development

### DIFF
--- a/.github/workflows/cargo_update_check.yml
+++ b/.github/workflows/cargo_update_check.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Update and Check Ockam Example
         working-directory: examples/rust/get_started
+        env:
+          RUSTFLAGS: -Dwarnings
         run: |
           rm -rf Cargo.lock
           cargo update

--- a/.github/workflows/ockam_features_check.yml
+++ b/.github/workflows/ockam_features_check.yml
@@ -28,6 +28,8 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-
 
       - name: Check Ockam no_std
+        env:
+          RUSTFLAGS: -Dwarnings
         run: |
           cd implementations/rust/ockam/ockam
           cargo check --no-default-features --features "no_std alloc software_vault"

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -1,13 +1,12 @@
 //! Ockam is a library for building devices that communicate securely, privately
 //! and trustfully with cloud services and other devices.
-#![deny(
-  //  missing_docs, // not compatible with big_array
+#![deny(unsafe_code)]
+#![warn(
+    // missing_docs // not compatible with big_array
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_channel/src/lib.rs
+++ b/implementations/rust/ockam/ockam_channel/src/lib.rs
@@ -5,14 +5,13 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -5,14 +5,13 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -1,14 +1,13 @@
 //! Entity is an abstraction over Profiles and Vaults, easing the use of these primitives in
 //! authentication and authorization APIs.
-#![deny(
-  // prevented by big_array
-  //  missing_docs,
+#![deny(unsafe_code)]
+#![warn(
+    // prevented by big_array
+    //  missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_executor/src/channel.rs
+++ b/implementations/rust/ockam/ockam_executor/src/channel.rs
@@ -21,7 +21,7 @@ pub fn channel<T>(_size: usize) -> (Sender<T>, Receiver<T>) {
 
 fn channel_with_queue<T>(queue: Queue<T>) -> (Sender<T>, Receiver<T>) {
     let inner = Arc::new(Inner {
-        queue: queue,
+        queue,
         wake_sender: AtomicWaker::new(),
         wake_receiver: AtomicWaker::new(),
         sender_count: AtomicUsize::new(1),
@@ -67,7 +67,7 @@ impl<T: core::fmt::Debug> Sender<T> {
                         self.0.is_sender_closed.swap(true, Ordering::AcqRel);
                         self.0.wake_receiver.wake();
                     }
-                    self.0.wake_sender.register(&context.waker());
+                    self.0.wake_sender.register(context.waker());
                     Poll::Pending
                 }
             }
@@ -118,7 +118,7 @@ impl<T: core::fmt::Debug> Receiver<T> {
                 Poll::Ready(Some(value))
             }
             None => {
-                self.0.wake_receiver.register(&context.waker());
+                self.0.wake_receiver.register(context.waker());
                 if self.0.is_sender_closed.load(Ordering::Acquire) {
                     Poll::Ready(None)
                 } else {

--- a/implementations/rust/ockam/ockam_executor/src/executor.rs
+++ b/implementations/rust/ockam/ockam_executor/src/executor.rs
@@ -139,6 +139,12 @@ impl<'a> Executor<'a> {
     }
 }
 
+impl<'a> Default for Executor<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // - Task ---------------------------------------------------------------------
 
 type Task = Node<dyn Future<Output = ()> + 'static>;
@@ -163,8 +169,7 @@ where
             let futurep = self.future.get() as *mut F;
             &mut (*futurep)
         };
-        let result = unsafe { Pin::new_unchecked(future).poll(context) };
-        result
+        unsafe { Pin::new_unchecked(future).poll(context) }
     }
 }
 
@@ -197,7 +202,8 @@ impl TaskId {
 
 struct NodeWaker;
 impl NodeWaker {
-    fn new(task_id: TaskId) -> Waker {
+    #[allow(clippy::new_ret_no_self)]
+    fn new(_task_id: TaskId) -> Waker {
         Waker::from(Arc::new(NodeWaker {}))
     }
 }

--- a/implementations/rust/ockam/ockam_executor/src/lib.rs
+++ b/implementations/rust/ockam/ockam_executor/src/lib.rs
@@ -6,17 +6,15 @@
 //!
 //! The ockam_node crate re-exports types defined in this crate when the 'std'
 //! feature is not enabled.
-#![allow(
+#![warn(
     //missing_docs,
     //trivial_casts,
     trivial_numeric_casts,
-    //unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(unused_imports)]
+#![allow(unused_imports, clippy::new_ret_no_self)]
 
 #[cfg(feature = "std")]
 #[allow(unused_imports)]

--- a/implementations/rust/ockam/ockam_executor/src/oneshot.rs
+++ b/implementations/rust/ockam/ockam_executor/src/oneshot.rs
@@ -28,7 +28,7 @@ pub fn channel<T>() -> (SyncSender<T>, Receiver<T>) {
 
 fn channel_with_queue<T>(queue: Queue<T>) -> (SyncSender<T>, Receiver<T>) {
     let sender = Arc::new(Inner {
-        queue: queue,
+        queue,
         wake_sender: AtomicWaker::new(),
         wake_receiver: AtomicWaker::new(),
         sender_count: AtomicUsize::new(1),
@@ -136,7 +136,7 @@ impl<T> Future for Receiver<T> {
                 Poll::Ready(Ok(value))
             }
             None => {
-                self.0.wake_receiver.register(&context.waker());
+                self.0.wake_receiver.register(context.waker());
                 if self.0.is_sender_closed.load(Ordering::Acquire) {
                     panic!("called after complete");
                 } else {

--- a/implementations/rust/ockam/ockam_executor/src/runtime.rs
+++ b/implementations/rust/ockam/ockam_executor/src/runtime.rs
@@ -99,6 +99,12 @@ impl<T: Send> JoinHandle<T> {
     }
 }
 
+impl<T: Send> Default for JoinHandle<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// yield_now
 pub async fn yield_now() {
     #[allow(dead_code)]

--- a/implementations/rust/ockam/ockam_ffi/src/lib.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/lib.rs
@@ -1,11 +1,10 @@
 //! Ockam Vault Foreign Function Interface (FFI) for library integration.
-#![deny(
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 

--- a/implementations/rust/ockam/ockam_key_exchange_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_core/src/lib.rs
@@ -5,14 +5,13 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -5,14 +5,13 @@
 //! Ockam library.
 //!
 //! The main Ockam crate re-exports types defined in this crate.
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -1,10 +1,10 @@
 //! ockam_node - Ockam Node API
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     dead_code,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
     unused_qualifications
 )]

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -5,15 +5,13 @@
 //! the input function inside the node.
 //!
 //! The main Ockam crate re-exports this macro.
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 
 extern crate proc_macro;

--- a/implementations/rust/ockam/ockam_node_test_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_test_attribute/src/lib.rs
@@ -9,12 +9,12 @@
 //! the input function inside the node.
 
 #![allow(clippy::unnecessary_wraps)]
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     dead_code,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
     unused_qualifications
 )]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -8,13 +8,12 @@
 //! You can use Ockam's routing mechanism for cryptographic protocols,
 //! key lifecycle, credential exchange, enrollment, etc, without having
 //! to worry about the transport specifics.
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     dead_code,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
     unused_qualifications
 )]

--- a/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
@@ -9,14 +9,14 @@
 //! key lifecycle, credetial exchange, enrollment, etc, without having
 //! to worry about the transport specifics.
 //!
-#![deny(
-// missing_docs,
-dead_code,
-trivial_casts,
-trivial_numeric_casts,
-unsafe_code,
-unused_import_braces,
-unused_qualifications
+#![deny(unsafe_code)]
+#![warn(
+    // missing_docs,
+    dead_code,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_qualifications
 )]
 
 #[macro_use]

--- a/implementations/rust/ockam/ockam_vault/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault/src/lib.rs
@@ -2,15 +2,13 @@
 //!
 //! This crate contains one of the possible implementation of the vault traits
 //! which you can use with Ockam library.
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_vault_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault_core/src/lib.rs
@@ -3,15 +3,13 @@
 //! This crate contains the core types and traits of the Ockam vault and is intended
 //! for use by other crates that either provide implementations for those traits,
 //! or use traits and types as an abstract dependency.
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/lib.rs
@@ -3,15 +3,13 @@
 //! This crate contains the core types and traits of the Ockam vault and is intended
 //! for use by other crates that either provide implementations for those traits,
 //! or use traits and types as an abstract dependency.
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/signature_bbs_plus/src/lib.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/lib.rs
@@ -1,12 +1,11 @@
 //!
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     // TODO restore missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/signature_bls/src/lib.rs
+++ b/implementations/rust/ockam/signature_bls/src/lib.rs
@@ -12,14 +12,13 @@
 //!
 //! but provides some optimizations when an allocator exists for verifying
 //! aggregated signatures.
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/signature_bls/src/secret_key.rs
+++ b/implementations/rust/ockam/signature_bls/src/secret_key.rs
@@ -86,6 +86,7 @@ impl SecretKey {
 
     /// Secret share this key by creating `N` shares where `T` are required
     /// to combine back into this secret
+    #[allow(unsafe_code)] // TODO
     pub fn split<R: RngCore + CryptoRng, const T: usize, const N: usize>(
         &self,
         rng: &mut R,

--- a/implementations/rust/ockam/signature_core/src/lib.rs
+++ b/implementations/rust/ockam/signature_core/src/lib.rs
@@ -1,12 +1,10 @@
 //! A crate for common methods used by short group signatures
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/signature_ps/src/lib.rs
+++ b/implementations/rust/ockam/signature_ps/src/lib.rs
@@ -1,15 +1,13 @@
 //! This crate implements the Pointcheval Saunders signature
 //! as described in <https://eprint.iacr.org/2015/525.pdf>
 //! and <https://eprint.iacr.org/2017/1197.pdf>
-
-#![deny(
+#![deny(unsafe_code)]
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
-    unused_qualifications,
-    warnings
+    unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Right now in the rust code, if there's a compiler warning during local development, the build will fail to complete. This is inconvenient, since *really*, we only care about this stuff when *landing* code in the repo. As a result, this PR moves these checks entirely into CI (where they already existed, for the most part, although I firmed that up).

The exception to this the `unsafe_code` lint, which is reported by various tooling, and isn't *really* in the same category as other lints. This one is kept as deny in the crates that can use it (although perhaps it should be increased to `#![forbid]` in the future).

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.
