### PR TITLE
ci: cancel github workflows if there is a new trigger

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -16,6 +16,10 @@ on:
   schedule:
     - cron:  '0 1 * * *' # Run every day at 1am UTC https://cron.help/#0_1_*_*_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,6 +5,10 @@ permissions:
 
 on: [pull_request, push, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -5,6 +5,10 @@ permissions:
 
 on: [pull_request, push, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -30,6 +30,10 @@ on:
   schedule:
     - cron:  '0 1 * * *' # Run every day at 1am UTC cron.help/#0_1_*_*_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,6 +22,10 @@ on:
   schedule:
     - cron:  '0 1 * * *' # run every day at 1am utc cron.help/#0_1_*_*_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   list_tasks:
     name: List Tasks

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron:  '0 1 * * *' # run every day at 1am utc cron.help/#0_1_*_*_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Use Concurrency Groups to cancel github workflows if there is a new trigger.
