### PR TITLE
chore(rust): improve performance of gradle lint task

### DIFF
--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -32,7 +32,7 @@ commands {
     lint: [
       'cargo fmt --all -- --check',
       'cargo clippy --no-deps -- -D warnings',
-      'cargo doc',
+      'cargo doc --no-deps',
       'cargo deny check licenses advisories',
     ],
     veryClean: [


### PR DESCRIPTION
By not generating documentation for dependencies. Ideally we'd use `RUSTDOCFLAGS="--check"` but it isn't stable yet, and I don't know how much more it would speed things up.

Times, according to gradle:

Before (already built): `9m 2s`
Before (full rebuild): I don't know, presumably longer.

After (already built): `2m 23s`
After (full rebuild): `5m 1s`