### PR TITLE
ci: remove built workspace members before caching

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/ockam-network/ockam/builder:latest
+FROM ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca

--- a/.github/actions/cargo_home_cache/action.yml
+++ b/.github/actions/cargo_home_cache/action.yml
@@ -10,6 +10,6 @@ runs:
           ~/.cargo/registry/index
           ~/.cargo/registry/cache
           ~/.cargo/git/db
-        key: cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+        key: cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
 
 # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: target
-        key: cargo-target--${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: cargo-target--${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59-
+        key: cargo-target---${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: cargo-target---${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: target
-        key: cargo-target---${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: cargo-target---${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-
+        key: cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html

--- a/.github/actions/cargo_target_dir_pre_cache/action.yml
+++ b/.github/actions/cargo_target_dir_pre_cache/action.yml
@@ -1,0 +1,18 @@
+name: CARGO_TARGET_DIR Pre Cache
+description: CARGO_TARGET_DIR Pre Cache
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        crates=($(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members[] | split(" ")  | .[0] | gsub("-";"_")'))
+
+        for mode in debug release; do
+          for dir in deps .fingerprint; do
+            if [ -d "target/$mode/$dir" ]; then
+              cd "target/$mode/$dir"
+              for crate in "${crates[@]}"; do rm -rf $crate* lib$crate*; done
+              cd -
+            fi
+          done
+        done

--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -6,6 +6,6 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: '**/deps'
-        key: elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59-${{ hashFiles('**/mix.lock') }}
+        key: elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59-
+          elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca-

--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -6,9 +6,9 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: ~/.gradle/wrapper/dists
-        key: gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+        key: gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
         restore-keys: |
-          gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+          gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
           gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-
           gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-
           gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
       - run: ./gradlew build -Pmode=release
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   list_gradle_tasks:
     name: All - List Gradle Tasks

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -33,7 +33,7 @@ jobs:
     name: All - Build
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,7 +45,7 @@ jobs:
     name: Documentation - Check Examples
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,3 +60,5 @@ jobs:
 
       - name: Run Kafka examples
         run: OCKAM_HOME=$PWD tools/docs/run_kafka_example.sh
+
+      - uses: ./.github/actions/cargo_target_dir_pre_cache

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -49,7 +49,7 @@ jobs:
     name: Elixir - Lint
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -60,7 +60,7 @@ jobs:
     name: Elixir - Build
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -71,7 +71,7 @@ jobs:
     name: Elixir - Test
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -79,3 +79,4 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
       - run: cd implementations/elixir && ../../gradlew test
+      - uses: ./.github/actions/cargo_target_dir_pre_cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew lint_cargo_fmt_check
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   lint_cargo_clippy:
     name: Rust - Lint with Cargo Clippy
@@ -58,6 +59,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew lint_cargo_clippy
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   lint_cargo_deny:
     name: Rust - Lint with Cargo Deny
@@ -70,6 +72,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew lint_cargo_deny
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   build_docs:
     name: Rust - Build Documentation
@@ -82,6 +85,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew build_docs
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   build:
     name: Rust - Build
@@ -94,6 +98,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew build
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   build_examples:
     name: Rust - Build Examples
@@ -106,6 +111,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew build_examples
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   test:
     name: Rust - Test
@@ -118,6 +124,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew test
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   check_no_std:
     name: Rust - Check Features - no_std alloc software_vault
@@ -132,6 +139,7 @@ jobs:
       - run: |
           cd implementations/rust/ockam/ockam
           RUSTFLAGS='-Dwarnings' cargo check --no-default-features --features 'no_std alloc software_vault'
+      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   check_cargo_update:
     name: Rust - Check Cargo Update
@@ -148,3 +156,4 @@ jobs:
           rm -rf Cargo.lock
           cargo update
           RUSTFLAGS='-Dwarnings' cargo check
+      - uses: ./.github/actions/cargo_target_dir_pre_cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
     name: Rust - Lint Formatting
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -51,7 +51,7 @@ jobs:
     name: Rust - Lint with Cargo Clippy
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -63,7 +63,7 @@ jobs:
     name: Rust - Lint with Cargo Deny
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -75,7 +75,7 @@ jobs:
     name: Rust - Build Documentation
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -87,7 +87,7 @@ jobs:
     name: Rust - Build
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -99,7 +99,7 @@ jobs:
     name: Rust - Build Examples
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -111,7 +111,7 @@ jobs:
     name: Rust - Test
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -123,7 +123,7 @@ jobs:
     name: Rust - Check Features - no_std alloc software_vault
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
@@ -137,7 +137,7 @@ jobs:
     name: Rust - Check Cargo Update
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ockam-network/ockam/builder@sha256:597fd3f89cfa198d9c3efc19599a3717673934bf4e23eee45be035203297cb59
+      image: ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache

--- a/examples/rust/ockam_kafka/Dockerfile
+++ b/examples/rust/ockam_kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ockam-network/ockam/builder AS builder
+FROM ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca AS builder
 
 WORKDIR /build
 
@@ -7,7 +7,7 @@ COPY . ./
 RUN cargo build --example ockam_kafka_bob
 RUN cargo build --example ockam_kafka_alice
 
-FROM ghcr.io/ockam-network/ockam/base
+FROM ghcr.io/ockam-network/ockam/base@sha256:ea156477d425e92640ec8574663f598bc019269a12ed0fefb5ad48256afff4e0
 
 COPY --from=builder /build/target/debug/examples/ockam_kafka_bob ./ockam_kafka_bob
 COPY --from=builder /build/target/debug/examples/ockam_kafka_alice ./ockam_kafka_alice

--- a/examples/rust/tcp_inlet_and_outlet/Dockerfile
+++ b/examples/rust/tcp_inlet_and_outlet/Dockerfile
@@ -1,6 +1,6 @@
-FROM ghcr.io/ockam-network/ockam/builder as builder
+FROM ghcr.io/ockam-network/ockam/builder@sha256:217f5dd606c71dca97bce17d2472a48b9874ff7c4bebaace7764e51377ff7eca as builder
 COPY . .
 RUN set -xe; cd examples/rust/tcp_inlet_and_outlet; cargo build --release --examples
 
-FROM ghcr.io/ockam-network/ockam/base
+FROM ghcr.io/ockam-network/ockam/base@sha256:ea156477d425e92640ec8574663f598bc019269a12ed0fefb5ad48256afff4e0
 COPY --from=builder /work/target/release/examples/* /usr/bin/

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -67,12 +67,18 @@ RUN set -xe; \
     JAVA_PACKAGE='OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz'; \
     curl -sSOL \
       "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/${JAVA_PACKAGE}"; \
-    echo "3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30  ${JAVA_PACKAGE}"; \
+    echo "3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30  ${JAVA_PACKAGE}" | sha256sum -c; \
     mv "${JAVA_PACKAGE}" openjdk.tar.gz; \
     mkdir -p "${JAVA_HOME}"; \
     cd "${JAVA_HOME}"; \
     tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
-    rm -rf /tmp/openjdk.tar.gz;
+    rm -rf /tmp/openjdk.tar.gz; \
+# Setup jq
+    cd /tmp; \
+    curl -sSOL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64; \
+    echo "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44  jq-linux64" | sha256sum -c; \
+    mv jq-linux64 /usr/bin/jq; \
+    chmod +x /usr/bin/jq
 
 ENV PATH="${JAVA_HOME}/bin:${RUSTUP_HOME}/bin:${CARGO_HOME}/bin:${CMAKE_HOME}/bin:$PATH" \
     AR=/usr/bin/ar \


### PR DESCRIPTION
Prior to saving the cache, delete artifacts which cannot be meaningfully
cached from the target folder. Specifically: all of the builds of our own crates.
