### PR TITLE
ci: fix dependabot coniguration for typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
       - "Type: Dependencies"
       - "Implementation: Rust"
 
-  # Maintain dependencies for typescript crates
-  - package-ecosystem: "yarn"
+  # Maintain dependencies for typescript packages
+  - package-ecosystem: "npm"
     directory: "/implementation/typescript"
     commit-message:
       prefix: "build:"


### PR DESCRIPTION
package-ecosystem value must be npm even though we use yarn.
