### PR TITLE
jared/metaclips/tag script update

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -30,6 +30,7 @@ commit_parsers = [
     { message = ".*crate release", skip = true},
     { message = ".*update crates changelog", skip = true},
     { message = "^ci", skip = true},
+    { message = "^chore", skip = true},
     { message = "^.*: add", group = "Added"},
     { message = "^.*: support", group = "Added"},
     { message = "^.*: remove", group = "Removed"},

--- a/release.toml
+++ b/release.toml
@@ -1,12 +1,12 @@
 dev-version = true
 dev-version-ext = "dev"
-post-release-commit-message = "ci: release {{crate_name}} dev version {{version}}"
+post-release-commit-message = "chore(rust): release {{crate_name}} dev version {{version}}"
 push = false
 tag = false
 verify = true
 consolidate-pushes = true
 sign-commit = true
-pre-release-commit-message = "ci: crate release {{crate_name}} version {{version}}"
+pre-release-commit-message = "chore(rust): crate release {{crate_name}} version {{version}}"
 pre-release-replacements = [
   {file="README.md", min=0, search="= \".*\"", replace="= \"{{version}}\""},
   {file="CHANGELOG.md", min=0, search="## unreleased", replace="## {{version}} - {{date}}"},

--- a/tools/scripts/release/README.md
+++ b/tools/scripts/release/README.md
@@ -8,7 +8,6 @@ To run changelog generator, from the Ockam root path, call
 tools/scripts/release/changelog.sh
 ```
 
-
 ## Crate Bump
 
 Crates versions are bumped using [cargo-release](https://github.com/crate-ci/cargo-release/issues) >= v0.18.6. While bumping crates, CHANGELOG.md and README.md files are also updated with the bumped version.
@@ -23,21 +22,16 @@ MODIFIED_RELEASE="signature_core:patch ockam_entity:major" RELEASE_VERSION=minor
 ```
 this bumps `signature_core` as a `patch`, `ockam_entity` as `major` and every other crate as `minor`.
 
-We can also release a `-dev` version of all crates right after a bump. To release crates,
-```bash
-DEV_VERSION=true tools/scripts/release/crate-bump.sh
-```
-This should be called before a new `git tag` is done so that only crates that are bumped and updated to a `-dev` version.
-
 
 ## Crate Publish
 
-Crates are published to `crates.io` using [cargo-release](https://github.com/crate-ci/cargo-release/issues) right after bump. Only crates that have been updated (comparing `git diff` with last git tag) are published. Crates can also be excluded from being published using the `EXCLUDE_CRATES` variable, to exclude crates, we can optionally specify crates that are to be excluded `EXCLUDE_CRATES="signature_core ockam_core"`, where `signature_core` and `ockam_core` are excluded.
+Crates are published to `crates.io` using [cargo-release](https://github.com/crate-ci/cargo-release) right after bump. Only crates that have been updated (comparing `git diff` with last git tag) are published. Crates can also be excluded from being published using the `EXCLUDE_CRATES` variable, to exclude crates, we can optionally specify crates that are to be excluded `EXCLUDE_CRATES="signature_core ockam_core"`, where `signature_core` and `ockam_core` are excluded.
 
 To publish crates
 ```bash
 PUBLISH_TOKEN=my_crates.io_token EXCLUDE_CRATES="signature_core ockam_core" tools/scripts/release/crate-publish.sh
 ```
+Note: Require cargo-release >= version 0.18.6
 
 ## Tagging
 
@@ -46,3 +40,22 @@ To perform `git tag`
 ```bash
 COMMIT_SHA=000000000 tools/scripts/release/tagging.sh
 ```
+
+## Dev Bump
+
+We can also bump crates to a `-dev` version right after a publish. To bump crates,
+```bash
+tools/scripts/release/dev-bump.sh
+```
+This should be called after git tagging is done.
+
+
+## Manual Release
+
+For a manual release to be done, we should
+
+- Generate Changelogs
+- Bump Crates
+- Publish Crates
+- Tag Crates
+- Dev Bump Crates

--- a/tools/scripts/release/README.md
+++ b/tools/scripts/release/README.md
@@ -7,6 +7,7 @@ To run changelog generator, from the Ockam root path, call
 ```bash
 tools/scripts/release/changelog.sh
 ```
+Generated changelogs should be reviewed and then commited before crate bump is done.
 
 ## Crate Bump
 

--- a/tools/scripts/release/changelog.sh
+++ b/tools/scripts/release/changelog.sh
@@ -8,3 +8,5 @@ source tools/scripts/release/crates-to-publish.sh
 for crate in ${updated_crates[@]}; do
     git cliff --unreleased --commit-path implementations/rust/ockam/$crate --prepend implementations/rust/ockam/$crate/CHANGELOG.md
 done
+
+echo "Changelog has been generated. Please review and commit."

--- a/tools/scripts/release/crate-bump.sh
+++ b/tools/scripts/release/crate-bump.sh
@@ -8,13 +8,9 @@
 # they are to be bumped "signature_core:minor ockam:major" signature_core
 # crate will be bumped as a minor and ockam crate will be bumped as
 # major.
-# We can also use this script to bump crates to its -dev version by specifying
-# DEV_VERSION variable. This bumps crates to their -dev version. We normally should
-# bump to -dev version right after RELEASE_VERSION is run (before git tags are updated)
-# so that we only bumps crates to be published.
 
-if [[ -z $RELEASE_VERSION && -z $DEV_VERSION ]]; then
-    echo "Please set RELEASE_VERSION if you want to release crates or DEV_VERSION if this is a dev bump"
+if [[ -z $RELEASE_VERSION ]]; then
+    echo "please set RELEASE_VERSION variable"
     exit 1
 fi
 
@@ -31,18 +27,12 @@ for word in ${crate_array[@]}; do
 done
 
 for to_update in ${updated_crates[@]}; do
-    if [[ $DEV_VERSION == true ]]; then
-        echo y| cargo release release --no-push --no-publish --no-tag --package $to_update --execute
-    else
+    version=$RELEASE_VERSION
 
-        # If the bump version is indicated as release, we don't bump
-        # or publish the crate.
-        version=$RELEASE_VERSION
-        if [[ ! -z "${specified_crate_version[$to_update]}" ]]; then
-            echo "bumping $to_update as ${specified_crate_version[$to_update]}"
-            version="${specified_crate_version[$to_update]}"
-        fi
-
-        echo y | cargo release $version --no-push --no-publish --no-tag --no-dev-version --package $to_update --execute
+    if [[ ! -z "${specified_crate_version[$to_update]}" ]]; then
+        echo "bumping $to_update as ${specified_crate_version[$to_update]}"
+        version="${specified_crate_version[$to_update]}"
     fi
+
+    echo y | cargo release $version --no-push --no-publish --no-tag --no-dev-version --package $to_update --execute
 done

--- a/tools/scripts/release/dev-bump.sh
+++ b/tools/scripts/release/dev-bump.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+for crate in $(ls "implementations/rust/ockam"); do
+    # Check if crate is a -dev version
+    version=$(eval "tomlq package.version -f implementations/rust/ockam/$crate/Cargo.toml")
+
+    if [[ "$version" != *"-dev"* ]]; then
+        echo "bumping crate $crate to dev"
+        echo y | cargo release release --no-push --no-publish --no-tag --package $crate --execute
+    fi
+done

--- a/tools/scripts/release/tagging.sh
+++ b/tools/scripts/release/tagging.sh
@@ -8,6 +8,18 @@ if [[ -z $COMMIT_SHA ]]; then
     exit 1
 fi
 
+# We tag crates using the name and version in Cargo.toml. We
+# should ensure we checkout to the specific commit SHA so that
+# we use the accurate tag name and version.
+#
+# Ensure that provided commit SHA is one that we checkout to.
+current_commit_sha=$(eval git rev-parse HEAD)
+
+if [[ $current_commit_sha != $COMMIT_SHA ]]; then
+    echo "please checkout to specified commit sha"
+    exit 1
+fi
+
 source tools/scripts/release/crates-to-publish.sh
 
 for crate in ${updated_crates[@]}; do


### PR DESCRIPTION
- chore: skip commits that are indicated as chore
- chore: ensure we checkout to sha when tagging
- chore: split out dev bump script from crate-bump
- docs: update script readme
- chore: inform user to review generated changelog
