### PR TITLE
jared/release jan 10 2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.11.1-dev"
+version = "0.12.0"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.32.1-dev"
+version = "0.33.0"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_examples"
-version = "0.25.1-dev"
+version = "0.26.0"
 dependencies = [
  "ockam",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.32.1-dev"
+version = "0.33.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "signature_ps"
-version = "0.30.1-dev"
+version = "0.31.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.34.1-dev"
+version = "0.35.0"
 dependencies = [
  "ockam_core",
  "ockam_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_macros"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "ockam-ffi"
-version = "0.32.1-dev"
+version = "0.32.1"
 dependencies = [
  "lazy_static",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.16.1-dev"
+version = "0.17.0"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.34.1-dev"
+version = "0.35.0"
 dependencies = [
  "ockam_core",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.3.1-dev"
+version = "0.4.0"
 dependencies = [
  "bunt",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.37.1-dev"
+version = "0.38.0"
 dependencies = [
  "futures 0.3.17",
  "hashbrown 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.41.1-dev"
+version = "0.42.0"
 dependencies = [
  "heapless",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.31.1-dev"
+version = "0.32.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.30.1-dev"
+version = "0.31.0"
 dependencies = [
  "bls12_381_plus",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.31.1-dev"
+version = "0.32.0"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.38.1-dev"
+version = "0.39.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.36.1-dev"
+version = "0.37.0"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.32.1-dev"
+version = "0.33.0"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.35.1-dev"
+version = "0.36.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.42.1-dev"
+version = "0.43.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.43.0-dev"
+version = "0.43.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.34.1-dev"
+version = "0.35.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.42.0 - 2021-12-13
 
 ### Added

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.43.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -102,7 +102,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_featur
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }
-ockam_entity = { path = "../ockam_entity", version = "^0.32.1-dev", default_features = false }
+ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.32.1-dev", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -98,7 +98,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_featu
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.38.1-dev", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -105,7 +105,7 @@ ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"
 ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
-signature_core = { version = "^0.32.1-dev", path = "../signature_core", optional = true }
+signature_core = { version = "^0.33.0", path = "../signature_core", optional = true }
 signature_bbs_plus = { version = "^0.33.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
 signature_bls = { version = "^0.31.0", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -97,7 +97,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -106,7 +106,7 @@ ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.32.1-dev", path = "../signature_core", optional = true }
-signature_bbs_plus = { version = "^0.32.1-dev", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
+signature_bbs_plus = { version = "^0.33.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
 signature_bls = { version = "^0.30.1-dev", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -93,7 +93,7 @@ name = "tests"
 path = "tests/main.rs"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -99,7 +99,7 @@ ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = f
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.1-dev", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.43.0-dev"
+version = "0.43.0"
 rust-version = "1.56.0"
 publish = true
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -101,7 +101,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_featur
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
@@ -118,7 +118,7 @@ dyn-clone = "1.0"
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev" }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -107,7 +107,7 @@ arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.32.1-dev", path = "../signature_core", optional = true }
 signature_bbs_plus = { version = "^0.33.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
-signature_bls = { version = "^0.30.1-dev", path = "../signature_bls", package = "signature_bls", optional = true }
+signature_bls = { version = "^0.31.0", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -96,7 +96,7 @@ path = "tests/main.rs"
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
@@ -117,7 +117,7 @@ hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -95,7 +95,7 @@ path = "tests/main.rs"
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -100,7 +100,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.37.1-dev", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -69,7 +69,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.42.0"
+ockam = "0.43.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.39.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.38.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.38.1-dev"
+version = "0.39.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -74,7 +74,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -73,7 +73,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
@@ -84,7 +84,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev" }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -85,7 +85,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev" }
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.34.1-dev" }
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -76,14 +76,14 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -72,7 +72,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -75,7 +75,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_featu
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
@@ -86,7 +86,7 @@ tracing = { version = "0.1", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -70,7 +70,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.38.0"
+ockam_channel = "0.39.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.3.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.4.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.3.1-dev"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+- Use the tracing crate for logging on no_std
+
 ## 0.42.0 - 2021-12-13
 
 ### Added

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.43.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.42.1-dev"
+version = "0.43.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.42.0"
+ockam_core = "0.43.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.42.0" , default-features = false }
+ockam_core = { version = "0.43.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.33.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_entity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_entity/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
+### Fixed
+
+- Fix credentials build failure
+
 ## 0.32.0 - 2021-12-13
 
 ### Added

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -81,7 +81,7 @@ ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default-features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -82,7 +82,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default-features = false, optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -75,7 +75,7 @@ credentials = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -78,7 +78,7 @@ credentials = [
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default-features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default-features = false, optional = true }
@@ -100,6 +100,6 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -89,7 +89,7 @@ heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.30.1-dev", optional = true }
-signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.32.1-dev", optional = true }
+signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 serde_json = { version = "1.0", optional = true }
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -80,7 +80,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-featu
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default-features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.38.1-dev", default-features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.35.1-dev", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_entity"
-version = "0.32.1-dev"
+version = "0.33.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -88,7 +88,7 @@ group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
-signature_bls = { path = "../signature_bls", version = "^0.30.1-dev", optional = true }
+signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -87,7 +87,7 @@ cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
+signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -79,7 +79,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default-features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default-features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default-features = false }
@@ -99,7 +99,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -77,7 +77,7 @@ credentials = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/README.md
+++ b/implementations/rust/ockam/ockam_entity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_entity = "0.32.0"
+ockam_entity = "0.33.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_examples/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_examples/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
+### Fixed
+
+- Fix credentials build failure
+
 ## 0.25.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_examples/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_examples/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.26.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_examples/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ockam Developers"]
 description = """Example projects using the Ockam APIs"""
-version = "0.25.1-dev"
+version = "0.26.0"
 edition = "2018"
 homepage = "https://github.com/ockam-network/ockam"
 keywords = ["ockam", "crypto", "cryptography"]

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+- Use the tracing crate for logging on no_std
+
 ## 0.11.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.12.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.15", default-features = false, features = [
     "async-await",
 ] }
 heapless = { version = "0.7", features = ["mpmc_large"] }
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.11.1-dev"
+version = "0.12.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_executor = "0.11.0"
+ockam_executor = "0.12.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.32.1 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Vault updates
 - Change uses of `ockam_vault_core::Foo` to use `ockam_core::vault::Foo` across crates
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
 
 ## v0.32.0 - 2021-12-06
 

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 bls = ["ockam_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev" }
+ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 lazy_static = "1.4"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.32.1-dev"
+version = "0.32.1"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -30,6 +30,6 @@ bls = ["ockam_core/bls"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -29,7 +29,7 @@ bls = ["ockam_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam-ffi = "0.32.0"
+ockam-ffi = "0.32.1"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.35.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.34.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.34.1-dev"
+version = "0.35.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -34,5 +34,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.34.0"
+ockam_key_exchange_core = "0.35.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.35.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.34.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.34.1-dev"
+version = "0.35.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -43,4 +43,4 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev" }
+ockam_node = { path = "../ockam_node", version = "^0.42.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -42,5 +42,5 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -41,6 +41,6 @@ arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.34.0"
+ockam_key_exchange_x3dh = "0.35.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.35.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.36.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.34.1-dev", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -39,6 +39,6 @@ ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = f
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -41,4 +41,4 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev" }
+ockam_node = { path = "../ockam_node", version = "^0.42.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.35.1-dev"
+version = "0.36.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -40,5 +40,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.34.1-dev" }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.35.0"
+ockam_key_exchange_xx = "0.36.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
+### Fixed
+
+- Fix no_std compilation error due to `ockam::node` attribute
+
 ## 0.3.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.4.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_macros"
-version = "0.4.0-dev"
+version = "0.4.0"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Ockam Developers"]

--- a/implementations/rust/ockam/ockam_macros/README.md
+++ b/implementations/rust/ockam/ockam_macros/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_macros = "0.3.0"
+ockam_macros = "0.4.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+- Use the tracing crate for logging on no_std
+
+### Fixed
+
+- Protect processor relays against accidental async executor deadlock
+
+### Removed
+
+- Delete the ockam_node_no_std crate
+
 ## 0.41.0 - 2021-12-13
 
 ### Added

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.42.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.41.1-dev"
+version = "0.42.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -58,4 +58,4 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.11.1-dev", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.12.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.41.0"
+ockam_node = "0.42.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.16.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.17.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.16.1-dev"
+version = "0.17.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -31,5 +31,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_core = "0.16.0"
+ockam_transport_core = "0.17.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.38.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
+### Removed
+
+- Delete the ockam_node_no_std crate
+
 ## 0.37.0 - 2021-12-13
 
 ### Added

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -31,7 +31,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.1-dev" }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -28,7 +28,7 @@ std = ["ockam_macros/std"]
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev" }
+ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev" }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.1-dev" }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -29,7 +29,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0"}
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev" }
+ockam_node = { path = "../ockam_node", version = "^0.42.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.1-dev" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.37.1-dev"
+version = "0.38.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.37.0"
+ockam_transport_tcp = "0.38.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.32.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
+### Removed
+
+- Delete the ockam_node_no_std crate
+
 ## 0.31.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.31.1-dev"
+version = "0.32.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -27,7 +27,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev" }
+ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.1-dev" }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -28,7 +28,7 @@ futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.43.0"}
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev" }
+ockam_node = { path = "../ockam_node", version = "^0.42.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.1-dev" }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.16.1-dev" }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",
     "sync",

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.31.0"
+ockam_transport_websocket = "0.32.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
+### Fixed
+
+- Fix credentials build failure
+
 ## 0.36.0 - 2021-12-13
 
 ### Added

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.37.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -66,7 +66,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
-signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.32.1-dev", optional = true }
+signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.30.1-dev", optional = true }
 signature_ps = { path = "../signature_ps", version = "^0.30.1-dev", default-features = false, optional = true }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.36.1-dev"
+version = "0.37.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -68,7 +68,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-featu
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
-signature_ps = { path = "../signature_ps", version = "^0.30.1-dev", default-features = false, optional = true }
+signature_ps = { path = "../signature_ps", version = "^0.31.0", default-features = false, optional = true }
 arrayref = "0.3"
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }
 curve25519-dalek = { version = "3.1", default-features = false }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -63,7 +63,7 @@ no_std = [
 alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.32.1-dev", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -65,7 +65,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
-signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
+signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
 signature_ps = { path = "../signature_ps", version = "^0.30.1-dev", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -82,5 +82,5 @@ cfg-if = "1.0"
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.31.1-dev" }
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.0"}
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -67,7 +67,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.32.1-dev", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
-signature_bls = { path = "../signature_bls", version = "^0.30.1-dev", optional = true }
+signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
 signature_ps = { path = "../signature_ps", version = "^0.30.1-dev", default-features = false, optional = true }
 arrayref = "0.3"
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.36.0"
+ockam_vault = "0.37.0"
 ```
 
 ## Crate Features
@@ -33,7 +33,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault = { version = "0.36.0" , default-features = false }
+ockam_vault = { version = "0.37.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.35.0 - 2022-01-10
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add no_main arg support to ockam::node macro
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.34.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -51,7 +51,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -54,7 +54,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.41.1-dev", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = [
     "sync",
 ], optional = true }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -66,4 +66,4 @@ rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.31.1-dev" }
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.0"}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_sync_core"
-version = "0.34.1-dev"
+version = "0.35.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -53,7 +53,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = [
     "sync",
@@ -65,5 +65,5 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.36.1-dev" }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.31.1-dev" }

--- a/implementations/rust/ockam/ockam_vault_sync_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_sync_core = "0.34.0"
+ockam_vault_sync_core = "0.35.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.31.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.32.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -9,7 +9,7 @@ categories = [
 ]
 description = """Ockam Vault test suite.
 """
-version = "0.31.1-dev"
+version = "0.32.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -27,5 +27,5 @@ publish = true
 rust-version = "1.56.0"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.42.1-dev" }
+ockam_core = { path = "../ockam_core", version = "^0.43.0"}
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault_test_suite/README.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_test_suite = "0.31.0"
+ockam_vault_test_suite = "0.32.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.33.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bbs_plus/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.32.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -31,7 +31,7 @@ managed = { version = "0.8", default-features = false, features = ["map"] }
 pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { version = "^0.32.1-dev", path = "../signature_core" }
+signature_core = { version = "^0.33.0", path = "../signature_core" }
 signature_bls = { version = "^0.31.0", path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bbs_plus"
-version = "0.32.1-dev"
+version = "0.33.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -32,7 +32,7 @@ pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { version = "^0.32.1-dev", path = "../signature_core" }
-signature_bls = { version = "^0.30.1-dev", path = "../signature_bls" }
+signature_bls = { version = "^0.31.0", path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_bbs_plus/README.md
+++ b/implementations/rust/ockam/signature_bbs_plus/README.md
@@ -18,14 +18,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_bbs_plus = "0.32.0"
+signature_bbs_plus = "0.33.0"
 ```
 
 ## Crate Features
 
 ```
 [dependencies]
-signature_bbs_plus = { version = "0.32.0" , default-features = false }
+signature_bbs_plus = { version = "0.33.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.30.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/signature_bls/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_bls/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.31.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bls"
-version = "0.30.1-dev"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_bls/README.md
+++ b/implementations/rust/ockam/signature_bls/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_bls = "0.30.0"
+signature_bls = "0.31.0"
 ```
 
 ## Crate Features
@@ -27,7 +27,7 @@ disabled as follows
 
 ```
 [dependencies]
-signature_bls = { version = "0.30.0" , default-features = false }
+signature_bls = { version = "0.31.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/signature_core/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.33.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_core/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.32.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_core"
-version = "0.32.1-dev"
+version = "0.33.0"
 authors = ["Ockam Deveopers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_core/README.md
+++ b/implementations/rust/ockam/signature_core/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_core = "0.32.0"
+signature_core = "0.33.0"
 ```
 
 ## Crate Features

--- a/implementations/rust/ockam/signature_ps/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_ps/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Changed
+
+- Improve formatting of `Cargo.toml`s  and add `rust-version` 1.56.0
+
 ## 0.30.0 - 2021-12-13
 
 ### Changed

--- a/implementations/rust/ockam/signature_ps/CHANGELOG.md
+++ b/implementations/rust/ockam/signature_ps/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.31.0 - 2022-01-10
 
 ### Changed
 

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_ps"
-version = "0.30.1-dev"
+version = "0.31.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -35,7 +35,7 @@ pairing = "0.20"
 rand_core = "0.6"
 rand_chacha = { version = "0.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { version = "^0.32.1-dev", path = "../signature_core" }
+signature_core = { version = "^0.33.0", path = "../signature_core" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 blake2 = { version = "0.9", default-features = false }
-signature_bls = { version = "^0.30.1-dev", path = "../signature_bls" }
+signature_bls = { version = "^0.31.0", path = "../signature_bls" }
 bls12_381_plus = { version = "0.5", default-features = false }
 digest = { version = "0.9", default-features = false }
 ff = { version = "0.10", default-features = false }

--- a/implementations/rust/ockam/signature_ps/README.md
+++ b/implementations/rust/ockam/signature_ps/README.md
@@ -16,14 +16,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-signature_ps = "0.30.0"
+signature_ps = "0.31.0"
 ```
 
 ## Crate Features
 
 ```
 [dependencies]
-signature_ps = { version = "0.30.0" , default-features = false }
+signature_ps = { version = "0.31.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency


### PR DESCRIPTION
- ci: release changelogs
- chore(rust): crate release ockam version 0.43.0
- chore(rust): crate release ockam_channel version 0.39.0
- chore(rust): crate release ockam_command version 0.4.0
- chore(rust): crate release ockam_core version 0.43.0
- chore(rust): crate release ockam_entity version 0.33.0
- chore(rust): crate release ockam_examples version 0.26.0
- chore(rust): crate release ockam_executor version 0.12.0
- chore(rust): crate release ockam_key_exchange_core version 0.35.0
- chore(rust): crate release ockam_key_exchange_x3dh version 0.35.0
- chore(rust): crate release ockam_key_exchange_xx version 0.36.0
- chore(rust): crate release ockam_macros version 0.4.0
- chore(rust): crate release ockam_node version 0.42.0
- chore(rust): crate release ockam_transport_core version 0.17.0
- chore(rust): crate release ockam_transport_tcp version 0.38.0
- chore(rust): crate release ockam_transport_websocket version 0.32.0
- chore(rust): crate release ockam_vault version 0.37.0
- chore(rust): crate release ockam_vault_sync_core version 0.35.0
- chore(rust): crate release ockam_vault_test_suite version 0.32.0
- chore(rust): crate release signature_bbs_plus version 0.33.0
- chore(rust): crate release signature_bls version 0.31.0
- chore(rust): crate release signature_core version 0.33.0
- chore(rust): crate release signature_ps version 0.31.0
- chore(rust): crate release ockam-ffi version 0.32.1
