### PR TITLE
Fix all the linting problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,19 +320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits 0.2.14",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,16 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits 0.2.14",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,7 +1519,6 @@ dependencies = [
  "log",
  "ockam",
  "serde 1.0.130",
- "stderrlog",
  "thiserror",
 ]
 
@@ -2659,19 +2635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stderrlog"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
-dependencies = [
- "atty",
- "chrono",
- "log",
- "termcolor",
- "thread_local",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,16 +2793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_channel/src/lib.rs
+++ b/implementations/rust/ockam/ockam_channel/src/lib.rs
@@ -49,17 +49,17 @@ mod tests {
 
     #[ockam_node_test_attribute::node_test]
     async fn simplest_channel(ctx: &mut Context) -> Result<()> {
-        let vault_sync = VaultSync::create(&ctx, SoftwareVault::default()).await?;
+        let vault_sync = VaultSync::create(ctx, SoftwareVault::default()).await?;
         let new_key_exchanger = XXNewKeyExchanger::new(vault_sync.async_try_clone().await?);
         SecureChannel::create_listener_extended(
-            &ctx,
+            ctx,
             "secure_channel_listener".to_string(),
             new_key_exchanger.async_try_clone().await?,
             vault_sync.async_try_clone().await?,
         )
         .await?;
         let initiator = SecureChannel::create_extended(
-            &ctx,
+            ctx,
             Route::new().append("secure_channel_listener"),
             None,
             new_key_exchanger.initiator().await?,

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_command"
 version = "0.1.0"
 edition = "2021"
-
+license = "Apache-2.0"
 
 [[bin]]
 name = "ockam"
@@ -20,5 +20,8 @@ indicatif = "0.16.2"
 log = "0.4.14"
 ockam = { version = "0.39.0", path = "../ockam" }
 serde = "1.0.130"
-stderrlog = "0.5.1"
+# FIXME: stderrlog depends on chrono, triggers:
+# - https://rustsec.org/advisories/RUSTSEC-2020-0159
+# - https://rustsec.org/advisories/RUSTSEC-2020-0071
+# stderrlog = "0.5.1"
 thiserror = "1.0.30"

--- a/implementations/rust/ockam/ockam_command/src/bin/ockam.rs
+++ b/implementations/rust/ockam/ockam_command/src/bin/ockam.rs
@@ -1,4 +1,4 @@
-use human_panic::setup_panic;
+// use human_panic::setup_panic;
 use log::{debug, info, trace, warn};
 use ockam_command::{config::AppConfig, console::Console, AppError};
 use std::time::Duration;
@@ -15,7 +15,7 @@ struct App {
 impl Default for App {
     fn default() -> Self {
         Self::load_environment();
-        Self::init_logging();
+        // Self::init_logging();
 
         Self {
             console: Console::default(),
@@ -29,6 +29,10 @@ impl App {
         dotenv::dotenv().ok();
     }
 
+    // FIXME: stderrlog depends on chrono, triggers:
+    // - https://rustsec.org/advisories/RUSTSEC-2020-0159
+    // - https://rustsec.org/advisories/RUSTSEC-2020-0071
+    #[cfg(any())]
     pub fn init_logging() {
         setup_panic!();
 

--- a/implementations/rust/ockam/ockam_command/src/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/config.rs
@@ -1,4 +1,4 @@
-use crate::command::{CommandResult};
+use crate::command::CommandResult;
 use crate::AppError;
 
 pub struct AppConfig {}
@@ -13,42 +13,42 @@ impl AppConfig {
     pub fn evaluate() -> Result<CommandResult, AppError> {
         Err(AppError::Unknown)
 
-    /*
-        let mut config = config::Config::default();
-        let yaml = load_yaml!("cli.yml");
-        let args = App::from_yaml(yaml).get_matches();
+        /*
+            let mut config = config::Config::default();
+            let yaml = load_yaml!("cli.yml");
+            let args = App::from_yaml(yaml).get_matches();
 
-        let config_file = args.value_of(CONFIG_ARG);
+            let config_file = args.value_of(CONFIG_ARG);
 
-        if let Some(config_file) = config_file {
-            if config.merge(config::File::with_name(config_file)).is_ok() {
-                debug!("Loaded settings from {} config file", config_file)
+            if let Some(config_file) = config_file {
+                if config.merge(config::File::with_name(config_file)).is_ok() {
+                    debug!("Loaded settings from {} config file", config_file)
+                } else {
+                    warn!("Unable to load settings from {}", config_file)
+                }
             } else {
-                warn!("Unable to load settings from {}", config_file)
+                warn!("No config file specified.")
             }
-        } else {
-            warn!("No config file specified.")
-        }
 
-        let secrets_file = args.value_of(SECRETS_ARG);
+            let secrets_file = args.value_of(SECRETS_ARG);
 
-        if let Some(secrets_file) = secrets_file {
-            if config.merge(config::File::with_name(secrets_file)).is_ok() {
-                debug!("Loaded secrets from {} secrets file.", secrets_file)
+            if let Some(secrets_file) = secrets_file {
+                if config.merge(config::File::with_name(secrets_file)).is_ok() {
+                    debug!("Loaded secrets from {} secrets file.", secrets_file)
+                } else {
+                    warn!("Unable to load secrets from {}", secrets_file)
+                }
             } else {
-                warn!("Unable to load secrets from {}", secrets_file)
+                debug!("No secrets file specified.")
             }
-        } else {
-            debug!("No secrets file specified.")
-        }
 
-        config
-            .merge(config::Environment::with_prefix(OCKAM_ENV_PREFIX))
-            .ok();
+            config
+                .merge(config::Environment::with_prefix(OCKAM_ENV_PREFIX))
+                .ok();
 
-        let (command_name, command_args) = args.subcommand();
-        let mut command: Command = command_name.parse()?;
-        command.run(command_args)
-    */
+            let (command_name, command_args) = args.subcommand();
+            let mut command: Command = command_name.parse()?;
+            command.run(command_args)
+        */
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/console.rs
+++ b/implementations/rust/ockam/ockam_command/src/console.rs
@@ -1,13 +1,8 @@
 use crate::AppError;
 use log::*;
 
+#[derive(Default)]
 pub struct Console;
-
-impl Default for Console {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl Console {
     pub fn error(&self, error: &AppError) {

--- a/implementations/rust/ockam/ockam_entity/src/authentication.rs
+++ b/implementations/rust/ockam/ockam_entity/src/authentication.rs
@@ -65,12 +65,12 @@ mod test {
     }
 
     async fn test_auth_use_case(ctx: &Context) -> ockam_core::Result<()> {
-        let alice_vault = Vault::create(&ctx).await.expect("failed to create vault");
-        let bob_vault = Vault::create(&ctx).await.expect("failed to create vault");
+        let alice_vault = Vault::create(ctx).await.expect("failed to create vault");
+        let bob_vault = Vault::create(ctx).await.expect("failed to create vault");
 
         // Alice and Bob are distinct Entities.
-        let mut alice = Entity::create(&ctx, &alice_vault).await?;
-        let mut bob = Entity::create(&ctx, &bob_vault).await?;
+        let mut alice = Entity::create(ctx, &alice_vault).await?;
+        let mut bob = Entity::create(ctx, &bob_vault).await?;
 
         // Alice and Bob create unique profiles for a Chat app.
         let mut alice_chat = alice.create_profile(&alice_vault).await?;
@@ -123,12 +123,12 @@ mod test {
     }
 
     async fn test_key_rotation(ctx: &Context) -> ockam_core::Result<()> {
-        let alice_vault = Vault::create(&ctx).await.expect("failed to create vault");
-        let bob_vault = Vault::create(&ctx).await.expect("failed to create vault");
+        let alice_vault = Vault::create(ctx).await.expect("failed to create vault");
+        let bob_vault = Vault::create(ctx).await.expect("failed to create vault");
 
         // Alice and Bob are distinct Entities.
-        let mut alice = Entity::create(&ctx, &alice_vault).await?;
-        let mut bob = Entity::create(&ctx, &bob_vault).await?;
+        let mut alice = Entity::create(ctx, &alice_vault).await?;
+        let mut bob = Entity::create(ctx, &bob_vault).await?;
 
         // Alice and Bob create unique profiles for a Chat app.
         let mut alice_chat = alice.create_profile(&alice_vault).await?;
@@ -161,11 +161,11 @@ mod test {
     }
 
     async fn test_update_contact_and_reprove(ctx: &Context) -> ockam_core::Result<()> {
-        let alice_vault = Vault::create(&ctx).await.expect("failed to create vault");
-        let bob_vault = Vault::create(&ctx).await.expect("failed to create vault");
+        let alice_vault = Vault::create(ctx).await.expect("failed to create vault");
+        let bob_vault = Vault::create(ctx).await.expect("failed to create vault");
 
-        let mut alice = Entity::create(&ctx, &alice_vault).await?;
-        let mut bob = Entity::create(&ctx, &bob_vault).await?;
+        let mut alice = Entity::create(ctx, &alice_vault).await?;
+        let mut bob = Entity::create(ctx, &bob_vault).await?;
 
         // Alice and Bob create unique profiles for a Chat app.
         let mut alice_chat = alice.create_profile(&alice_vault).await?;

--- a/implementations/rust/ockam/ockam_entity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_entity/src/channel.rs
@@ -45,11 +45,11 @@ mod test {
 
     #[ockam_node_test_attribute::node_test]
     async fn test_channel(ctx: &mut Context) -> Result<()> {
-        let alice_vault = Vault::create(&ctx).await.expect("failed to create vault");
-        let bob_vault = Vault::create(&ctx).await.expect("failed to create vault");
+        let alice_vault = Vault::create(ctx).await.expect("failed to create vault");
+        let bob_vault = Vault::create(ctx).await.expect("failed to create vault");
 
-        let mut alice = Entity::create(&ctx, &alice_vault).await?;
-        let mut bob = Entity::create(&ctx, &bob_vault).await?;
+        let mut alice = Entity::create(ctx, &alice_vault).await?;
+        let mut bob = Entity::create(ctx, &bob_vault).await?;
 
         let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().await?);
         let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().await?);
@@ -90,10 +90,10 @@ mod test {
 
     #[ockam_node_test_attribute::node_test]
     async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
-        let vault = Vault::create(&ctx).await?;
+        let vault = Vault::create(ctx).await?;
 
-        let mut alice = Entity::create(&ctx, &vault).await?;
-        let mut bob = Entity::create(&ctx, &vault).await?;
+        let mut alice = Entity::create(ctx, &vault).await?;
+        let mut bob = Entity::create(ctx, &vault).await?;
 
         let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().await?);
         let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().await?);
@@ -135,10 +135,10 @@ mod test {
 
     #[ockam_node_test_attribute::node_test]
     async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
-        let vault = Vault::create(&ctx).await?;
+        let vault = Vault::create(ctx).await?;
 
-        let mut alice = Entity::create(&ctx, &vault).await?;
-        let mut bob = Entity::create(&ctx, &vault).await?;
+        let mut alice = Entity::create(ctx, &vault).await?;
+        let mut bob = Entity::create(ctx, &vault).await?;
 
         let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().await?);
         let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().await?);
@@ -190,10 +190,10 @@ mod test {
 
     #[ockam_node_test_attribute::node_test]
     async fn test_many_times_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
-        let vault = Vault::create(&ctx).await?;
+        let vault = Vault::create(ctx).await?;
 
-        let mut alice = Entity::create(&ctx, &vault).await?;
-        let mut bob = Entity::create(&ctx, &vault).await?;
+        let mut alice = Entity::create(ctx, &vault).await?;
+        let mut bob = Entity::create(ctx, &vault).await?;
 
         let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().await?);
         let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().await?);

--- a/implementations/rust/ockam/ockam_entity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_entity/src/identifiers.rs
@@ -110,7 +110,7 @@ mod test {
         let id1 = EntityIdentifier::random();
 
         let str: String = id1.clone().into();
-        assert!(str.starts_with("P"));
+        assert!(str.starts_with('P'));
 
         let id2: EntityIdentifier = str.try_into().unwrap();
         assert_eq!(id1, id2);

--- a/implementations/rust/ockam/ockam_entity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lib.rs
@@ -221,11 +221,11 @@ mod test {
 
     #[ockam_node_test_attribute::node_test]
     async fn async_tests(ctx: &mut Context) -> Result<()> {
-        let alice_vault = Vault::create(&ctx).await.expect("failed to create vault");
-        let bob_vault = Vault::create(&ctx).await.expect("failed to create vault");
+        let alice_vault = Vault::create(ctx).await.expect("failed to create vault");
+        let bob_vault = Vault::create(ctx).await.expect("failed to create vault");
 
-        let entity_alice = Entity::create(&ctx, &alice_vault).await?;
-        let entity_bob = Entity::create(&ctx, &bob_vault).await?;
+        let entity_alice = Entity::create(ctx, &alice_vault).await?;
+        let entity_bob = Entity::create(ctx, &bob_vault).await?;
 
         let mut alice = entity_alice.current_profile().await.unwrap().unwrap();
         let mut bob = entity_bob.current_profile().await.unwrap().unwrap();

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -168,13 +168,13 @@ mod tests {
 
             assert_eq!(initiator.h(), responder.h());
 
-            let s1 = vault.secret_export(&initiator.encrypt_key()).await.unwrap();
-            let s2 = vault.secret_export(&responder.decrypt_key()).await.unwrap();
+            let s1 = vault.secret_export(initiator.encrypt_key()).await.unwrap();
+            let s2 = vault.secret_export(responder.decrypt_key()).await.unwrap();
 
             assert_eq!(s1, s2);
 
-            let s1 = vault.secret_export(&initiator.decrypt_key()).await.unwrap();
-            let s2 = vault.secret_export(&responder.encrypt_key()).await.unwrap();
+            let s1 = vault.secret_export(initiator.decrypt_key()).await.unwrap();
+            let s2 = vault.secret_export(responder.encrypt_key()).await.unwrap();
 
             assert_eq!(s1, s2);
             ctx.stop().await.unwrap();

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -104,13 +104,13 @@ mod tests {
 
             assert_eq!(initiator.h(), responder.h());
 
-            let s1 = vault.secret_export(&initiator.encrypt_key()).await.unwrap();
-            let s2 = vault.secret_export(&responder.decrypt_key()).await.unwrap();
+            let s1 = vault.secret_export(initiator.encrypt_key()).await.unwrap();
+            let s2 = vault.secret_export(responder.decrypt_key()).await.unwrap();
 
             assert_eq!(s1, s2);
 
-            let s1 = vault.secret_export(&initiator.decrypt_key()).await.unwrap();
-            let s2 = vault.secret_export(&responder.encrypt_key()).await.unwrap();
+            let s1 = vault.secret_export(initiator.decrypt_key()).await.unwrap();
+            let s2 = vault.secret_export(responder.encrypt_key()).await.unwrap();
 
             assert_eq!(s1, s2);
 

--- a/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node_attribute/src/lib.rs
@@ -63,10 +63,7 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
         {
             ctx_ident = ident;
         } else {
-            let message = format!(
-                "Expected an identifier, found `{}`",
-                quote! {#pat}.to_string()
-            );
+            let message = format!("Expected an identifier, found `{}`", quote! {#pat});
             return Error::new_spanned(pat, message).to_compile_error().into();
         };
 
@@ -107,7 +104,7 @@ pub fn node(_args: TokenStream, item: TokenStream) -> TokenStream {
         if !ctx_used {
             let message = format!(
                 "Unused `{}`. Passed `ockam::Context` should be used.",
-                &ctx_ident.to_string()
+                ctx_ident,
             );
             return Error::new_spanned(ctx_ident, message)
                 .to_compile_error()

--- a/implementations/rust/ockam/ockam_node_test_attribute/src/hygiene.rs
+++ b/implementations/rust/ockam/ockam_node_test_attribute/src/hygiene.rs
@@ -137,10 +137,7 @@ impl NodeCtx {
         let ident = match pat {
             Pat::Ident(ident) => ident,
             _ => {
-                let msg = format!(
-                    "Expected an identifier, found `{}`",
-                    quote! {#pat}.to_string()
-                );
+                let msg = format!("Expected an identifier, found `{}`", quote! {#pat});
                 return Err(Error::new_spanned(pat, msg));
             }
         };

--- a/implementations/rust/ockam/ockam_vault_test_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault_test_attribute/src/lib.rs
@@ -10,18 +10,13 @@ pub fn vault_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let original_fn = parse_macro_input!(item as ItemFn);
     let original_fn_ident = original_fn.sig.ident;
     let import_test = TokenStream::from_str(
-        format!(
-            "use ockam_vault_test_suite::{};",
-            original_fn_ident
-        )
-        .as_str(),
+        format!("use ockam_vault_test_suite::{};", original_fn_ident).as_str(),
     )
     .unwrap();
     let import_test: Stmt = syn::parse(import_test).expect("B");
-    let run_test = TokenStream::from_str(
-        format!("{}(&mut vault).await;", original_fn_ident).as_str(),
-    )
-    .unwrap();
+    let run_test =
+        TokenStream::from_str(format!("{}(&mut vault).await;", original_fn_ident).as_str())
+            .unwrap();
     let run_test: Stmt = syn::parse(run_test).expect("B");
 
     let output_function = quote! {
@@ -41,18 +36,13 @@ pub fn vault_test_sync(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let original_fn = parse_macro_input!(item as ItemFn);
     let original_fn_ident = original_fn.sig.ident;
     let import_test = TokenStream::from_str(
-        format!(
-            "use ockam_vault_test_suite::{};",
-            original_fn_ident
-        )
-        .as_str(),
+        format!("use ockam_vault_test_suite::{};", original_fn_ident).as_str(),
     )
     .unwrap();
     let import_test: Stmt = syn::parse(import_test).expect("B");
-    let run_test = TokenStream::from_str(
-        format!("{}(&mut vault).await;", original_fn_ident).as_str(),
-    )
-    .unwrap();
+    let run_test =
+        TokenStream::from_str(format!("{}(&mut vault).await;", original_fn_ident).as_str())
+            .unwrap();
     let run_test: Stmt = syn::parse(run_test).expect("B");
 
     let output_function = quote! {

--- a/implementations/rust/ockam/ockam_vault_test_attribute/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault_test_attribute/src/lib.rs
@@ -12,14 +12,14 @@ pub fn vault_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let import_test = TokenStream::from_str(
         format!(
             "use ockam_vault_test_suite::{};",
-            original_fn_ident.to_string()
+            original_fn_ident
         )
         .as_str(),
     )
     .unwrap();
     let import_test: Stmt = syn::parse(import_test).expect("B");
     let run_test = TokenStream::from_str(
-        format!("{}(&mut vault).await;", original_fn_ident.to_string()).as_str(),
+        format!("{}(&mut vault).await;", original_fn_ident).as_str(),
     )
     .unwrap();
     let run_test: Stmt = syn::parse(run_test).expect("B");
@@ -43,14 +43,14 @@ pub fn vault_test_sync(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let import_test = TokenStream::from_str(
         format!(
             "use ockam_vault_test_suite::{};",
-            original_fn_ident.to_string()
+            original_fn_ident
         )
         .as_str(),
     )
     .unwrap();
     let import_test: Stmt = syn::parse(import_test).expect("B");
     let run_test = TokenStream::from_str(
-        format!("{}(&mut vault).await;", original_fn_ident.to_string()).as_str(),
+        format!("{}(&mut vault).await;", original_fn_ident).as_str(),
     )
     .unwrap();
     let run_test: Stmt = syn::parse(run_test).expect("B");

--- a/implementations/rust/ockam/signature_bls/src/partial_signature.rs
+++ b/implementations/rust/ockam/signature_bls/src/partial_signature.rs
@@ -11,14 +11,8 @@ use subtle::Choice;
 use vsss_rs::Share;
 
 /// Represents a BLS partial signature in G1 using the proof of possession scheme
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PartialSignature(pub(crate) Share<PARTIAL_SIGNATURE_BYTES>);
-
-impl Default for PartialSignature {
-    fn default() -> Self {
-        Self(Share::default())
-    }
-}
 
 impl Display for PartialSignature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/implementations/rust/ockam/signature_bls/src/partial_signature_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/partial_signature_vt.rs
@@ -11,14 +11,8 @@ use subtle::Choice;
 use vsss_rs::Share;
 
 /// Represents a BLS partial signature in G2 using the proof of possession scheme
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PartialSignatureVt(pub(crate) Share<PARTIAL_SIGNATURE_VT_BYTES>);
-
-impl Default for PartialSignatureVt {
-    fn default() -> Self {
-        Self(Share::default())
-    }
-}
 
 impl Display for PartialSignatureVt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/implementations/rust/ockam/signature_bls/src/secret_key_share.rs
+++ b/implementations/rust/ockam/signature_bls/src/secret_key_share.rs
@@ -10,7 +10,7 @@ use zeroize::Zeroize;
 /// to produce the completed key, or used for
 /// creating partial signatures which can be
 /// combined into a complete signature
-#[derive(Clone, Debug, Zeroize)]
+#[derive(Clone, Debug, Default, Zeroize)]
 pub struct SecretKeyShare(pub Share<SECRET_KEY_SHARE_BYTES>);
 
 impl Drop for SecretKeyShare {
@@ -28,12 +28,6 @@ impl From<Share<SECRET_KEY_SHARE_BYTES>> for SecretKeyShare {
 impl<'a> From<&'a Share<SECRET_KEY_SHARE_BYTES>> for SecretKeyShare {
     fn from(share: &'a Share<SECRET_KEY_SHARE_BYTES>) -> Self {
         Self(*share)
-    }
-}
-
-impl Default for SecretKeyShare {
-    fn default() -> Self {
-        Self(Share::default())
     }
 }
 

--- a/implementations/rust/ockam/signature_ps/src/lib.rs
+++ b/implementations/rust/ockam/signature_ps/src/lib.rs
@@ -9,6 +9,7 @@
     unused_import_braces,
     unused_qualifications
 )]
+#![allow(clippy::question_mark)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]

--- a/tools/docs/example_blocks/src/main.rs
+++ b/tools/docs/example_blocks/src/main.rs
@@ -7,7 +7,7 @@ fn print_file(file: &str) {
     let file = format!("{}/{}", examples, file);
 
     let err = format!("Can't find example source {}", file);
-    let mut file = File::open(file).expect(err.as_str());
+    let mut file = File::open(file).unwrap_or_else(|_| { panic!("{}", err) });
 
     let mut content = String::new();
     file.read_to_string(&mut content).expect("short read");
@@ -15,9 +15,7 @@ fn print_file(file: &str) {
 }
 
 fn main() {
-    let file: String = std::env::args()
-        .skip(1)
-        .next()
+    let file: String = std::env::args().nth(1)
         .expect("missing file argument");
 
     let file = File::open(file).expect("unable to open file");
@@ -40,7 +38,7 @@ fn main() {
                     println!("{}", line);
                     if example_start {
                         in_example = true;
-                        let example_name = line.split("/").last().expect("no example filename");
+                        let example_name = line.split('/').last().expect("no example filename");
                         print_file(example_name);
                     }
                 }

--- a/tools/docs/example_blocks/src/main.rs
+++ b/tools/docs/example_blocks/src/main.rs
@@ -7,7 +7,7 @@ fn print_file(file: &str) {
     let file = format!("{}/{}", examples, file);
 
     let err = format!("Can't find example source {}", file);
-    let mut file = File::open(file).unwrap_or_else(|_| { panic!("{}", err) });
+    let mut file = File::open(file).unwrap_or_else(|_| panic!("{}", err));
 
     let mut content = String::new();
     file.read_to_string(&mut content).expect("short read");
@@ -15,8 +15,7 @@ fn print_file(file: &str) {
 }
 
 fn main() {
-    let file: String = std::env::args().nth(1)
-        .expect("missing file argument");
+    let file: String = std::env::args().nth(1).expect("missing file argument");
 
     let file = File::open(file).expect("unable to open file");
     let file = BufReader::new(file);

--- a/tools/docs/example_runner/src/main.rs
+++ b/tools/docs/example_runner/src/main.rs
@@ -124,7 +124,7 @@ fn run_stage(stage: Stage) -> Result<()> {
     }
 
     stop.store(true, Relaxed);
-    let join_handles = join_handles.clone();
+    let join_handles = join_handles;
     let mut join_handles = join_handles.lock().unwrap();
     while !join_handles.is_empty() {
         let h = join_handles.pop().unwrap();
@@ -142,9 +142,7 @@ fn run(script: Script) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let file = std::env::args()
-        .skip(1)
-        .next()
+    let file = std::env::args().nth(1)
         .expect("missing script file");
     let mut file = File::open(file).expect("unable to open script");
     let mut guide = String::new();

--- a/tools/docs/example_runner/src/main.rs
+++ b/tools/docs/example_runner/src/main.rs
@@ -96,8 +96,8 @@ fn run_stage(stage: Stage) -> Result<()> {
                 .unwrap();
             while !stop.load(Relaxed) {
                 match handle.try_wait() {
-                    Ok(maybe_output) => match maybe_output {
-                        Some(output) => {
+                    Ok(maybe_output) => {
+                        if let Some(output) = maybe_output {
                             println!(
                                 "Output: {}",
                                 String::from_utf8(output.clone().stdout).unwrap()
@@ -105,8 +105,7 @@ fn run_stage(stage: Stage) -> Result<()> {
                             finished.store(true, Relaxed);
                             break;
                         }
-                        _ => (),
-                    },
+                    }
                     Err(_) => {
                         std::process::exit(1);
                     }
@@ -142,8 +141,7 @@ fn run(script: Script) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let file = std::env::args().nth(1)
-        .expect("missing script file");
+    let file = std::env::args().nth(1).expect("missing script file");
     let mut file = File::open(file).expect("unable to open script");
     let mut guide = String::new();
 

--- a/tools/ockam-hub-cli/src/auth/github.rs
+++ b/tools/ockam-hub-cli/src/auth/github.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use std::pin::Pin;
 use webbrowser;
 
-const GITHUB_CLIENT_ID: &'static str = "609323e5ba23958cb2f5";
+const GITHUB_CLIENT_ID: &str = "609323e5ba23958cb2f5";
 
 pub async fn post(
     client: &reqwest::Client,
@@ -44,7 +44,7 @@ pub fn try_access_token<'a>(
         }
 
         println!("Access token validated!");
-        return Ok(response);
+        Ok(response)
     })
 }
 
@@ -95,7 +95,7 @@ pub async fn authenticate() -> Result<(), reqwest::Error> {
     let interval = &login_response["interval"];
     let device_code = &login_response["device_code"];
 
-    if !webbrowser::open(verification_uri).is_ok() {
+    if webbrowser::open(verification_uri).is_err() {
         println!("Error opening the browser");
     }
 

--- a/tools/ockam-hub-cli/src/auth/github.rs
+++ b/tools/ockam-hub-cli/src/auth/github.rs
@@ -22,6 +22,7 @@ pub async fn post(
     Ok(parsed_response)
 }
 
+#[allow(clippy::type_complexity)]
 pub fn try_access_token<'a>(
     client: &'a reqwest::Client,
     payload: &'a HashMap<&str, &str>,


### PR DESCRIPTION
1. Fixes `cargo fmt` errors and other fallout from #2242.
2. Fixes  #2241 (`gradlew lint` on rust code now passes).
3. Fixes (or `#[allows]` where reasonable) every clippy error in the workspace.