### PR TITLE
fix(rust): change context import from ockam_node to crate

### DIFF
--- a/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
@@ -7,10 +7,12 @@ pub use resend::{ReceiverConfirm, SenderConfirm};
 mod ordering;
 pub use ordering::ReceiverOrdering;
 
-use crate::protocols::pipe::{internal::InternalCmd, PipeMessage};
+use crate::{
+    protocols::pipe::{internal::InternalCmd, PipeMessage},
+    Context,
+};
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{async_trait, Address, Result, Route};
-use ockam_node::Context;
 
 /// Define the behavior of a pipe
 #[async_trait]

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/ordering.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/ordering.rs
@@ -1,12 +1,12 @@
 use crate::{
     pipe::{BehaviorHook, PipeModifier},
     protocols::pipe::{internal::InternalCmd, PipeMessage},
+    Context,
 };
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{
     async_trait, compat::collections::BTreeMap, Address, LocalMessage, Result, Route,
 };
-use ockam_node::Context;
 
 #[derive(Default, Clone)]
 pub struct ReceiverOrdering {

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/resend.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/resend.rs
@@ -5,10 +5,10 @@ use crate::{
         internal::{Ack, InternalCmd, Resend},
         PipeMessage,
     },
+    Context,
 };
 use ockam_core::compat::boxed::Box;
 use ockam_core::{async_trait, compat::collections::BTreeMap, Address, Result, Route};
-use ockam_node::Context;
 
 #[derive(Default, Clone)]
 pub struct SenderConfirm {

--- a/implementations/rust/ockam/ockam/src/pipe/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/mod.rs
@@ -17,9 +17,8 @@ pub use sender::PipeSender;
 #[cfg(test)]
 mod tests;
 
-use crate::protocols::pipe::PipeMessage;
+use crate::{protocols::pipe::PipeMessage, Context};
 use ockam_core::{Address, LocalMessage, Result, Route};
-use ockam_node::Context;
 
 const CLUSTER_NAME: &str = "_internal.pipe";
 

--- a/implementations/rust/ockam/ockam/src/pipe/receiver.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/receiver.rs
@@ -1,10 +1,10 @@
 use crate::{
     pipe::{PipeBehavior, PipeModifier},
     protocols::pipe::{internal::InternalCmd, PipeMessage},
+    Context,
 };
 use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Any, Decodable, Result, Routed, Worker};
-use ockam_node::Context;
 
 pub struct PipeReceiver {
     hooks: PipeBehavior,

--- a/implementations/rust/ockam/ockam/src/pipe/sender.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/sender.rs
@@ -2,10 +2,10 @@ use crate::{
     monotonic::Monotonic,
     pipe::PipeBehavior,
     protocols::pipe::{internal::InternalCmd, PipeMessage},
+    Context,
 };
 use ockam_core::compat::{boxed::Box, collections::VecDeque};
 use ockam_core::{Address, Any, Result, Route, Routed, Worker};
-use ockam_node::Context;
 
 enum PeerRoute {
     Peer(Route),

--- a/implementations/rust/ockam/ockam/src/pipe/tests.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/tests.rs
@@ -1,7 +1,9 @@
-use crate::pipe::*;
-use crate::protocols::pipe::{internal::InternalCmd, PipeMessage};
+use crate::{
+    pipe::*,
+    protocols::pipe::{internal::InternalCmd, PipeMessage},
+    Context,
+};
 use ockam_core::{async_trait, Address, Result, Route};
-use ockam_node::Context;
 
 use super::behavior::ReceiverOrdering;
 


### PR DESCRIPTION
A small fix related to #2197 