### PR TITLE
ci: fix invalid argument for cargo release

### DIFF
--- a/tools/scripts/release/crate-bump.sh
+++ b/tools/scripts/release/crate-bump.sh
@@ -14,7 +14,7 @@ done
 
 for to_update in ${updated_crates[@]}; do
     if [[ $DEV_VERSION == true ]]; then
-        echo y | cargo release release --no-push --no-publish --no-tag -p $to_update --execute
+        cargo release release --no-push --no-publish --no-confirm --no-tag --package $to_update --execute
     else
 
         # If the bump version is indicated as release, we don't bump
@@ -25,6 +25,6 @@ for to_update in ${updated_crates[@]}; do
             version="${specified_crate_version[$to_update]}"
         fi
 
-        echo y | cargo release $version --no-push --no-publish --no-tag --no-dev-version -p $to_update --execute
+        cargo release $version --no-push --no-publish --no-confirm --no-tag --no-dev-version --package $to_update --execute
     fi
 done


### PR DESCRIPTION
The script uses `-p` instead of `--package` which is not recognized as a `cargo-release` argument.

Additionally, `echo y` does not work to avoid confirmation. The proper way to do that is `--no-confirm`
## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
