### PR TITLE
feat(elixir, rust): Make pub_sub API compatible with RemoteForwarder

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/responder.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/responder.ex
@@ -23,15 +23,20 @@ defmodule Ockam.Messaging.PipeChannel.Responder do
     sender_options = Keyword.get(options, :sender_options, [])
     receiver_options = Keyword.get(options, :receiver_options, [])
 
+    address_options = Keyword.take(options, [:address, :inner_address])
+
     Session.Responder.create(
-      init_message: init_message,
-      worker_mod: PipeChannel.Simple,
-      handshake: PipeChannel.Handshake,
-      handshake_options: [
-        pipe_mod: pipe_mod,
-        sender_options: sender_options,
-        receiver_options: receiver_options
-      ]
+      address_options ++
+        [
+          init_message: init_message,
+          worker_mod: PipeChannel.Simple,
+          handshake: PipeChannel.Handshake,
+          handshake_options: [
+            pipe_mod: pipe_mod,
+            sender_options: sender_options,
+            receiver_options: receiver_options
+          ]
+        ]
     )
   end
 end
@@ -50,11 +55,16 @@ defmodule Ockam.Messaging.PipeChannel.Spawner do
   """
 
   def create(options) do
+    ## TODO: addresses for other workers
+    address_options = Keyword.take(options, [:address, :inner_address])
     responder_options = Keyword.fetch!(options, :responder_options)
 
     Ockam.Session.Spawner.create(
-      worker_mod: Ockam.Messaging.PipeChannel.Responder,
-      worker_options: responder_options
+      address_options ++
+        [
+          worker_mod: Ockam.Messaging.PipeChannel.Responder,
+          worker_options: responder_options
+        ]
     )
   end
 end


### PR DESCRIPTION
## Current Behaviour

There is a new `pub_sub_service` which creates forwarding workers similar to the `forwarding_service` but with static addresses

## Proposed Changes

Make pub_sub topic workers reply on subscription same way forwarding workers reply on creation

Make RemoteForwarder compatible with the pub_sub API

Usage:

Pretty similar to the forwarding service RemoteForwarder

Create a forwarder:
```
let forwarder = RemoteForwarder::create_pub_sub(&ctx, (TCP, cloud_node_tcp_address), "worker_to_forward", "my_subscription", "my_topic").await?;
```

Send messages to forwarder:
```
ctx.send(
    route![(TCP, cloud_node_tcp_address), "pub_sub_t_my_topic"],
    "Hello Ockam!".to_string(),
)
.await?;
```

`pub_sub_t` is a default prefix for pub_sub topic workers

Currently only works with localhost, since there are elixir changes.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
