### PR TITLE
Release 2021-12-13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.29.1-dev"
+version = "0.30.0"
 dependencies = [
  "bls12_381_plus",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.34.1-dev"
+version = "0.35.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.33.1-dev"
+version = "0.34.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.30.1-dev"
+version = "0.31.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.36.1-dev"
+version = "0.37.0"
 dependencies = [
  "futures 0.3.18",
  "hashbrown 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.31.1-dev"
+version = "0.32.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "signature_ps"
-version = "0.29.1-dev"
+version = "0.30.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.31.1-dev"
+version = "0.32.0"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_examples"
-version = "0.24.1-dev"
+version = "0.25.0"
 dependencies = [
  "ockam",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.10.1-dev"
+version = "0.11.0"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.2.1-dev"
+version = "0.3.0"
 dependencies = [
  "bunt",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.15.1-dev"
+version = "0.16.0"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.33.1-dev"
+version = "0.34.0"
 dependencies = [
  "ockam_core",
  "ockam_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.31.1-dev"
+version = "0.32.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node_no_std"
-version = "0.13.1-dev"
+version = "0.14.0"
 dependencies = [
  "executor",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.30.1-dev"
+version = "0.31.0"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.35.1-dev"
+version = "0.36.0"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.37.1-dev"
+version = "0.38.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.40.1-dev"
+version = "0.41.0"
 dependencies = [
  "cortex-m",
  "cortex-m-semihosting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.41.1-dev"
+version = "0.42.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.41.1-dev"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.33.1-dev"
+version = "0.34.0"
 dependencies = [
  "ockam_core",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_macros"
-version = "0.2.1-dev"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add a test for full pipe behaviour stack
+
+### Changed
+
+- Introduce nested pipe behaviour test
+- Initial ockam channel implementation
+- Simplify channel creation handshake
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
+### Fixed
+
+- Fix channel channel behavior and add tests
+- Clippy style update
+- Update channels with no_std support
+
 ## 0.41.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.42.0 - 2021-12-13
 
 ### Added
 

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce nested pipe behaviour test
 - Initial ockam channel implementation
 - Simplify channel creation handshake
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ### Fixed

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -81,7 +81,7 @@ ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.41.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -86,7 +86,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_featur
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.36.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }
-ockam_entity = { path = "../ockam_entity", version = "^0.31.1-dev", default_features = false }
+ockam_entity = { path = "../ockam_entity", version = "^0.32.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.31.1-dev", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -91,7 +91,7 @@ arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.31.1-dev", path = "../signature_core", optional = true }
 signature_bbs_plus = { version = "^0.32.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
-signature_bls = { version = "^0.29.1-dev", path = "../signature_bls", package = "signature_bls", optional = true }
+signature_bls = { version = "^0.30.0", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -79,7 +79,7 @@ path = "tests/main.rs"
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.41.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.41.1-dev"
+version = "0.42.0"
 publish = true
 
 [features]

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -82,7 +82,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_featu
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.37.1-dev", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.36.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -89,7 +89,7 @@ ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0"
 ockam_entity = { path = "../ockam_entity", version = "^0.32.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
-signature_core = { version = "^0.31.1-dev", path = "../signature_core", optional = true }
+signature_core = { version = "^0.32.0", path = "../signature_core", optional = true }
 signature_bbs_plus = { version = "^0.32.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
 signature_bls = { version = "^0.30.0", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -78,7 +78,7 @@ path = "tests/main.rs"
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -85,7 +85,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_featur
 ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.36.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.32.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
@@ -102,7 +102,7 @@ dyn-clone = "1.0"
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -77,7 +77,7 @@ name = "tests"
 path = "tests/main.rs"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -90,7 +90,7 @@ ockam_entity = { path = "../ockam_entity", version = "^0.32.0", default_features
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.31.1-dev", path = "../signature_core", optional = true }
-signature_bbs_plus = { version = "^0.31.1-dev", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
+signature_bbs_plus = { version = "^0.32.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
 signature_bls = { version = "^0.29.1-dev", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -83,7 +83,7 @@ ockam_node = { path = "../ockam_node", version = "^0.41.0", default-features = f
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.36.1-dev", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.32.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -80,7 +80,7 @@ path = "tests/main.rs"
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.41.0", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.0", optional = true }
@@ -101,7 +101,7 @@ hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -84,7 +84,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.38.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.36.1-dev", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.32.0", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -69,7 +69,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.41.0"
+ockam = "0.42.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Update `LocalInfo` logic
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.37.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `LocalInfo` logic
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.37.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.38.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -37,14 +37,14 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.41.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.34.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -36,7 +36,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features 
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.41.0", default_features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
@@ -47,6 +47,6 @@ tracing = { version = "0.1", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.34.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0"}
 trybuild = {version = "1.0", features = ["diff"]}
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -33,7 +33,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchang
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -46,7 +46,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev"}
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.33.1-dev"}
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.34.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 trybuild = {version = "1.0", features = ["diff"]}
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.37.1-dev"
+version = "0.38.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -34,7 +34,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchang
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
@@ -45,7 +45,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.34.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 trybuild = {version = "1.0", features = ["diff"]}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -31,7 +31,7 @@ no_std = ["ockam_core/no_std", "ockam_macros/no_std", "ockam_key_exchange_core/n
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchange_xx/alloc", "ockam_node/alloc", "ockam_vault_sync_core/alloc", "ockam_vault/alloc", "serde/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -35,7 +35,7 @@ ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.41.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -32,7 +32,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "ockam_key_exchang
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.37.0"
+ockam_channel = "0.38.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated deps
 
 ## 0.2.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.3.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.2.0 - 2021-12-06
 
 ### Fixed

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.2.1-dev"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -19,7 +19,7 @@ exitcode = "1.1.2"
 human-panic = "1.0.3"
 indicatif = "0.16.2"
 log = "0.4.14"
-ockam = { version = "^0.41.1-dev", path = "../ockam" }
+ockam = { version = "^0.42.0", path = "../ockam" }
 serde = "1.0.130"
 # FIXME: stderrlog depends on chrono, triggers:
 # - https://rustsec.org/advisories/RUSTSEC-2020-0159

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `LocalInfo` logic
 - Initial ockam channel implementation
 - Simplify channel creation handshake
-- Change all crates to `-dev` version
 - Move ockam_vault_core crate into ockam_core
 
 ## 0.41.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add access control
+- Add ockam_core/bls feature and small fixes
+
+### Changed
+
+- Update `LocalInfo` logic
+- Initial ockam channel implementation
+- Simplify channel creation handshake
+- Change all crates to `-dev` version
+- Move ockam_vault_core crate into ockam_core
+
 ## 0.41.0 - 2021-12-06
 
 ### Added

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.42.0 - 2021-12-13
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.41.1-dev"
+version = "0.42.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -30,7 +30,7 @@ alloc = ["core2/alloc", "heapless", "hex/alloc", "serde/alloc", "serde_bare/allo
 bls = []
 
 [dependencies]
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 async-trait = "0.1.42"
 hashbrown =  { version = "0.11", default-features = false, features = ["ahash", "serde"] }
 heapless = { version = "0.7.1", optional = true }

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.41.0"
+ockam_core = "0.42.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.41.0" , default-features = false }
+ockam_core = { version = "0.42.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement add key for entity
 - Update entity structure
 - Update `LocalInfo` logic
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ### Removed

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add access control
+- Add ockam_core/bls feature and small fixes
+
+### Changed
+
+- Vault updates
+- Implement add key for entity
+- Update entity structure
+- Update `LocalInfo` logic
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
+### Removed
+
+- Remove stale ref to `KeyAttributes`
+
 ## 0.31.0 - 2021-12-06
 
 ### Added

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.32.0 - 2021-12-13
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -39,7 +39,7 @@ credentials = [ "ockam_vault/bls", "signature_core", "signature_bbs_plus", "sign
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false  }
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.35.1-dev", default-features = false, optional = true}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -40,7 +40,7 @@ credentials = [ "ockam_vault/bls", "signature_core", "signature_bbs_plus", "sign
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false  }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
-ockam_node = {path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
+ockam_node = {path = "../ockam_node", version = "^0.41.0", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.35.1-dev", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.38.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -52,7 +52,7 @@ heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
 signature_bls = { path = "../signature_bls", version = "^0.29.1-dev", optional = true     }
-signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.31.1-dev", optional = true     }
+signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 serde_json = { version ="1.0", optional = true }
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -50,7 +50,7 @@ cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
+signature_core = { path = "../signature_core", version = "^0.32.0", optional = true     }
 signature_bls = { path = "../signature_bls", version = "^0.30.0", optional = true     }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -42,7 +42,7 @@ ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.41.0", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}
-ockam_vault = {path = "../ockam_vault", version = "^0.35.1-dev", default-features = false, optional = true}
+ockam_vault = {path = "../ockam_vault", version = "^0.36.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.38.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default-features = false, optional = true}
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default-features = false }
@@ -62,7 +62,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 rand_xorshift = "0"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -44,7 +44,7 @@ ockam_node = {path = "../ockam_node", version = "^0.40.1-dev", default-features 
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.35.1-dev", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.38.0", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default-features = false, optional = true}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default-features = false, optional = true}
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -45,7 +45,7 @@ ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-d
 ockam_vault = {path = "../ockam_vault", version = "^0.35.1-dev", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.38.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default-features = false, optional = true}
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -38,7 +38,7 @@ alloc = ["ockam_core/alloc","ockam_channel/alloc", "ockam_key_exchange_core/allo
 credentials = [ "ockam_vault/bls", "signature_core", "signature_bbs_plus", "signature_bls", "bls12_381_plus"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default-features = false  }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false  }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -41,7 +41,7 @@ credentials = [ "ockam_vault/bls", "signature_core", "signature_bbs_plus", "sign
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default-features = false  }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
 ockam_node = {path = "../ockam_node", version = "^0.41.0", default-features = false }
-ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}
+ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.34.0", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.36.0", default-features = false, optional = true}
 ockam_channel = {path = "../ockam_channel", version = "^0.38.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.0", default-features = false, optional = true}
@@ -63,6 +63,6 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp"}
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0"}
 rand_xorshift = "0"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -51,7 +51,7 @@ group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
-signature_bls = { path = "../signature_bls", version = "^0.29.1-dev", optional = true     }
+signature_bls = { path = "../signature_bls", version = "^0.30.0", optional = true     }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 serde_json = { version ="1.0", optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -43,7 +43,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default-featu
 ockam_node = {path = "../ockam_node", version = "^0.40.1-dev", default-features = false }
 ockam_vault_sync_core = {path = "../ockam_vault_sync_core", version = "^0.33.1-dev", default-features = false, optional = true}
 ockam_vault = {path = "../ockam_vault", version = "^0.35.1-dev", default-features = false, optional = true}
-ockam_channel = {path = "../ockam_channel", version = "^0.37.1-dev", default-features = false }
+ockam_channel = {path = "../ockam_channel", version = "^0.38.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.34.1-dev", default-features = false, optional = true}
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_entity"
-version = "0.31.1-dev"
+version = "0.32.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_entity/README.md
+++ b/implementations/rust/ockam/ockam_entity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_entity = "0.31.0"
+ockam_entity = "0.32.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_examples/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_examples/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.25.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_examples/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_examples/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.24.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_examples/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_examples/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.24.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_examples/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ockam Developers"]
 description = """Example projects using the Ockam APIs"""
-version = "0.24.1-dev"
+version = "0.25.0"
 edition = "2018"
 homepage = "https://github.com/ockam-network/ockam"
 keywords = ["ockam", "crypto", "cryptography"]

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.11.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.10.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.10.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.10.1-dev"
+version = "0.11.0"
 publish = true
 
 [features]

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -29,6 +29,6 @@ no_std  = ["ockam_core/no_std"]
 crossbeam-queue = { version = "0.3.2", default_features = false, features = ["alloc"] }
 futures = { version = "0.3.15", default-features = false, features = [ "async-await" ] }
 heapless = { version = "0.7", features = [ "mpmc_large" ] }
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_executor = "0.10.0"
+ockam_executor = "0.11.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add script to rebuild macos native vault lib
+- Add ockam_core/bls feature and small fixes
+
+### Changed
+
+- Vault updates
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## v0.32.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Vault updates
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## v0.32.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -23,6 +23,6 @@ bls = ["ockam_core/bls"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0"}
 lazy_static = "1.4"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 bls = ["ockam_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev"}
+ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 lazy_static = "1.4"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -22,7 +22,7 @@ bls = ["ockam_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 lazy_static = "1.4"
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.33.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.34.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.33.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.33.1-dev"
+version = "0.34.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -27,5 +27,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.33.0"
+ockam_key_exchange_core = "0.34.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.34.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Vault updates
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.33.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Vault updates
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.33.0 - 2021-12-06
 
 ### Fixed

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -28,7 +28,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.33.1-dev", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.33.1-dev"
+version = "0.34.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -34,6 +34,6 @@ arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,5 +35,5 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.33.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core" , version = "^0.34.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -36,4 +36,4 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
-ockam_node = { path = "../ockam_node" , version = "^0.40.1-dev"}
+ockam_node = { path = "../ockam_node" , version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.33.0"
+ockam_key_exchange_x3dh = "0.34.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Vault updates
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.34.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.35.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Vault updates
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.34.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -32,6 +32,6 @@ ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = f
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.34.1-dev"
+version = "0.35.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -34,4 +34,4 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
-ockam_node = { path = "../ockam_node" , version = "^0.40.1-dev"}
+ockam_node = { path = "../ockam_node" , version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -29,7 +29,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.0", default_features = false }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -33,5 +33,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.33.1-dev"}
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_node = { path = "../ockam_node" , version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -28,7 +28,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.33.1-dev", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.34.0"
+ockam_key_exchange_xx = "0.35.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.3.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.2.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.2.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_macros"
-version = "0.2.1-dev"
+version = "0.3.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Ockam Developers"]

--- a/implementations/rust/ockam/ockam_macros/README.md
+++ b/implementations/rust/ockam/ockam_macros/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_macros = "0.2.0"
+ockam_macros = "0.3.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.40.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.41.0 - 2021-12-13
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add access control
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.40.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -36,7 +36,7 @@ tokio = {version = "1.8", default-features = false, optional = true, features = 
 tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }
 heapless = { version = "0.7", features = [ "mpmc_large" ], optional = true }
-ockam_node_no_std = { path = "../ockam_node_no_std", version = "^0.13.1-dev", default-features = false, optional = true }
+ockam_node_no_std = { path = "../ockam_node_no_std", version = "^0.14.0", default-features = false, optional = true }
 ockam_executor = { path = "../ockam_executor", version = "^0.11.0", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "arm")'.dependencies]

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -30,7 +30,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc", "ockam_node_no_std/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev"}
 tokio = {version = "1.8", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"]}
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -37,7 +37,7 @@ tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }
 heapless = { version = "0.7", features = [ "mpmc_large" ], optional = true }
 ockam_node_no_std = { path = "../ockam_node_no_std", version = "^0.13.1-dev", default-features = false, optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.10.1-dev", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.11.0", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "arm")'.dependencies]
 # TODO replace cortex-m-semihosting with 'log'

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -31,7 +31,7 @@ dump_internals = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev"}
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0"}
 tokio = {version = "1.8", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"]}
 tracing = { version = "0.1", default_features = false }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"], optional = true }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "cryptography", "network-programming", "encryption"]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.40.1-dev"
+version = "0.41.0"
 publish = true
 
 [features]

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.40.0"
+ockam_node = "0.41.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.13.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.13.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node_no_std/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.14.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_node_no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_no_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_node_no_std"
-version = "0.13.1-dev"
+version = "0.14.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_node_no_std/README.md
+++ b/implementations/rust/ockam/ockam_node_no_std/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node_no_std = "0.13.0"
+ockam_node_no_std = "0.14.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Upgrade portals flow
+- Change all crates to `-dev` version
+
 ## 0.15.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade portals flow
-- Change all crates to `-dev` version
 
 ## 0.15.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.16.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.15.1-dev"
+version = "0.16.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -36,5 +36,5 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false  }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false  }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_core = "0.15.0"
+ockam_transport_core = "0.16.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.37.0 - 2021-12-13
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade portals flow
 - Adjust portals delays to avoid race conditions
 - Stop tcp worker on hearbeat failure
-- Change all crates to `-dev` version
 
 ### Fixed
 

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add basic portal test
+- Add tcp heartbeats
+
+### Changed
+
+- Upgrade portals flow
+- Adjust portals delays to avoid race conditions
+- Stop tcp worker on hearbeat failure
+- Change all crates to `-dev` version
+
+### Fixed
+
+- Fix clippy warnings
+
 ## 0.36.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -23,7 +23,7 @@ alloc = []
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev"}
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev"}
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -24,7 +24,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_node = { path = "../ockam_node", version = "^0.41.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = ["rt-multi-thread","sync","net","macros","time","io-util"] }
 futures = "0.3.10"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -21,7 +21,7 @@ std = ["ockam_macros/std"]
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev"}
+ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev"}
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.36.1-dev"
+version = "0.37.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -22,7 +22,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
-ockam_node = { path = "../ockam_node", version = "^0.40.1-dev"}
+ockam_node = { path = "../ockam_node", version = "^0.41.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.36.0"
+ockam_transport_tcp = "0.37.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.30.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.30.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.31.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.30.1-dev"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -26,7 +26,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_node = { path = "../ockam_node", version = "^0.41.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.0"}
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -25,7 +25,7 @@ alloc = []
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
 ockam_core = { path = "../ockam_core", version = "^0.42.0"}
-ockam_node = { path = "../ockam_node", version = "^0.40.1-dev"}
+ockam_node = { path = "../ockam_node", version = "^0.41.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }
 tokio-tungstenite = "0.15"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -24,7 +24,7 @@ alloc = []
 [dependencies]
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["tokio-io"] }
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev"}
+ockam_core = { path = "../ockam_core", version = "^0.42.0"}
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.15.1-dev"}
 tokio = { version = "1.8", features = ["rt-multi-thread", "sync", "net", "macros", "time"] }

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.30.0"
+ockam_transport_websocket = "0.31.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Vault updates
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.35.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.36.0 - 2021-12-13
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add ockam_core/bls feature and small fixes
+
+### Changed
+
+- Vault updates
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.35.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -35,7 +35,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
-signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.31.1-dev", optional = true     }
+signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
 signature_bls = { path = "../signature_bls", version = "^0.29.1-dev", optional = true     }
 signature_ps = { path = "../signature_ps", version = "^0.29.1-dev", default-features = false, optional = true }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -51,5 +51,5 @@ cfg-if = "1.0"
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.30.1-dev"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.31.0"}
 tokio = {version = "1.8", features = ["full"]}

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.35.1-dev"
+version = "0.36.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -36,7 +36,7 @@ ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
-signature_bls = { path = "../signature_bls", version = "^0.29.1-dev", optional = true     }
+signature_bls = { path = "../signature_bls", version = "^0.30.0", optional = true     }
 signature_ps = { path = "../signature_ps", version = "^0.29.1-dev", default-features = false, optional = true }
 arrayref = "0.3"
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -37,7 +37,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features 
 signature_core = { path = "../signature_core", version = "^0.32.0", optional = true     }
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
 signature_bls = { path = "../signature_bls", version = "^0.30.0", optional = true     }
-signature_ps = { path = "../signature_ps", version = "^0.29.1-dev", default-features = false, optional = true }
+signature_ps = { path = "../signature_ps", version = "^0.30.0", default-features = false, optional = true }
 arrayref = "0.3"
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }
 curve25519-dalek = { version = "3.1", default-features = false }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -33,7 +33,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.31.1-dev", optional = true     }
 signature_bls = { path = "../signature_bls", version = "^0.29.1-dev", optional = true     }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -34,7 +34,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default-features = false }
-signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
+signature_core = { path = "../signature_core", version = "^0.32.0", optional = true     }
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.32.0", optional = true     }
 signature_bls = { path = "../signature_bls", version = "^0.30.0", optional = true     }
 signature_ps = { path = "../signature_ps", version = "^0.29.1-dev", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -32,7 +32,7 @@ no_std = ["ockam_core/no_std", "ockam_macros/no_std", "rand_pcg", "x25519-dalek/
 alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.31.1-dev", optional = true     }
 signature_bbs_plus = {path = "../signature_bbs_plus", version = "^0.31.1-dev", optional = true     }

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.35.0"
+ockam_vault = "0.36.0"
 ```
 
 ## Crate Features
@@ -33,7 +33,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault = { version = "0.35.0" , default-features = false }
+ockam_vault = { version = "0.36.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.33.0 - 2021-12-06
 
 ### Changed

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.33.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.34.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_sync_core"
-version = "0.33.1-dev"
+version = "0.34.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -43,4 +43,4 @@ rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.30.1-dev"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.31.0"}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -32,7 +32,7 @@ alloc = ["ockam_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/all
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.41.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = ["sync"], optional = true}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -42,5 +42,5 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev"}
+ockam_vault = { path = "../ockam_vault", version = "^0.36.0"}
 ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.30.1-dev"}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -33,7 +33,7 @@ alloc = ["ockam_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/all
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.41.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = ["sync"], optional = true}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -30,7 +30,7 @@ no_std = ["ockam_core/no_std", "ockam_macros/no_std", "ockam_vault/no_std", "ock
 alloc = ["ockam_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.41.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -31,7 +31,7 @@ alloc = ["ockam_core/alloc", "ockam_vault/alloc", "ockam_node/alloc", "serde/all
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.42.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.2.1-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.3.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.40.1-dev", default_features = false }
 tokio = { version = "1.8", default-features = false, features = ["sync"], optional = true}

--- a/implementations/rust/ockam/ockam_vault_sync_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_sync_core = "0.33.0"
+ockam_vault_sync_core = "0.34.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Vault updates
+- Change all crates to `-dev` version
+- Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+
 ## 0.30.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Vault updates
-- Change all crates to `-dev` version
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
 
 ## 0.30.0 - 2021-12-06

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.31.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -14,5 +14,5 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 publish = true
 
 [dependencies]
-ockam_core = {path = "../ockam_core", version = "^0.41.1-dev"}
+ockam_core = {path = "../ockam_core", version = "^0.42.0"}
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -3,7 +3,7 @@ name = "ockam_vault_test_suite"
 categories = ["cryptography", "asynchronous", "authentication","network-programming", "embedded"]
 description = """Ockam Vault test suite.
 """
-version = "0.30.1-dev"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_test_suite/README.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_test_suite = "0.30.0"
+ockam_vault_test_suite = "0.31.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.32.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.31.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -24,7 +24,7 @@ managed = { version = "0.8", default-features = false, features = ["map"] }
 pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { version = "^0.31.1-dev", path = "../signature_core" }
+signature_core = { version = "^0.32.0", path = "../signature_core" }
 signature_bls = { version = "^0.30.0", path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bbs_plus"
-version = "0.31.1-dev"
+version = "0.32.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -25,7 +25,7 @@ pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { version = "^0.31.1-dev", path = "../signature_core" }
-signature_bls = { version = "^0.29.1-dev", path = "../signature_bls" }
+signature_bls = { version = "^0.30.0", path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_bbs_plus/README.md
+++ b/implementations/rust/ockam/signature_bbs_plus/README.md
@@ -18,14 +18,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_bbs_plus = "0.31.0"
+signature_bbs_plus = "0.32.0"
 ```
 
 ## Crate Features
 
 ```
 [dependencies]
-signature_bbs_plus = { version = "0.31.0" , default-features = false }
+signature_bbs_plus = { version = "0.32.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.30.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.29.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.29.0 - 2021-12-06
 

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bls"
-version = "0.29.1-dev"
+version = "0.30.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_bls/README.md
+++ b/implementations/rust/ockam/signature_bls/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_bls = "0.29.0"
+signature_bls = "0.30.0"
 ```
 
 ## Crate Features
@@ -27,7 +27,7 @@ disabled as follows
 
 ```
 [dependencies]
-signature_bls = { version = "0.29.0" , default-features = false }
+signature_bls = { version = "0.30.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/signature_core/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_core/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.31.0 - 2021-12-06
 

--- a/implementations/rust/ockam/signature_core/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.32.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_core/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.31.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_core"
-version = "0.31.1-dev"
+version = "0.32.0"
 authors = ["Ockam Deveopers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_core/README.md
+++ b/implementations/rust/ockam/signature_core/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_core = "0.31.0"
+signature_core = "0.32.0"
 ```
 
 ## Crate Features

--- a/implementations/rust/ockam/signature_ps/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_ps/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.30.0 - 2021-12-13
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_ps/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_ps/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Change all crates to `-dev` version
+
 ## 0.29.0 - 2021-12-06
 
 ### Removed

--- a/implementations/rust/ockam/signature_ps/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_ps/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change all crates to `-dev` version
+- Updated dependencies
 
 ## 0.29.0 - 2021-12-06
 

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_ps"
-version = "0.29.1-dev"
+version = "0.30.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 
 [dependencies]
 blake2 = { version = "0.9", default-features = false }
-signature_bls = { version = "^0.29.1-dev", path = "../signature_bls" }
+signature_bls = { version = "^0.30.0", path = "../signature_bls" }
 bls12_381_plus = { version = "0.5", default-features = false }
 digest = { version = "0.9", default-features = false }
 ff = { version = "0.10", default-features = false }

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -28,7 +28,7 @@ pairing = "0.20"
 rand_core = "0.6"
 rand_chacha = { version = "0.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { version = "^0.31.1-dev", path = "../signature_core" }
+signature_core = { version = "^0.32.0", path = "../signature_core" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_ps/README.md
+++ b/implementations/rust/ockam/signature_ps/README.md
@@ -16,14 +16,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_ps = "0.29.0"
+signature_ps = "0.30.0"
 ```
 
 ## Crate Features
 
 ```
 [dependencies]
-signature_ps = { version = "0.29.0" , default-features = false }
+signature_ps = { version = "0.30.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency


### PR DESCRIPTION
- ci: changelogs for release
- ci: crate release ockam version 0.42.0
- ci: crate release ockam_channel version 0.38.0
- ci: crate release ockam_command version 0.3.0
- ci: crate release ockam_core version 0.42.0
- ci: crate release ockam_entity version 0.32.0
- ci: crate release ockam_examples version 0.25.0
- ci: crate release ockam_executor version 0.11.0
- ci: crate release ockam_key_exchange_core version 0.34.0
- ci: crate release ockam_key_exchange_x3dh version 0.34.0
- ci: crate release ockam_key_exchange_xx version 0.35.0
- ci: crate release ockam_macros version 0.3.0
- ci: crate release ockam_node version 0.41.0
- ci: crate release ockam_node_no_std version 0.14.0
- ci: crate release ockam_transport_core version 0.16.0
- ci: crate release ockam_transport_tcp version 0.37.0
- ci: crate release ockam_transport_websocket version 0.31.0
- ci: crate release ockam_vault version 0.36.0
- ci: crate release ockam_vault_sync_core version 0.34.0
- ci: crate release ockam_vault_test_suite version 0.31.0
- ci: crate release signature_bbs_plus version 0.32.0
- ci: crate release signature_bls version 0.30.0
- ci: crate release signature_core version 0.32.0
- ci: crate release signature_ps version 0.30.0
- ci: remove dev tag entries
