### PR TITLE
jared/dev bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "signature_ps"
-version = "0.31.0"
+version = "0.31.1-dev"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.32.0"
+version = "0.32.1-dev"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.35.0"
+version = "0.35.1-dev"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "signature_bls"
-version = "0.31.0"
+version = "0.31.1-dev"
 dependencies = [
  "bls12_381_plus",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_examples"
-version = "0.26.0"
+version = "0.26.1-dev"
 dependencies = [
  "ockam",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.36.0"
+version = "0.36.1-dev"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.42.0"
+version = "0.42.1-dev"
 dependencies = [
  "heapless",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "signature_core"
-version = "0.33.0"
+version = "0.33.1-dev"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.17.0"
+version = "0.17.1-dev"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.43.0"
+version = "0.43.1-dev"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.39.0"
+version = "0.39.1-dev"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_entity"
-version = "0.33.0"
+version = "0.33.1-dev"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "ockam-ffi"
-version = "0.32.1"
+version = "0.32.2-dev"
 dependencies = [
  "lazy_static",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_macros"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "bunt",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.43.0"
+version = "0.43.1-dev"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "signature_bbs_plus"
-version = "0.33.0"
+version = "0.33.1-dev"
 dependencies = [
  "blake2",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.38.0"
+version = "0.38.1-dev"
 dependencies = [
  "futures 0.3.17",
  "hashbrown 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.12.0"
+version = "0.12.1-dev"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.35.0"
+version = "0.35.1-dev"
 dependencies = [
  "ockam_core",
  "ockam_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.37.0"
+version = "0.37.1-dev"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.35.0"
+version = "0.35.1-dev"
 dependencies = [
  "ockam_core",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.32.0"
+version = "0.32.1-dev"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -98,7 +98,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_featu
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -106,7 +106,7 @@ ockam_entity = { path = "../ockam_entity", version = "^0.33.1-dev", default_feat
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.33.0", path = "../signature_core", optional = true }
-signature_bbs_plus = { version = "^0.33.0", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
+signature_bbs_plus = { version = "^0.33.1-dev", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
 signature_bls = { version = "^0.31.0", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -94,7 +94,7 @@ path = "tests/main.rs"
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -95,7 +95,7 @@ path = "tests/main.rs"
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -96,7 +96,7 @@ path = "tests/main.rs"
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.1-dev", optional = true }
@@ -117,7 +117,7 @@ hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -100,7 +100,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.33.1-dev", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -97,7 +97,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -102,7 +102,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_fe
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
-ockam_entity = { path = "../ockam_entity", version = "^0.33.0", default_features = false }
+ockam_entity = { path = "../ockam_entity", version = "^0.33.1-dev", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.33.0", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -105,7 +105,7 @@ ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-
 ockam_entity = { path = "../ockam_entity", version = "^0.33.1-dev", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
-signature_core = { version = "^0.33.0", path = "../signature_core", optional = true }
+signature_core = { version = "^0.33.1-dev", path = "../signature_core", optional = true }
 signature_bbs_plus = { version = "^0.33.1-dev", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
 signature_bls = { version = "^0.31.1-dev", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -99,7 +99,7 @@ ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.1-dev", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.33.1-dev", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -101,7 +101,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features =
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.38.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_entity = { path = "../ockam_entity", version = "^0.33.1-dev", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
@@ -118,7 +118,7 @@ dyn-clone = "1.0"
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -107,7 +107,7 @@ arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.33.0", path = "../signature_core", optional = true }
 signature_bbs_plus = { version = "^0.33.1-dev", path = "../signature_bbs_plus", package = "signature_bbs_plus", optional = true }
-signature_bls = { version = "^0.31.0", path = "../signature_bls", package = "signature_bls", optional = true }
+signature_bls = { version = "^0.31.1-dev", path = "../signature_bls", package = "signature_bls", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.43.0"
+version = "0.43.1-dev"
 rust-version = "1.56.0"
 publish = true
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -93,7 +93,7 @@ name = "tests"
 path = "tests/main.rs"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -72,7 +72,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -71,7 +71,7 @@ alloc = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -85,7 +85,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.0"}
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.1-dev"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -74,7 +74,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -73,7 +73,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
@@ -84,7 +84,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.1-dev"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -70,7 +70,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -76,14 +76,14 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.1-dev"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.39.0"
+version = "0.39.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -75,7 +75,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_featu
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default_features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
@@ -86,7 +86,7 @@ tracing = { version = "0.1", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.35.1-dev"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -20,7 +20,7 @@ exitcode = "1.1.2"
 human-panic = "1.0.3"
 indicatif = "0.16.2"
 log = "0.4.14"
-ockam = { version = "^0.43.0-dev", path = "../ockam" }
+ockam = { version = "^0.43.1-dev", path = "../ockam" }
 serde = "1.0.130"
 # FIXME: stderrlog depends on chrono, triggers:
 # - https://rustsec.org/advisories/RUSTSEC-2020-0159

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.4.0"
+version = "0.4.1-dev"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.43.0"
+version = "0.43.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -50,7 +50,7 @@ alloc = [
 bls = []
 
 [dependencies]
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 async-trait = "0.1.42"
 hashbrown = { version = "0.11", default-features = false, features = [
     "ahash",

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -78,7 +78,7 @@ credentials = [
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default-features = false, optional = true }
@@ -100,6 +100,6 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev"}
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -79,7 +79,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default-features = false }
@@ -99,7 +99,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -81,7 +81,7 @@ ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = f
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default-features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.1-dev", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -75,7 +75,7 @@ credentials = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -89,7 +89,7 @@ heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
-signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
+signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 serde_json = { version = "1.0", optional = true }
 sha2 = { version = "0.9", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -76,7 +76,7 @@ credentials = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -88,7 +88,7 @@ group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
-signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
+signature_bls = { path = "../signature_bls", version = "^0.31.1-dev", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_entity"
-version = "0.33.0"
+version = "0.33.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -77,7 +77,7 @@ credentials = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default-features = false }

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -80,7 +80,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-featu
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.39.0", default-features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -82,7 +82,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.39.1-dev", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.36.0", default-features = false, optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_entity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_entity/Cargo.toml
@@ -87,7 +87,7 @@ cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
+signature_core = { path = "../signature_core", version = "^0.33.1-dev", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.1-dev", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_examples/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ockam Developers"]
 description = """Example projects using the Ockam APIs"""
-version = "0.26.0"
+version = "0.26.1-dev"
 edition = "2018"
 homepage = "https://github.com/ockam-network/ockam"
 keywords = ["ockam", "crypto", "cryptography"]

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.12.0"
+version = "0.12.1-dev"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.15", default-features = false, features = [
     "async-await",
 ] }
 heapless = { version = "0.7", features = ["mpmc_large"] }
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 bls = ["ockam_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0"}
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 lazy_static = "1.4"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -30,6 +30,6 @@ bls = ["ockam_core/bls"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -29,7 +29,7 @@ bls = ["ockam_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.32.1"
+version = "0.32.2-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -34,5 +34,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.35.0"
+version = "0.35.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -41,6 +41,6 @@ arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -43,4 +43,4 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
-ockam_node = { path = "../ockam_node", version = "^0.42.0"}
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -42,5 +42,5 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.35.0"
+version = "0.35.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -41,4 +41,4 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
-ockam_node = { path = "../ockam_node", version = "^0.42.0"}
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.36.0"
+version = "0.36.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.0", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -39,6 +39,6 @@ ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.35.1-dev", default_features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.1-dev"}
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -40,5 +40,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.35.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_macros"
-version = "0.4.0"
+version = "0.4.1-dev"
 edition = "2018"
 license = "Apache-2.0"
 authors = ["Ockam Developers"]

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -44,7 +44,7 @@ dump_internals = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev"}
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",
     "time",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -58,4 +58,4 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.12.0", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.12.1-dev", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.42.0"
+version = "0.42.1-dev"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.17.0"
+version = "0.17.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -31,5 +31,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -28,7 +28,7 @@ std = ["ockam_macros/std"]
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0"}
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -31,7 +31,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.1-dev"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -29,7 +29,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
-ockam_node = { path = "../ockam_node", version = "^0.42.0"}
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -30,7 +30,7 @@ alloc = []
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev" }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.38.0"
+version = "0.38.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -28,7 +28,7 @@ futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
-ockam_node = { path = "../ockam_node", version = "^0.42.0"}
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -27,7 +27,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
-ockam_core = { path = "../ockam_core", version = "^0.43.0"}
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.32.0"
+version = "0.32.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.17.1-dev"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",
     "sync",

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -64,7 +64,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -68,7 +68,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-featu
 signature_core = { path = "../signature_core", version = "^0.33.1-dev", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.1-dev", optional = true }
-signature_ps = { path = "../signature_ps", version = "^0.31.0", default-features = false, optional = true }
+signature_ps = { path = "../signature_ps", version = "^0.31.1-dev", default-features = false, optional = true }
 arrayref = "0.3"
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }
 curve25519-dalek = { version = "3.1", default-features = false }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -67,7 +67,7 @@ ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
-signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
+signature_bls = { path = "../signature_bls", version = "^0.31.1-dev", optional = true }
 signature_ps = { path = "../signature_ps", version = "^0.31.0", default-features = false, optional = true }
 arrayref = "0.3"
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.37.0"
+version = "0.37.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -66,7 +66,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
-signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }
+signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.0", optional = true }
 signature_ps = { path = "../signature_ps", version = "^0.31.0", default-features = false, optional = true }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -82,5 +82,5 @@ cfg-if = "1.0"
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.0"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.1-dev"}
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -63,7 +63,7 @@ no_std = [
 alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -65,7 +65,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default-features = false }
-signature_core = { path = "../signature_core", version = "^0.33.0", optional = true }
+signature_core = { path = "../signature_core", version = "^0.33.1-dev", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.33.1-dev", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.31.1-dev", optional = true }
 signature_ps = { path = "../signature_ps", version = "^0.31.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_sync_core"
-version = "0.35.0"
+version = "0.35.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -51,7 +51,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -53,7 +53,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default_features = false }
 tokio = { version = "1.8", default-features = false, features = [
     "sync",
@@ -65,5 +65,5 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.37.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
 ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.0"}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -52,7 +52,7 @@ alloc = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.4.0-dev", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
 tokio = { version = "1.8", default-features = false, features = [

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -66,4 +66,4 @@ rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.37.1-dev"}
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.0"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.32.1-dev"}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -54,7 +54,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.43.1-dev", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.4.1-dev", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.37.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.42.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.42.1-dev", default_features = false }
 tokio = { version = "1.8", default-features = false, features = [
     "sync",
 ], optional = true }

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -9,7 +9,7 @@ categories = [
 ]
 description = """Ockam Vault test suite.
 """
-version = "0.32.0"
+version = "0.32.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -27,5 +27,5 @@ publish = true
 rust-version = "1.56.0"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.43.0"}
+ockam_core = { path = "../ockam_core", version = "^0.43.1-dev"}
 arrayref = "0.3"

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bbs_plus"
-version = "0.33.0"
+version = "0.33.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -32,7 +32,7 @@ pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 signature_core = { version = "^0.33.0", path = "../signature_core" }
-signature_bls = { version = "^0.31.0", path = "../signature_bls" }
+signature_bls = { version = "^0.31.1-dev", path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -31,7 +31,7 @@ managed = { version = "0.8", default-features = false, features = ["map"] }
 pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { version = "^0.33.0", path = "../signature_core" }
+signature_core = { version = "^0.33.1-dev", path = "../signature_core" }
 signature_bls = { version = "^0.31.1-dev", path = "../signature_bls" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_bls"
-version = "0.31.0"
+version = "0.31.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_core"
-version = "0.33.0"
+version = "0.33.1-dev"
 authors = ["Ockam Deveopers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature_ps"
-version = "0.31.0"
+version = "0.31.1-dev"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -35,7 +35,7 @@ pairing = "0.20"
 rand_core = "0.6"
 rand_chacha = { version = "0.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-signature_core = { version = "^0.33.0", path = "../signature_core" }
+signature_core = { version = "^0.33.1-dev", path = "../signature_core" }
 subtle = { version = "2.4", default-features = false }
 typenum = "1.13"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 blake2 = { version = "0.9", default-features = false }
-signature_bls = { version = "^0.31.0", path = "../signature_bls" }
+signature_bls = { version = "^0.31.1-dev", path = "../signature_bls" }
 bls12_381_plus = { version = "0.5", default-features = false }
 digest = { version = "0.9", default-features = false }
 ff = { version = "0.10", default-features = false }


### PR DESCRIPTION
- chore(rust): release ockam dev version 0.43.0
- chore(rust): release ockam_channel dev version 0.39.0
- chore(rust): release ockam_command dev version 0.4.0
- chore(rust): release ockam_core dev version 0.43.0
- chore(rust): release ockam_entity dev version 0.33.0
- chore(rust): release ockam_examples dev version 0.26.0
- chore(rust): release ockam_executor dev version 0.12.0
- chore(rust): release ockam_key_exchange_core dev version 0.35.0
- chore(rust): release ockam_key_exchange_x3dh dev version 0.35.0
- chore(rust): release ockam_key_exchange_xx dev version 0.36.0
- chore(rust): release ockam_macros dev version 0.4.0
- chore(rust): release ockam_node dev version 0.42.0
- chore(rust): release ockam_transport_core dev version 0.17.0
- chore(rust): release ockam_transport_tcp dev version 0.38.0
- chore(rust): release ockam_transport_websocket dev version 0.32.0
- chore(rust): release ockam_vault dev version 0.37.0
- chore(rust): release ockam_vault_sync_core dev version 0.35.0
- chore(rust): release ockam_vault_test_suite dev version 0.32.0
- chore(rust): release signature_bbs_plus dev version 0.33.0
- chore(rust): release signature_bls dev version 0.31.0
- chore(rust): release signature_core dev version 0.33.0
- chore(rust): release signature_ps dev version 0.31.0
- chore(rust): release ockam-ffi dev version 0.32.1
