### PR TITLE
test(elixir): increase timeout in ordering test to make it more stable

### DIFF
--- a/implementations/elixir/ockam/ockam/test/ockam/messaging/ordering_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/messaging/ordering_test.exs
@@ -5,13 +5,13 @@ defmodule Ockam.Messaging.Ordering.Tests do
 
   monotonic_pipes = [Ockam.Messaging.Ordering.Monotonic.IndexPipe]
 
-  strict_pipes = [
+  continuous_pipes = [
     Ockam.Messaging.Ordering.Strict.ConfirmPipe,
     Ockam.Messaging.Ordering.Strict.IndexPipe
   ]
 
-  Enum.each(strict_pipes, fn pipe ->
-    test "Pipe #{pipe} is ordered" do
+  Enum.each(continuous_pipes, fn pipe ->
+    test "Pipe #{pipe} is continuously ordered" do
       pipe_mod = unquote(pipe)
       {:ok, me} = Ockam.Node.register_random_address()
 
@@ -35,7 +35,7 @@ defmodule Ockam.Messaging.Ordering.Tests do
           receive do
             %{payload: pl} -> String.to_integer(pl)
           after
-            1000 ->
+            2000 ->
               raise "message #{n} not received"
           end
         end)


### PR DESCRIPTION
## Current Behaviour

There is an unstable test https://github.com/ockam-network/ockam/runs/4458049139?check_suite_focus=true

## Proposed Changes

Increased the timeout waiting for ordered messages

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
