### PR TITLE
ci: reduce commitlint and editorconfig run

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,5 +1,10 @@
 name: Lint Commit Messages
-on: [pull_request, push, workflow_dispatch]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -1,5 +1,10 @@
 name: Lint Editorconfig
-on: [pull_request, push, workflow_dispatch]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour
Editorconfig and commit message linter is run twice on a pull request as a pull request perform a `on: push and pull_request`. 
<img width="828" alt="Screenshot 2021-12-06 at 6 26 37 PM" src="https://user-images.githubusercontent.com/31141573/144892993-f1173c7c-7c4b-4211-9411-9210f65b87ff.png">


<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
We should only run the workflow if it's a pull request or if merged to develop.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
