### PR TITLE
Rust bi-directional messaging channels

### DIFF
--- a/implementations/rust/ockam/ockam/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam/src/channel/listener.rs
@@ -1,0 +1,74 @@
+use crate::{
+    channel::CLUSTER_NAME,
+    pipe::{PipeBehavior, PipeReceiver, PipeSender},
+    protocols::channel::{ChannelCreationHandshake, ChannelProtocol},
+    Context,
+};
+use ockam_core::{Address, Result, Routed, Worker};
+
+pub struct ChannelListener {
+    hooks: PipeBehavior,
+}
+
+impl ChannelListener {
+    pub async fn create(ctx: &Context, addr: Address, hooks: PipeBehavior) -> Result<()> {
+        ctx.start_worker(addr, Self { hooks }).await
+    }
+}
+
+#[crate::worker]
+impl Worker for ChannelListener {
+    type Message = ChannelCreationHandshake;
+    type Context = Context;
+
+    async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        ctx.set_cluster(CLUSTER_NAME).await?;
+        Ok(())
+    }
+
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        msg: Routed<ChannelCreationHandshake>,
+    ) -> Result<()> {
+        info!(
+            "Receiving new channel creation request from {:?}",
+            msg.return_route()
+        );
+
+        // First compute the route to the peer pipe receiver
+        let ChannelCreationHandshake(ref rx_addr) = dbg!(msg.as_body());
+        let peer = dbg!(msg.return_route().recipient());
+        let rx_route = dbg!(msg
+            .return_route()
+            .modify()
+            .pop_back()
+            .append(rx_addr.clone())
+            .append(peer)
+            .into());
+
+        // Start the PipeSender pointing at the remote receiver
+        let tx_addr = Address::random(0);
+        PipeSender::create(
+            ctx,
+            rx_route,
+            tx_addr.clone(),
+            Address::random(0),
+            self.hooks.clone(),
+        )
+        .await?;
+        debug!("Started PipeSender with appropriate sender route");
+
+        // Start the PipeReceiver
+        let rx_addr = Address::random(0);
+        PipeReceiver::create(ctx, rx_addr.clone(), Address::random(0), self.hooks.clone()).await?;
+
+        // Create the local channel worker
+
+        // Then message the remote Channel peer
+        ctx.send(msg.return_route(), ChannelProtocol::ReceiverReady(rx_addr))
+            .await?;
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam/src/channel/listener.rs
@@ -4,6 +4,7 @@ use crate::{
     protocols::channel::ChannelCreationHandshake,
     Context,
 };
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Result, Route, Routed, Worker};
 
 pub struct ChannelListener {

--- a/implementations/rust/ockam/ockam/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam/src/channel/listener.rs
@@ -4,7 +4,7 @@ use crate::{
     protocols::channel::ChannelCreationHandshake,
     Context,
 };
-use ockam_core::{Address, Result, Routed, Worker};
+use ockam_core::{Address, Result, Route, Routed, Worker};
 
 pub struct ChannelListener {
     tx_hooks: PipeBehavior,
@@ -38,29 +38,43 @@ impl Worker for ChannelListener {
         msg: Routed<ChannelCreationHandshake>,
     ) -> Result<()> {
         info!(
-            "Receiving new channel creation request from {:?}",
-            msg.return_route()
+            "Receiving new channel creation request from {:?}: {:?}",
+            msg.return_route(),
+            msg.as_body(),
         );
 
-        // First compute routes to the peer's PipeSender and PipeReceiver
-        let ChannelCreationHandshake(ref rx_addr, ref tx_addr) = msg.as_body();
-        let peer_rx_route = msg
-            .return_route()
+        // First compute routes to the peer's PipeSender and
+        // PipeReceiver with both their public and internal addresses
+        let ChannelCreationHandshake {
+            channel_addr, // this is the channel's internal address!
+            tx_addr,
+            rx_addr,
+            rx_int_addr,
+            tx_int_addr,
+        } = msg.as_body();
+        let peer_channel_addr = msg.return_route().recipient();
+
+        let peer_rx_base: Route = msg.return_route().modify().pop_back().into();
+        let peer_rx_pub = peer_rx_base.clone().modify().append(rx_addr.clone()).into();
+        let peer_rx_int = peer_rx_base
+            .clone()
             .modify()
-            .pop_back()
-            .append(rx_addr.clone())
-            .into();
-        let peer_tx_route = msg
-            .return_route()
-            .modify()
-            .pop_back()
-            .append(tx_addr.clone())
+            .append(rx_int_addr.clone())
             .into();
 
+        let peer_tx_base: Route = msg.return_route().modify().pop_back().into();
+        let peer_tx_pub = peer_tx_base.clone().modify().append(tx_addr.clone()).into();
+        let peer_tx_int = peer_tx_base
+            .clone()
+            .modify()
+            .append(tx_int_addr.clone())
+            .into();
         ChannelWorker::stage2(
             ctx,
-            peer_tx_route,
-            peer_rx_route,
+            (peer_tx_pub, peer_tx_int),
+            (peer_rx_pub, peer_rx_int),
+            channel_addr.clone(),
+            peer_channel_addr,
             self.tx_hooks.clone(),
             self.rx_hooks.clone(),
         )

--- a/implementations/rust/ockam/ockam/src/channel/mod.rs
+++ b/implementations/rust/ockam/ockam/src/channel/mod.rs
@@ -1,0 +1,84 @@
+//! Ockam general bi-directional channel
+
+mod listener;
+mod worker;
+
+use self::{listener::ChannelListener, worker::ChannelWorker};
+use crate::{
+    pipe::{BehaviorHook, PipeBehavior},
+    Context,
+};
+use ockam_core::{Address, Result, Route, RouteBuilder};
+
+#[cfg(test)]
+mod tests;
+
+const CLUSTER_NAME: &str = "ockam.channel";
+
+pub struct ChannelHandle {
+    tx: Address,
+}
+
+impl ChannelHandle {
+    pub fn tx(&self) -> RouteBuilder {
+        RouteBuilder::new().prepend_route(self.tx.clone().into())
+    }
+}
+
+/// Generalised ockam channel API
+pub struct ChannelBuilder {
+    ctx: Context,
+    hooks: PipeBehavior,
+}
+
+impl ChannelBuilder {
+    /// Create a new Ockam channel context
+    ///
+    /// ```rust
+    /// # use ockam::{channel::ChannelBuilder, Context};
+    /// # use ockam_core::Result;
+    /// # async fn test_api(ctx: &mut Context) -> Result<()> {
+    /// let builder = ChannelBuilder::new(ctx).await?;
+    ///
+    /// // Create a new channel listener
+    /// builder.create_channel_listener("my-channel-listener").await?;
+    ///
+    /// // Connect a channel to the listener
+    /// let ch = builder.connect(vec!["my-channel-listener"]).await?;
+    /// ctx.send(ch.tx().append("app"), String::from("Hello via channel!")).await?;
+    ///
+    /// // Wait for the reply message
+    /// let msg = ctx.receive::<String>().await?;
+    /// println!("Received message '{}'", msg);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn new(ctx: &Context) -> Result<Self> {
+        debug!("Creating new ChannelBuilder context...");
+        ctx.new_context(Address::random(0)).await.map(|ctx| Self {
+            ctx,
+            hooks: PipeBehavior::empty(),
+        })
+    }
+
+    /// Attach a new behavior to be used by the underlying pipes
+    pub fn attach_behavior<B: BehaviorHook + Clone + Send + Sync + 'static>(
+        mut self,
+        bev: B,
+    ) -> Self {
+        self.hooks.insert(bev);
+        self
+    }
+
+    /// Connect to a channel listener
+    pub async fn connect<R: Into<Route>>(&self, listener: R) -> Result<ChannelHandle> {
+        let tx = Address::random(0);
+        ChannelWorker::create(&self.ctx, tx.clone(), listener.into()).await?;
+        Ok(ChannelHandle { tx })
+    }
+
+    /// Create a new channel listener
+    pub async fn create_channel_listener<A: Into<Address>>(&self, addr: A) -> Result<()> {
+        ChannelListener::create(&self.ctx, addr.into(), self.hooks.clone()).await
+    }
+}

--- a/implementations/rust/ockam/ockam/src/channel/tests.rs
+++ b/implementations/rust/ockam/ockam/src/channel/tests.rs
@@ -1,0 +1,27 @@
+//! Ockam channel tests
+use crate::{channel::*, Context};
+use ockam_core::Result;
+
+#[crate::test]
+async fn simple_channel(ctx: &mut Context) -> Result<()> {
+    let builder = ChannelBuilder::create(ctx).await?;
+
+    // Create a channel listener
+    builder
+        .create_channel_listener("my-channel-listener")
+        .await?;
+
+    // Create a channel via the listener
+    let ch = builder.connect(vec!["my-channel-listener"]).await?;
+
+    // Send a message through the channel
+    let msg = "Hello through the channel!".to_string();
+    ctx.send(ch.tx().append("app"), msg.clone()).await?;
+
+    // Then wait for the message through the channel
+    let recv = ctx.receive().await?;
+    info!("Received message '{}' through channel", recv);
+    assert_eq!(recv, msg);
+
+    ctx.stop().await
+}

--- a/implementations/rust/ockam/ockam/src/channel/tests.rs
+++ b/implementations/rust/ockam/ockam/src/channel/tests.rs
@@ -11,7 +11,8 @@ async fn simple_channel(ctx: &mut Context) -> Result<()> {
         .create_channel_listener("my-channel-listener")
         .await?;
 
-    // Create a channel via the listener
+    // Create a channel via the listener.  We re-use the
+    // ChannelBuilder here but could also use a new one
     let ch = builder.connect(vec!["my-channel-listener"]).await?;
 
     // Send a message through the channel

--- a/implementations/rust/ockam/ockam/src/channel/tests.rs
+++ b/implementations/rust/ockam/ockam/src/channel/tests.rs
@@ -1,10 +1,43 @@
 //! Ockam channel tests
-use crate::{channel::*, Context};
+use crate::{
+    channel::*,
+    pipe::{ReceiverConfirm, ReceiverOrdering, SenderConfirm},
+    Context,
+};
 use ockam_core::Result;
 
 #[crate::test]
 async fn simple_channel(ctx: &mut Context) -> Result<()> {
-    let builder = ChannelBuilder::create(ctx).await?;
+    let builder = ChannelBuilder::new(ctx).await?;
+
+    // Create a channel listener
+    builder
+        .create_channel_listener("my-channel-listener")
+        .await?;
+
+    // Create a channel via the listener.  We re-use the
+    // ChannelBuilder here but could also use a new one
+    let ch = builder.connect(vec!["my-channel-listener"]).await?;
+
+    // Send a message through the channel
+    let msg = "Hello through the channel!".to_string();
+    ctx.send(ch.tx().append("app"), msg.clone()).await?;
+
+    // Then wait for the message through the channel
+    let recv = ctx.receive().await?;
+    info!("Received message '{}' through channel", recv);
+    assert_eq!(recv, msg);
+
+    ctx.stop().await
+}
+
+#[crate::test]
+async fn reliable_channel(ctx: &mut Context) -> Result<()> {
+    let builder = ChannelBuilder::new(ctx)
+        .await?
+        .attach_rx_behavior(ReceiverConfirm)
+        .attach_rx_behavior(ReceiverOrdering::new())
+        .attach_tx_behavior(SenderConfirm::new());
 
     // Create a channel listener
     builder

--- a/implementations/rust/ockam/ockam/src/channel/worker.rs
+++ b/implementations/rust/ockam/ockam/src/channel/worker.rs
@@ -1,0 +1,157 @@
+use crate::{
+    channel::CLUSTER_NAME,
+    pipe::{
+        PipeBehavior, PipeReceiver, PipeSender, ReceiverConfirm, ReceiverOrdering, SenderConfirm,
+    },
+    protocols::channel::{ChannelCreationHandshake, ChannelProtocol},
+    Context,
+};
+use ockam_core::compat::collections::VecDeque;
+use ockam_core::{
+    Address, Any, Decodable, LocalMessage, Result, Route, Routed, TransportMessage, Worker,
+};
+
+pub struct ChannelWorker {
+    /// Route to the peer channel listener
+    listener: Option<Route>,
+    /// Internal address used for status messages
+    int_addr: Address,
+    /// Address of the pipe sender
+    tx_addr: Option<Address>,
+    /// Sender behaviour in use for this channel
+    tx_hooks: PipeBehavior,
+    /// A temporary send buffer
+    tx_buffer: VecDeque<TransportMessage>,
+}
+
+impl ChannelWorker {
+    pub async fn initialized(ctx: &Context, addr: Address, tx_addr: Address) -> Result<()> {
+        let int_addr = Address::random(0);
+        ctx.start_worker(
+            vec![addr, int_addr.clone()],
+            ChannelWorker {
+                listener: None,
+                int_addr,
+                tx_addr: Some(tx_addr),
+                tx_hooks: PipeBehavior::with(SenderConfirm::new()),
+                tx_buffer: VecDeque::new(),
+            },
+        )
+        .await
+    }
+
+    pub async fn create(ctx: &Context, tx: Address, listener: Route) -> Result<()> {
+        let int_addr = Address::random(0);
+        ctx.start_worker(
+            vec![tx, int_addr.clone()],
+            ChannelWorker {
+                listener: Some(listener),
+                int_addr,
+                tx_addr: None,
+                tx_hooks: PipeBehavior::with(SenderConfirm::new()),
+                tx_buffer: VecDeque::new(),
+            },
+        )
+        .await
+    }
+}
+
+#[crate::worker]
+impl Worker for ChannelWorker {
+    type Context = Context;
+    type Message = Any;
+
+    async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        ctx.set_cluster(CLUSTER_NAME).await?;
+
+        // If this worker doesn't have a TX address associated yet
+        // then we need to start the channel creation handshake
+        if self.tx_addr.is_none() && self.listener.is_some() {
+            debug!("{}: Initiating channel creation handshake", ctx.address());
+            let rx_addr = Address::random(0);
+            PipeReceiver::create(
+                ctx,
+                rx_addr.clone(),
+                Address::random(0), // TODO: pass int_addr to handshake handler too
+                PipeBehavior::with(ReceiverConfirm).attach(ReceiverOrdering::new()),
+            )
+            .await?;
+
+            ctx.send(
+                self.listener.clone().unwrap(),
+                ChannelCreationHandshake(rx_addr),
+            )
+            .await?;
+        }
+
+        // Otherwise we're good to go
+        Ok(())
+    }
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
+        trace!("Receiving message to address '{}'", msg.msg_addr());
+        match msg.msg_addr() {
+            addr if addr == self.int_addr => self.handle_internal(ctx, msg).await,
+            _ => self.handle_external(ctx, msg).await,
+        }
+    }
+}
+
+impl ChannelWorker {
+    /// Handle channel internal messages
+    async fn handle_internal(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
+        trace!("ChannelWorker receiving internal command");
+        let mut return_route = msg.return_route();
+        let trans = msg.into_transport_message();
+        let internal_cmd = ChannelProtocol::decode(&trans.payload)?;
+
+        match internal_cmd {
+            // Peer receiver is ready, we can start our sender
+            ChannelProtocol::ReceiverReady(rx_addr) => {
+                debug!("ChannelWorker handles ReceiverReady message");
+                let rx_route = return_route
+                    .modify()
+                    .pop_back()
+                    .append(rx_addr.clone())
+                    .into();
+
+                self.tx_addr = Some(Address::random(0));
+
+                PipeSender::create(
+                    ctx,
+                    rx_route,
+                    self.tx_addr.clone().unwrap(),
+                    Address::random(0),
+                    self.tx_hooks.clone(),
+                )
+                .await?
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle external user messages
+    ///
+    /// These messages are always `TransportMessage`
+    async fn handle_external(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
+        let mut trans = msg.into_transport_message();
+        match self.tx_addr {
+            Some(ref tx) => {
+                // If we have messages in our output buffer send these first
+                for mut msg in core::mem::take(&mut self.tx_buffer) {
+                    msg.onward_route.modify().prepend(tx.clone());
+                    ctx.forward(LocalMessage::new(msg, vec![])).await?;
+                }
+
+                trans.onward_route.modify().prepend(tx.clone());
+                ctx.forward(LocalMessage::new(trans, vec![])).await?;
+            }
+            None => {
+                self.tx_buffer.push_back(trans);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam/src/channel/worker.rs
+++ b/implementations/rust/ockam/ockam/src/channel/worker.rs
@@ -24,8 +24,13 @@ pub struct ChannelWorker {
     tx_addr: Address,
     /// Address of the local pipe receiver
     rx_addr: Address,
+    /// Pair of addresses: one public, one internal
+    self_addrs: (Address, Address),
+    /// Peer channel worker address
+    peer_addr: Address,
     /// Route to the peer's channel worker
-    peer_routes: Option<(Route, Route)>,
+    // FIXME please
+    peer_routes: Option<((Route, Route), (Route, Route))>,
     /// Sender behaviour in use for this channel
     tx_hooks: PipeBehavior,
     /// Receiver behaviour in use for this channel
@@ -35,19 +40,24 @@ pub struct ChannelWorker {
 impl ChannelWorker {
     pub async fn stage2(
         ctx: &Context,
-        peer_tx_route: Route,
-        peer_rx_route: Route,
+        peer_tx_route: (Route, Route),
+        peer_rx_route: (Route, Route),
+        int_addr: Address,
+        peer_addr: Address,
         tx_hooks: PipeBehavior,
         rx_hooks: PipeBehavior,
     ) -> Result<()> {
+        let pub_addr = Address::random(0);
         ctx.start_worker(
-            Address::random(0),
+            vec![int_addr.clone(), pub_addr.clone()],
             ChannelWorker {
                 stage: WorkerStage::Stage2,
                 listener: None,
                 tx_addr: Address::random(0),
                 rx_addr: Address::random(0),
                 peer_routes: Some((peer_tx_route, peer_rx_route)),
+                self_addrs: (pub_addr, int_addr),
+                peer_addr,
                 tx_hooks,
                 rx_hooks,
             },
@@ -61,19 +71,26 @@ impl ChannelWorker {
     /// and initiating the channel creation handshake
     pub async fn stage1(
         ctx: &Context,
-        addr: Address,
+        pub_addr: Address,
         listener: Route,
         tx_hooks: PipeBehavior,
         rx_hooks: PipeBehavior,
     ) -> Result<()> {
+        let int_addr = Address::random(0);
         ctx.start_worker(
-            addr,
+            vec![int_addr.clone(), pub_addr.clone()],
             ChannelWorker {
                 stage: WorkerStage::Stage1,
                 listener: Some(listener),
                 peer_routes: None,
+                // This is a bit of a hack so that we don't have to
+                // create an outgoing message cache in the channel
+                // endpoint and can instead use the PipeSender cache
+                // mechanism instead
+                peer_addr: Address::random(0),
                 rx_addr: Address::random(0),
                 tx_addr: Address::random(0),
+                self_addrs: (pub_addr, int_addr),
                 tx_hooks,
                 rx_hooks,
             },
@@ -89,6 +106,11 @@ impl Worker for ChannelWorker {
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
         ctx.set_cluster(CLUSTER_NAME).await?;
+
+        debug!(
+            "Initialise ChannelWorker (pub: {}, int: {})",
+            self.self_addrs.0, self.self_addrs.1
+        );
 
         match self.stage {
             WorkerStage::Stage1 => self.init_stage1(ctx).await?,
@@ -118,27 +140,45 @@ impl ChannelWorker {
     /// should be forwarded to the sender, which acts as an output
     /// buffer.
     async fn init_stage1(&mut self, ctx: &mut Context) -> Result<()> {
-        debug!("{}: Initiating channel creation handshake", ctx.address());
+        debug!(
+            "Stage 1 channel init: Sender '{}' and Receiver '{}' pipes",
+            self.tx_addr, self.rx_addr
+        );
+
+        let rx_int = Address::random(0);
         PipeReceiver::create(
             ctx,
             self.rx_addr.clone(),
-            Address::random(0),    // TODO: pass int_addr to handshake handler too
-            self.rx_hooks.clone(), // PipeBehavior::with(ReceiverConfirm).attach(ReceiverOrdering::new()),
+            rx_int.clone(),
+            self.rx_hooks.clone(),
         )
         .await?;
 
+        let tx_int = Address::random(0);
         PipeSender::uninitialized(
             ctx,
             self.tx_addr.clone(),
-            Address::random(0),
-            Route::new().into(),
+            tx_int.clone(),
+            None,
             self.tx_hooks.clone(),
         )
         .await?;
 
-        ctx.send(
+        // Send a ChannelCreationHandshake from the internal address,
+        // which the peer channel worker will associate with this
+        // worker.  That way we can distinguish between messages sent
+        // to us by users, and messages sent to us by the PipeReceiver
+        debug!("{}: Initiating channel creation handshake", ctx.address());
+        ctx.send_from_address(
             self.listener.clone().unwrap(),
-            ChannelCreationHandshake(self.rx_addr.clone(), self.tx_addr.clone()),
+            ChannelCreationHandshake {
+                channel_addr: self.peer_addr.clone(),
+                tx_addr: self.tx_addr.clone(),
+                rx_addr: self.rx_addr.clone(),
+                tx_int_addr: tx_int,
+                rx_int_addr: rx_int,
+            },
+            self.self_addrs.1.clone(),
         )
         .await?;
 
@@ -154,25 +194,28 @@ impl ChannelWorker {
     ///
     /// No further initialisation is needed past this point
     async fn init_stage2(&mut self, ctx: &mut Context) -> Result<()> {
+        debug!(
+            "Stage 2 channel init: Sender '{}' and Receiver '{}' pipes",
+            self.tx_addr, self.rx_addr
+        );
+
         // Get the TX and RX worker routes
         let (route_to_sender, route_to_receiver) = self.peer_routes.clone().unwrap();
 
         // Create a PipeReceiver
+        let rx_int_addr = Address::random(0);
         PipeReceiver::create(
             ctx,
             self.rx_addr.clone(),
-            Address::random(0),
+            rx_int_addr.clone(),
             self.rx_hooks.clone().attach(HandshakeInit::default()),
-            // PipeBehavior::with(ReceiverConfirm)
-            //     .attach(ReceiverOrdering::new())
-            //     .attach(HandshakeInit::default()),
         )
         .await?;
 
         // Create a PipeSender
         PipeSender::create(
             ctx,
-            route_to_receiver,
+            route_to_receiver.0,
             self.tx_addr.clone(),
             Address::random(0),
             self.tx_hooks.clone(),
@@ -181,8 +224,10 @@ impl ChannelWorker {
 
         // Send HandshakeInit message to Receiver
         ctx.send(
-            self.rx_addr.clone(),
-            InternalCmd::Handshake(Handshake { route_to_sender }),
+            rx_int_addr,
+            InternalCmd::Handshake(Handshake {
+                route_to_sender: route_to_sender.1,
+            }),
         )
         .await?;
 
@@ -196,8 +241,31 @@ impl ChannelWorker {
     /// forwarded to the PipeSender.  If the sender isn't fully
     /// initialised yet it can buffer messages for us.
     async fn handle_external(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
+        let msg_addr = msg.msg_addr();
         let mut trans = msg.into_transport_message();
-        trans.onward_route.modify().prepend(self.tx_addr.clone());
-        ctx.forward(LocalMessage::new(trans, vec![])).await
+        match msg_addr {
+            // Message received to public address -- forward to PipeSender
+            addr if addr == self.self_addrs.0 => {
+                trans
+                    .onward_route
+                    .modify()
+                    .pop_front()
+                    .prepend(self.peer_addr.clone())
+                    .prepend(self.tx_addr.clone());
+            }
+            // Message received to internal address -- forward to user
+            addr if addr == self.self_addrs.1 => {
+                trans.onward_route.modify().pop_front();
+                trans
+                    .return_route
+                    .modify()
+                    .prepend(self.self_addrs.0.clone());
+            }
+            addr => warn!("Received invalid message to address {}", addr),
+        }
+
+        // Forward message
+        ctx.forward(LocalMessage::new(trans, vec![])).await.unwrap();
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam/src/channel/worker.rs
+++ b/implementations/rust/ockam/ockam/src/channel/worker.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     Context,
 };
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Any, LocalMessage, Result, Route, Routed, Worker};
 
 /// Encode the channel creation handshake stage a worker is in

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -55,6 +55,7 @@ pub use protocols::*;
 pub use remote_forwarder::*;
 pub use unique::*;
 
+pub mod channel;
 pub mod pipe;
 pub mod stream;
 

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/handshake.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/handshake.rs
@@ -21,6 +21,7 @@ impl BehaviorHook for HandshakeInit {
         msg: &InternalCmd,
     ) -> Result<()> {
         if let (InternalCmd::Handshake(Handshake { route_to_sender }), false) = (msg, self.0) {
+            debug!("Sending InitSender request to {:?}", route_to_sender);
             ctx.send(route_to_sender.clone(), InternalCmd::InitSender)
                 .await?;
             self.0 = true;

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/handshake.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/handshake.rs
@@ -1,0 +1,41 @@
+use crate::{
+    pipe::{BehaviorHook, PipeModifier},
+    protocols::pipe::{
+        internal::{Handshake, InternalCmd},
+        PipeMessage,
+    },
+    Context,
+};
+use ockam_core::{Address, Result, Route};
+
+#[derive(Clone, Default)]
+pub struct HandshakeInit(bool);
+
+#[ockam_core::async_trait]
+impl BehaviorHook for HandshakeInit {
+    async fn on_internal(
+        &mut self,
+        _: Address,
+        _: Route,
+        ctx: &mut Context,
+        msg: &InternalCmd,
+    ) -> Result<()> {
+        if let (InternalCmd::Handshake(Handshake { route_to_sender }), false) = (msg, self.0) {
+            ctx.send(route_to_sender.clone(), InternalCmd::InitSender)
+                .await?;
+            self.0 = true;
+        }
+
+        Ok(())
+    }
+
+    async fn on_external(
+        &mut self,
+        _: Address,
+        _: Route,
+        _: &mut Context,
+        _: &PipeMessage,
+    ) -> Result<PipeModifier> {
+        Ok(PipeModifier::None)
+    }
+}

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/handshake.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/handshake.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     Context,
 };
+use ockam_core::compat::boxed::Box;
 use ockam_core::{Address, Result, Route};
 
 #[derive(Clone, Default)]

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
@@ -58,7 +58,7 @@ pub enum PipeModifier {
 
 /// Structure to combine a set of pipe BehaviorHooks
 pub struct PipeBehavior {
-    hooks: Vec<Box<dyn BehaviorHook + Send + 'static>>,
+    hooks: Vec<Box<dyn BehaviorHook + Send + Sync + 'static>>,
 }
 
 impl Clone for PipeBehavior {
@@ -73,14 +73,14 @@ impl Clone for PipeBehavior {
     }
 }
 
-impl<T: BehaviorHook + Send + 'static> From<T> for PipeBehavior {
+impl<T: BehaviorHook + Send + Sync + 'static> From<T> for PipeBehavior {
     fn from(hook: T) -> Self {
         Self::with(hook)
     }
 }
 
 impl PipeBehavior {
-    pub fn with<T: BehaviorHook + Send + 'static>(t: T) -> Self {
+    pub fn with<T: BehaviorHook + Send + Sync + 'static>(t: T) -> Self {
         Self {
             hooks: vec![Box::new(t)],
         }
@@ -90,9 +90,15 @@ impl PipeBehavior {
         Self { hooks: vec![] }
     }
 
-    pub fn attach<T: BehaviorHook + Send + 'static>(mut self, t: T) -> Self {
-        self.hooks.push(Box::new(t));
+    /// Attach a new BehaviorHook in a chainable manner
+    pub fn attach<T: BehaviorHook + Send + Sync + 'static>(mut self, t: T) -> Self {
+        self.insert(t);
         self
+    }
+
+    /// Insert a new BehaviorHook in place
+    pub fn insert<T: BehaviorHook + Send + Sync + 'static>(&mut self, t: T) {
+        self.hooks.push(Box::new(t));
     }
 
     /// Run all external message hooks associated with this pipe

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
@@ -7,6 +7,9 @@ pub use resend::{ReceiverConfirm, SenderConfirm};
 mod ordering;
 pub use ordering::ReceiverOrdering;
 
+mod handshake;
+pub use handshake::HandshakeInit;
+
 use crate::{
     protocols::pipe::{internal::InternalCmd, PipeMessage},
     Context,

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/resend.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/resend.rs
@@ -77,7 +77,7 @@ impl BehaviorHook for SenderConfirm {
                 debug!("Received pipe delivery ACK for index {}", idx);
                 self.on_route.remove(idx);
             }
-            _ => todo!(),
+            cmd => trace!("SenderResend behavior ignoring {:?}", cmd),
         }
 
         Ok(())
@@ -118,7 +118,6 @@ impl BehaviorHook for ReceiverConfirm {
         _: &mut Context,
         _: &InternalCmd,
     ) -> Result<()> {
-        // PipeReceiver does not currently receive internal messages!
-        unimplemented!()
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam/src/pipe/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/mod.rs
@@ -2,7 +2,8 @@
 
 mod behavior;
 pub use behavior::{
-    BehaviorHook, PipeBehavior, PipeModifier, ReceiverConfirm, ReceiverOrdering, SenderConfirm,
+    BehaviorHook, HandshakeInit, PipeBehavior, PipeModifier, ReceiverConfirm, ReceiverOrdering,
+    SenderConfirm,
 };
 
 mod listener;

--- a/implementations/rust/ockam/ockam/src/pipe/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/mod.rs
@@ -73,7 +73,7 @@ pub async fn connect_dynamic(ctx: &mut Context, listener: Route) -> Result<Addre
         ctx,
         addr.clone(),
         int_addr.clone(),
-        listener,
+        Some(listener),
         PipeBehavior::empty(),
     )
     .await?;

--- a/implementations/rust/ockam/ockam/src/pipe/receiver.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/receiver.rs
@@ -17,8 +17,7 @@ impl Worker for PipeReceiver {
     type Message = Any;
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
-        ctx.set_cluster(super::CLUSTER_NAME).await?;
-        Ok(())
+        ctx.set_cluster(super::CLUSTER_NAME).await
     }
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {

--- a/implementations/rust/ockam/ockam/src/pipe/sender.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/sender.rs
@@ -119,7 +119,6 @@ impl PipeSender {
                     .internal_all(self.int_addr.clone(), peer.clone(), ctx, &internal_cmd)
                     .await?;
             }
-
             _ => match internal_cmd {
                 InternalCmd::InitSender => {
                     debug!("Initialise pipe sender for route {:?}", return_route);

--- a/implementations/rust/ockam/ockam/src/pipe/sender.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/sender.rs
@@ -97,10 +97,7 @@ impl PipeSender {
             Self {
                 index: Monotonic::from(1),
                 out_buf: VecDeque::new(),
-                peer: match listener {
-                    Some(route) => Some(PeerRoute::Listener(route)),
-                    None => None,
-                },
+                peer: listener.map(PeerRoute::Listener),
                 int_addr,
                 hooks,
             },

--- a/implementations/rust/ockam/ockam/src/pipe/tests.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/tests.rs
@@ -18,7 +18,7 @@ async fn static_simple_pipe(ctx: &mut Context) -> Result<()> {
         .await?;
 
     let msg = ctx.receive().await?;
-    info!("App received msg: '{}'", msg);
+    info!("App reiceved msg: '{}'", msg);
     assert_eq!(msg, sent_msg);
 
     ctx.stop().await
@@ -122,7 +122,7 @@ async fn fails_static_confirm_pipe(ctx: &mut Context) -> Result<()> {
         .await?;
 
     let invalid = ctx.receive::<String>().await?;
-    warn!("App received msg: '{}'", invalid);
+    warn!("App reiceved msg: '{}'", invalid);
     assert_eq!(invalid, "Shut it down...".to_string());
 
     ctx.stop().await
@@ -155,6 +155,7 @@ async fn static_ordering_pipe(ctx: &mut Context) -> Result<()> {
     ctx.stop().await
 }
 
+/// A test for a pipe that enforces ordering _and_ sends confirm messages
 #[crate::test]
 async fn static_confirm_ordering_pipe(ctx: &mut Context) -> Result<()> {
     receiver_with_behavior(

--- a/implementations/rust/ockam/ockam/src/pipe/tests.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/tests.rs
@@ -156,6 +156,82 @@ async fn static_ordering_pipe(ctx: &mut Context) -> Result<()> {
 }
 
 #[crate::test]
+async fn static_confirm_ordering_pipe(ctx: &mut Context) -> Result<()> {
+    receiver_with_behavior(
+        ctx,
+        "pipe-receiver",
+        PipeBehavior::with(ReceiverConfirm).attach(ReceiverOrdering::new()),
+    )
+    .await?;
+
+    let tx = connect_static_with_behavior(
+        ctx,
+        "pipe-receiver",
+        PipeBehavior::with(SenderConfirm::new()),
+    )
+    .await?;
+
+    let sent_msg1 = String::from("Message number one");
+    info!("Sending message '{}' through pipe sender {}", sent_msg1, tx);
+    ctx.send(vec![tx.clone(), "app".into()], sent_msg1.clone())
+        .await?;
+
+    let sent_msg2 = String::from("Message number two");
+    info!("Sending message '{}' through pipe sender {}", sent_msg2, tx);
+    ctx.send(vec![tx.clone(), "app".into()], sent_msg2.clone())
+        .await?;
+
+    let msg1 = ctx.receive().await?;
+    info!("App reiceved msg: '{}'", msg1);
+    assert_eq!(msg1, sent_msg1);
+
+    let msg2 = ctx.receive().await?;
+    info!("App reiceved msg: '{}'", msg2);
+    assert_eq!(msg2, sent_msg2);
+
+    ctx.stop().await
+}
+
+/// A test for a pipe that enforces ordering _and_ sends confirm
+/// messages but with a flipped behaviour order on the receiver end
+#[crate::test]
+async fn static_confirm_ordering_pipe_reversed(ctx: &mut Context) -> Result<()> {
+    receiver_with_behavior(
+        ctx,
+        "pipe-receiver",
+        PipeBehavior::with(ReceiverOrdering::new()).attach(ReceiverConfirm),
+    )
+    .await?;
+
+    let tx = connect_static_with_behavior(
+        ctx,
+        "pipe-receiver",
+        PipeBehavior::with(SenderConfirm::new()),
+    )
+    .await?;
+
+    let sent_msg1 = String::from("Message number one");
+    info!("Sending message '{}' through pipe sender {}", sent_msg1, tx);
+    ctx.send(vec![tx.clone(), "app".into()], sent_msg1.clone())
+        .await?;
+
+    let sent_msg2 = String::from("Message number two");
+    info!("Sending message '{}' through pipe sender {}", sent_msg2, tx);
+    ctx.send(vec![tx.clone(), "app".into()], sent_msg2.clone())
+        .await?;
+
+    let msg1 = ctx.receive().await?;
+    info!("App reiceved msg: '{}'", msg1);
+    assert_eq!(msg1, sent_msg1);
+
+    let msg2 = ctx.receive().await?;
+    info!("App reiceved msg: '{}'", msg2);
+    assert_eq!(msg2, sent_msg2);
+
+    ctx.stop().await
+}
+
+#[crate::test]
 async fn simple_pipe_handshake(ctx: &mut Context) -> Result<()> {
     // Create a pipe spawn listener and connect to it via a dynamic sender
     let listener = listen(ctx).await.unwrap();

--- a/implementations/rust/ockam/ockam/src/protocols/channel/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/channel/mod.rs
@@ -4,10 +4,4 @@ use serde::{Deserialize, Serialize};
 
 /// A simple message type to create a bi-directional channel
 #[derive(Debug, Serialize, Deserialize, Message)]
-pub struct ChannelCreationHandshake(pub Address);
-
-#[derive(Debug, Serialize, Deserialize, Message)]
-pub enum ChannelProtocol {
-    /// Sent from peer Receiver
-    ReceiverReady(Address),
-}
+pub struct ChannelCreationHandshake(pub Address, pub Address);

--- a/implementations/rust/ockam/ockam/src/protocols/channel/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/channel/mod.rs
@@ -4,4 +4,10 @@ use serde::{Deserialize, Serialize};
 
 /// A simple message type to create a bi-directional channel
 #[derive(Debug, Serialize, Deserialize, Message)]
-pub struct ChannelCreationHandshake(pub Address, pub Address);
+pub struct ChannelCreationHandshake {
+    pub channel_addr: Address,
+    pub tx_addr: Address,
+    pub tx_int_addr: Address,
+    pub rx_addr: Address,
+    pub rx_int_addr: Address,
+}

--- a/implementations/rust/ockam/ockam/src/protocols/channel/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/channel/mod.rs
@@ -1,0 +1,13 @@
+use crate::Message;
+use ockam_core::Address;
+use serde::{Deserialize, Serialize};
+
+/// A simple message type to create a bi-directional channel
+#[derive(Debug, Serialize, Deserialize, Message)]
+pub struct ChannelCreationHandshake(pub Address);
+
+#[derive(Debug, Serialize, Deserialize, Message)]
+pub enum ChannelProtocol {
+    /// Sent from peer Receiver
+    ReceiverReady(Address),
+}

--- a/implementations/rust/ockam/ockam/src/protocols/mod.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/mod.rs
@@ -7,6 +7,7 @@ use crate::{Message, Result};
 use ockam_core::{compat::vec::Vec, ProtocolId};
 use serde::{Deserialize, Serialize};
 
+pub mod channel;
 pub mod pipe;
 pub mod stream;
 

--- a/implementations/rust/ockam/ockam/src/protocols/pipe/internal.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/pipe/internal.rs
@@ -18,7 +18,7 @@ pub struct Ack {
 
 /// Payload sent from handshake listener to newly spawned receiver
 #[derive(Debug, Serialize, Deserialize, Message)]
-pub struct HandShake {
+pub struct Handshake {
     pub route_to_sender: Route,
 }
 
@@ -32,7 +32,7 @@ pub enum InternalCmd {
     /// Message received by pipe spawn listener
     InitHandshake,
     /// Message sent from listener to receiver
-    Handshake(HandShake),
+    Handshake(Handshake),
     /// Initialise a pipe sender with a route
     InitSender,
 }

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -144,7 +144,7 @@ impl Default for RouteBuilder<'_> {
 }
 
 impl RouteBuilder<'_> {
-    /// Create a new empty route builder
+    #[doc(hidden)]
     pub fn new() -> Self {
         Self {
             inner: VecDeque::new(),

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -137,8 +137,15 @@ pub struct RouteBuilder<'r> {
     write_back: Option<&'r mut Route>,
 }
 
+impl Default for RouteBuilder<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RouteBuilder<'_> {
-    fn new() -> Self {
+    /// Create a new empty route builder
+    pub fn new() -> Self {
         Self {
             inner: VecDeque::new(),
             write_back: None,


### PR DESCRIPTION
The initial implementation of bi-directional messaging channels, built on top of uni-directional messaging pipes.

During the handshake creation two pipe workers are spawned on each end of the channel (Sender and Receiver), plus an additional channel worker that is responsible for doing route backtracing.

Currently this code does not allow for additional behaviour to be attached to a channel worker (for example to implement secure channels)