### PR TITLE
ci: prefix workflow names to job names

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    name: All Implementations - Build
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew build
 
   test:
-    name: Test
+    name: All Implementations - Test
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    name: Commits - Lint
     runs-on: ubuntu-20.04
 
     # We assume that commit 2fd0d36fe6ae0c2d527368683ec3a6352617b381 will be in the history

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    name: Editorconfig - Lint
     runs-on: ubuntu-20.04
     container: # gitlab.com/greut/eclint
       image: greut/eclint:v0.3.3@sha256:95e9a3dcbd236bae6569625cd403175cbde3705303774e7baca418b6442b8d77

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    name: Elixir - Build
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
@@ -47,7 +47,7 @@ jobs:
         run: ./gradlew build_elixir
 
   test:
-    name: Test
+    name: Elixir - Test
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   list_tasks:
-    name: List Tasks
+    name: Gradle - List Tasks
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019] # github.com/actions/virtual-environments#available-environments

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    name: Rust - Build
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
@@ -37,7 +37,7 @@ jobs:
         run: ./gradlew build_rust
 
   test:
-    name: Test
+    name: Rust - Test
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
@@ -48,7 +48,7 @@ jobs:
         run: ./gradlew test_rust
 
   check_no_std:
-    name: Check Features - no_std alloc software_vault
+    name: Rust - Check Features - no_std alloc software_vault
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
@@ -63,7 +63,7 @@ jobs:
           cargo check --no-default-features --features "no_std alloc software_vault"
 
   check_cargo_update:
-    name: Check Cargo Update
+    name: Rust - Check Cargo Update
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59


### PR DESCRIPTION
Some github UIs, like the gh command don't show workflow name
when showing running checks. This repition makes it easier to
observe what is running.
