### PR TITLE
Changed the wrong numbering

### DIFF
--- a/documentation/guides/rust/get-started/04-transport/README.md
+++ b/documentation/guides/rust/get-started/04-transport/README.md
@@ -229,5 +229,5 @@ cargo run --example 04-routing-over-transport-two-hops-initiator
 Note how the message is routed.
 
 <div style="display: none; visibility: hidden;">
-<hr><b>Next:</b> <a href="../05-secure-channel#readme">04. Secure Channel</a>
+<hr><b>Next:</b> <a href="../05-secure-channel#readme">05. Secure Channel</a>
 </div>


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour
In the last line of the [readme](https://github.com/ockam-network/ockam/tree/develop/documentation/guides/rust/get-started/04-transport#readme), the link which is meant to take you to [05-secure-channel](https://github.com/ockam-network/ockam/tree/develop/documentation/guides/rust/get-started/05-secure-channel#readme) had been wrongly named as 04. Secure Channel.

## Proposed Changes
Corrected the numbering by changing it from 04. Secure Channel to 05. Secure Channel.
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
