### PR TITLE
build: bump gradle version to 7.3.1

### DIFF
--- a/tools/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
-distributionSha256Sum=dccda8aa069563c8ba2f6cdfd0777df0e34a5b4d15138ca8b9757e94f4e8a8cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionSha256Sum=9afb3ca688fc12c761a0e9e4321e4d24e977a4a8916c8a768b1fe05ddb4d6b66
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Current Behaviour

On newer JDK versions (`>= openjdk16`)  all gradle operations  fail with the message:

```
Could not open settings generic class cache for settings file ...
```

## Proposed Changes

Updating gradle to the latest version (`7.3.1`) resolves this issue.