### PR TITLE
chore(rust): fix no_std compilation due to ockam::node attribute

### DIFF
--- a/implementations/rust/ockam/ockam_macros/src/node_attribute/parser.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_attribute/parser.rs
@@ -29,7 +29,17 @@ fn output_node(
     let err_handling = if ret_type == ReturnType::Default {
         quote! {.unwrap();}
     } else {
+        #[cfg(feature = "std")]
         quote! {?}
+
+        // For now the executor's `Executor::execute` for std returns `Result<F::Output>`
+        // while for no_std it returns `Result<()>` and always returns `Ok(())` or panics.
+        // So while it makes sense using the `?` operator in std in no_std just returning Ok(())
+        // would be enough(since execute already hides the return type) but we are letting the
+        // `Executor::execute` return bubble up to keep the code simpler.
+        // Note: This also means that for no_std `main` return type can only be `Result<()>` or nothing.
+        #[cfg(not(feature = "std"))]
+        quote! {}
     };
 
     // Assumes the target platform knows about main() functions


### PR DESCRIPTION
While working in #2213 I found that the compilation of `no_std` examples were failing due to problems with the `ockam::node` attribute

<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

When doing: 
```
cd implementations/rust/ockam/ockam_examples/example_projects/no_std/
cargo run --example hello --no-default-features --features="alloc, no_std"
```
I got the error:

```
error[E0308]: `?` operator has incompatible types
  --> examples/hello.rs:45:1
   |
45 | #[ockam::node]
   | ^^^^^^^^^^^^^^ expected enum `Result`, found `()`
   |
   = note: `?` operator cannot convert from `()` to `Result<(), ockam::Error>`
   = note:   expected enum `Result<(), ockam::Error>`
           found unit type `()`
   = note: this error originates in the attribute macro `ockam::node` (in Nightly builds, run with -Z macro-backtrace for more info)
help: try removing this `?`
   |
45 - #[ockam::node]
45 + #[ockam::node
   | 
help: try using a variant of the expected enum
   |
45 | Ok(#[ockam::node])
   |

For more information about this error, try `rustc --explain E0308`.
error: could not compile `hello_ockam_no_std` due to previous error
```

The same happened when running the example with any of the feature flags corresponding to `no_std`

## Proposed Changes

The reason for this is that the `node` attribute [returns the result from `Executor::execute`](https://github.com/ockam-network/ockam/blob/5a84ea59fd9d8a67b8e0585a6be312c6d54fc906/implementations/rust/ockam/ockam_macros/src/node_attribute/parser.rs#L40) and it [either `unwraps` the result or attach a `?`](https://github.com/ockam-network/ockam/blob/5a84ea59fd9d8a67b8e0585a6be312c6d54fc906/implementations/rust/ockam/ockam_macros/src/node_attribute/parser.rs#L29-L33) depending on the return type of `main`.

This works well for std where [the return type of `execute` is `Result<F::Output>`](https://github.com/ockam-network/ockam/blob/5a84ea59fd9d8a67b8e0585a6be312c6d54fc906/implementations/rust/ockam/ockam_node/src/executor.rs#L53) where `F::Output` is the return type of `main`, so if the return type of `main` is `Result<()>` the return type of `execute` is `Result<Result<()>>` and applying the `?` operator we get a `Result<()>`. 

However, [for no_std the return type of `execute` is `Result<()>`](https://github.com/ockam-network/ockam/blob/5a84ea59fd9d8a67b8e0585a6be312c6d54fc906/implementations/rust/ockam/ockam_node/src/executor.rs#L72) so applying the `?` operator to `Result<()>` we get a `()` which doesn't match with the return type of a main `Result<()>`, so in the `no_std` case I simply changed it to let the attribute return the result from `execute` verbatim.

This also means that `Ockam::node` in no_std will only work with no return type or `Result<()>` but since there is a TODO for `execute` to be unified with the std case that'll be solved, there's also no option to make it compatible with any other return type since the `execute` function as is now consume any type returned from `main` by unwrapping it and returning `Ok(())`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository. (Created PR: ockam-network/contributors#56 )

<!-- Looking forward to merging your contribution!! -->
