### PR TITLE
fix(rust): import correct ed25519 signature trait

### DIFF
--- a/implementations/rust/ockam/ockam_vault/src/xeddsa.rs
+++ b/implementations/rust/ockam/ockam_vault/src/xeddsa.rs
@@ -4,7 +4,7 @@
 use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT, montgomery::MontgomeryPoint, scalar::Scalar,
 };
-use ed25519_dalek::{PublicKey as EPublicKey, Signature, Verifier};
+use ed25519_dalek::{ed25519::signature::Signature, PublicKey as EPublicKey, Verifier};
 use sha2::digest::Digest;
 use x25519_dalek::{PublicKey as XPublicKey, StaticSecret as XSecretKey};
 


### PR DESCRIPTION
## Current Behaviour

When I try to compile the following example for Ockam embedded:

[examples/04-routing-over-transport-responder.rs](https://github.com/antoinevg/hello_ockam_embedded/blob/8ecb206bbe71660c386bdf53ab666156454ca55f/examples/04-routing-over-transport-responder.rs) 

I get the following build error:

```
cargo +nightly -Z unstable-options \
                --config "target.cfg.runner = 'arm-none-eabi-gdb -q -x openocd-itm.gdb'" \
                build --example 04-routing-over-transport-responder \
                        --target thumbv7em-none-eabihf \
                        --no-default-features \
                        --features="stm32h7,bsp_nucleo_h7xx,no_main"
   Compiling hello-ockam v0.1.0 (/Users/antoine/Ockam/hello_ockam_embedded.git)
   Compiling ockam_vault v0.34.0 (/Users/antoine/Ockam/ockam.git/implementations/rust/ockam/ockam_vault)
error[E0599]: no function or associated item named `from_bytes` found for struct `ed25519_dalek::Signature` in the current scope
  --> /Users/antoine/Ockam/ockam.git/implementations/rust/ockam/ockam_vault/src/xeddsa.rs:94:38
   |
94 |                 let sig = Signature::from_bytes(sig).unwrap();
   |                                      ^^^^^^^^^^ function or associated item not found in `ed25519_dalek::Signature`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
4  | use ed25519_dalek::ed25519::signature::Signature;
   |
help: there is an associated function with a similar name
   |
94 |                 let sig = Signature::to_bytes(sig).unwrap();
   |                                      ~~~~~~~~

For more information about this error, try `rustc --explain E0599`.
error: could not compile `ockam_vault` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
make: *** [nucleo-h7xx] Error 101
```


## Proposed Changes

I'm not sure if this affects anyone else as this did not show up on CI, but I thought it's better to be safe than sorry!

Fix was to change the trait reference from:

    ed25519_dalek::Signature

To:

    ed25519_dalek::ed25519::signature::Signature
