### PR TITLE
Fix grade tasks on Windows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         # https://github.com/actions/virtual-environments#available-environments
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15] # windows-2016, windows-2019
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, windows-2016, windows-2019]
         java: [8, 11, 16]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Current Behaviour

Running `../../gradlew lint` from an implementation folder doesn't work on Windows and crashes the gradle build:
```
A problem occurred configuring root project 'rust'.
> Could not create task ':__build_ockam\ockam_0'.
   > The task name '__build_ockam\ockam_0' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]
   ```
## Proposed Changes
This PR changes up how paths are handled building the gradle tasks. Instead of using bash(sh?)-isms and hardcoding `/` as the path seperator, use the platform's separator and use platform-agnostic methods to read directory contents. This lets it work on both UNIX systems and Windows. 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository. (It is [here](https://github.com/ockam-network/contributors/pull/52))

(having a bit of a night with the commit lint, sorry)
