### PR TITLE
feat(elixir): support heartbeats in TCP transport

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/router.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/router.ex
@@ -81,11 +81,19 @@ defmodule Ockam.Router do
     end
   end
 
-  defp invoke_handler(handler, message) when is_function(handler, 1) do
-    case handler.(message) do
+  defp invoke_handler(handler, message) do
+    case apply_handler(handler, message) do
       {:error, error} -> {:error, {:handler_error, error, message, handler}}
       _anything_else -> :ok
     end
+  end
+
+  defp apply_handler(handler, message) when is_function(handler, 1) do
+    apply(handler, [message])
+  end
+
+  defp apply_handler({m, f, a}, message) when is_atom(m) and is_atom(f) and is_list(a) do
+    apply(m, f, [message | a])
   end
 
   @doc """

--- a/implementations/elixir/ockam/ockam/lib/ockam/router/message_handler.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/router/message_handler.ex
@@ -4,10 +4,19 @@ defmodule Ockam.Router.MessageHandler do
   alias Ockam.Message
 
   @typedoc """
-  A function that accepts an address and a message as arguments.
-  It returns `:ok` or `{:error, reason}`, where `reason` can be any term.
+  Ockam message handler.
+  Can be a single argument function, that accepts ockam message as an argument
+  Or an `{module, function, args}` tuple, which will be called with
+  ockam message as a first argument and `args` as the rest
+
+  Should return `:ok` or `{:error, reason}`, where `reason` can be any term.
   """
-  @type t :: (Message.t() -> :ok | {:error, reason :: any()})
+  @type t :: (Message.t() -> :ok | {:error, reason :: any()}) | {atom(), atom(), [any()]}
+
+  @doc false
+  defguard is_mfa(term)
+           when is_tuple(term) and tuple_size(term) == 3 and is_atom(elem(term, 0)) and
+                  is_atom(elem(term, 1)) and is_list(elem(term, 2))
 
   @doc """
   Returns `true` if `term` is a valid `t:Ockam.Router.MessageHandler.t/0`;
@@ -16,5 +25,5 @@ defmodule Ockam.Router.MessageHandler do
   Allowed in guard tests. Inlined by the compiler.
   """
   @doc guard: true
-  defguard is_message_handler(term) when is_function(term)
+  defguard is_message_handler(term) when is_function(term, 1) or is_mfa(term)
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/handler.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/handler.ex
@@ -44,6 +44,11 @@ defmodule Ockam.Transport.TCP.Handler do
   end
 
   @impl true
+  def handle_info({:tcp, socket, ""}, %{socket: socket} = state) do
+    ## Empty TCP payload - ignore
+    {:noreply, state}
+  end
+
   def handle_info({:tcp, socket, data}, %{socket: socket, address: address} = state) do
     {function_name, _} = __ENV__.function
 


### PR DESCRIPTION
## Current Behaviour

Load balancers tend to stop connections when they idle for few minutes.

TCP keepalives may be used to address that, but keepalive interval requires
kernel tuning.


## Proposed Changes

TCP transport can support custom keepalive heartbeats by sending periodic empty
messages from TCP client to handler.

Handler ignores empty messages.

Client can be configured to send heartbeats every `interval` milliseconds
by using `heartbeat: interval` option.

To make sure client is created with `heartbeat` option,
TCP transport should be started with client options:
`Ockam.Transport.TCP.start(client_options: [heartbeat: interval])`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
