### PR TITLE
fix(rust): use `Zeroize` on sensitive values in x3dh protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "ockam_vault",
  "ockam_vault_core",
  "ockam_vault_sync_core",
+ "zeroize",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -31,6 +31,7 @@ ockam_core = { path = "../ockam_core", version = "^0.40.0", default_features = f
 ockam_vault_core = { path = "../ockam_vault_core" , version = "^0.34.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.32.0", default_features = false }
 arrayref = "0.3"
+zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.32.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -12,6 +12,7 @@ use ockam_core::{compat::vec::Vec, hex::encode, AsyncTryClone};
 use ockam_vault_core::{
     AsymmetricVault, Hasher, PublicKey, SecretVault, Signer, SymmetricVault, Verifier,
 };
+use zeroize::Zeroize;
 
 mod error;
 pub use error::*;
@@ -25,7 +26,8 @@ pub use new_key_exchanger::*;
 
 /// Represents and (X)EdDSA or ECDSA signature
 /// from Ed25519 or P-256
-#[derive(Clone, Copy)]
+#[derive(Clone, Zeroize)]
+#[zeroize(drop)]
 pub struct Signature([u8; 64]);
 
 impl AsRef<[u8; 64]> for Signature {
@@ -53,7 +55,8 @@ impl core::fmt::Debug for Signature {
 }
 
 /// Represents all the keys and signature to send to an enrollee
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Zeroize)]
+#[zeroize(drop)]
 pub struct PreKeyBundle {
     identity_key: PublicKey,
     signed_prekey: PublicKey,


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

As per opened issue #2051, there are currently temporary sensitive values that should be zeroized. This PR enables zeroisation of sensitive values present in the current X3DH implementation.

It does so by making the `PreKeyBundle` and `Signature` structs [derive the `Zeroize` trait](https://docs.rs/zeroize/1.4.2/zeroize/#custom-derive-support) so that they get zeroized on drop.

Please let me know if I've missed any other place where we can do the same. If there are other places, I can open a generic PR with smaller commits corresponding to changes to each specific part of the codebase, if that sounds better.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
