### PR TITLE
feat(rust): initial commit for ockam_transport_ble crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "heapless",
  "rand_core 0.6.3",
 ]
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +117,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.5",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,12 +141,54 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+checksum = "ee6adc1648f03fbc1bc1b5cf0f2fdfb5edbc96215b711edcfe6ce2641ef9b347"
 dependencies = [
  "critical-section",
  "riscv-target",
+]
+
+[[package]]
+name = "atsamd-hal"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868f22ff864d664efd9a0134cad0905d918f62f3b14d7761ca6d64bdcb1df96b"
+dependencies = [
+ "atsame54p",
+ "bitfield",
+ "cortex-m 0.6.7",
+ "embedded-hal",
+ "nb 0.1.3",
+ "paste",
+ "rand_core 0.5.1",
+ "vcell",
+ "void",
+]
+
+[[package]]
+name = "atsame54_xpro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d838033a755fa931bb1c560fb9771d9dca0e0daa44e6bdc45c6cfb22dd8f82"
+dependencies = [
+ "atsamd-hal",
+ "cortex-m 0.6.7",
+ "cortex-m-rt",
+ "embedded-hal",
+ "nb 0.1.3",
+]
+
+[[package]]
+name = "atsame54p"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3717f3a978e0a867c55823e78e2d2c0d087dd5016ffac4b0c2467a5fc38052eb"
+dependencies = [
+ "bare-metal 0.2.5",
+ "cortex-m 0.6.7",
+ "cortex-m-rt",
+ "vcell",
 ]
 
 [[package]]
@@ -141,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -166,7 +229,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -229,12 +292,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -252,6 +321,84 @@ dependencies = [
  "serde 1.0.136",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bluenrg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c14a9347cc57f132eb0d4413064df017c8d166421cc954dc5659ca7998d819"
+dependencies = [
+ "bitflags",
+ "bluetooth-hci",
+ "byteorder",
+ "embedded-hal",
+ "nb 0.1.3",
+]
+
+[[package]]
+name = "bluetooth-hci"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8c2b20e8648a369c0c984201cdc1673917420f1f5e28cce90635048eeb1032"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "nb 0.1.3",
+]
+
+[[package]]
+name = "bluez-async"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a8c776528da76d05d5d7b4f6566aa8a03390ec731c7022463dcad2068aafcc"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bluez-generated",
+ "dbus",
+ "dbus-tokio",
+ "futures 0.3.21",
+ "itertools",
+ "log",
+ "serde 1.0.136",
+ "serde-xml-rs",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "bluez-generated"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad8f302dd79411881cd0181f3bd9fc91a959b71c3a13159bd8a07d2c40dc7f"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
+name = "btleplug"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669c9c827d9f057e8691945b9e826bf63707dbf6819a270c051861d0fd73dd3e"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bluez-async",
+ "cocoa",
+ "dashmap",
+ "dbus",
+ "futures 0.3.21",
+ "libc",
+ "log",
+ "objc",
+ "static_assertions",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows",
 ]
 
 [[package]]
@@ -299,10 +446,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "cc"
-version = "1.0.72"
+name = "cast"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -311,12 +467,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -332,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.13"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -349,15 +515,46 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.12"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -408,12 +605,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
 name = "core2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal 0.2.5",
+ "bitfield",
+ "cortex-m 0.7.4",
+ "volatile-register",
 ]
 
 [[package]]
@@ -426,6 +677,27 @@ dependencies = [
  "bitfield",
  "embedded-hal",
  "volatile-register",
+]
+
+[[package]]
+name = "cortex-m-rt"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+dependencies = [
+ "cortex-m-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "cortex-m-rt-macros"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -445,15 +717,15 @@ checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
- "cortex-m",
+ "cortex-m 0.7.4",
  "riscv",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
+checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -461,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
 ]
@@ -477,8 +749,8 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
- "parking_lot",
+ "mio 0.7.14",
+ "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -499,7 +771,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -509,7 +781,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -546,6 +818,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+ "parking_lot 0.12.0",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0a745c25b32caa56b82a3950f5fec7893a960f4c10ca3b02060b0c38d8c2ce"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-tokio"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a1a74a0c53b22d7d994256cf3ecbeefa5eedce3cf9d362945ac523c4132180"
+dependencies = [
+ "dbus",
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,7 +867,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -615,10 +922,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-hal"
-version = "0.2.6"
+name = "either"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "embedded-dma"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c8c02e4347a0267ca60813c952017f4c5948c232474c6010a381a337f1bda4"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
 dependencies = [
  "nb 0.1.3",
  "void",
@@ -629,6 +951,26 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "enumflags2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -653,7 +995,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "duct",
- "rand 0.8.4",
+ "rand 0.8.5",
  "ron",
  "serde 1.0.136",
 ]
@@ -693,6 +1035,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +1079,7 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -743,6 +1101,17 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -790,6 +1159,24 @@ dependencies = [
  "pin-utils",
  "slab",
  "tokio-io",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -919,7 +1306,7 @@ version = "0.1.0"
 dependencies = [
  "ockam",
  "ockam_transport_websocket",
- "rand 0.8.4",
+ "rand 0.8.5",
  "serde 1.0.136",
  "serde_json",
 ]
@@ -976,7 +1363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.14.5",
  "hmac 0.8.1",
 ]
 
@@ -993,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "human-panic"
@@ -1070,6 +1457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,9 +1492,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c185b5b7ad900923ef3a8ff594083d4d9b5aea80bb4f32b8342363138c0d456b"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1131,6 +1536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1193,12 +1607,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
 name = "miow"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "mips-mcu"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a48259532f7fa880d505a4a0ad9f57b77d1f4b2f88331625442b7c87a0cd64"
+dependencies = [
+ "bare-metal 0.2.5",
+]
+
+[[package]]
+name = "mips-rt"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ef9b6faac46760cc54840023bcf28290b64aeaf7164f5fe39dcbc07b4faba7"
+dependencies = [
+ "bare-metal 0.2.5",
+ "mips-rt-macros",
+ "r0",
+]
+
+[[package]]
+name = "mips-rt-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c223fbc6420c51757552c6e738a7b58385ed2de415adb51e4f5bae324e29d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1242,11 +1700,21 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1284,6 +1752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,7 +1787,7 @@ dependencies = [
  "ockam_transport_tcp",
  "ockam_vault",
  "ockam_vault_sync_core",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xorshift",
  "serde 1.0.136",
  "serde-big-array",
@@ -1346,7 +1823,7 @@ dependencies = [
  "ockam_node",
  "ockam_vault",
  "ockam_vault_sync_core",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_pcg",
  "serde 1.0.136",
  "tokio",
@@ -1359,7 +1836,7 @@ name = "ockam_command"
 version = "0.7.0"
 dependencies = [
  "bunt",
- "clap 3.0.13",
+ "clap 3.1.0",
  "comfy-table",
  "config",
  "ctrlc",
@@ -1389,7 +1866,7 @@ dependencies = [
  "heapless",
  "hex",
  "ockam_macros",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_pcg",
  "serde 1.0.136",
  "serde_bare",
@@ -1435,7 +1912,7 @@ dependencies = [
  "ockam_transport_tcp",
  "ockam_vault",
  "ockam_vault_sync_core",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xorshift",
  "serde 1.0.136",
  "serde-big-array",
@@ -1511,6 +1988,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_transport_ble"
+version = "0.1.0"
+dependencies = [
+ "atsame54_xpro",
+ "bluenrg",
+ "bluetooth-hci",
+ "btleplug",
+ "cortex-m 0.7.4",
+ "embedded-hal",
+ "futures 0.3.21",
+ "futures-util",
+ "heapless",
+ "nb 1.0.0",
+ "ockam",
+ "ockam_core",
+ "ockam_executor",
+ "ockam_node",
+ "ockam_transport_core",
+ "pic32-hal",
+ "riscv",
+ "serde 1.0.136",
+ "stm32-device-signature",
+ "stm32f4xx-hal",
+ "stm32h7xx-hal",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "ockam_transport_core"
 version = "0.20.0"
 dependencies = [
@@ -1562,7 +2068,7 @@ dependencies = [
  "ockam_core",
  "ockam_macros",
  "ockam_vault_test_suite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_pcg",
  "sha2",
  "signature_bbs_plus",
@@ -1583,7 +2089,7 @@ dependencies = [
  "ockam_node",
  "ockam_vault",
  "ockam_vault_test_suite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_pcg",
  "serde 1.0.136",
  "serde-big-array",
@@ -1656,7 +2162,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1674,10 +2190,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.32.0",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pic32-hal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4186fbd24c1b26a182991a955b429d90cb7009d1d9b583805ce78d4d26833a9a"
+dependencies = [
+ "embedded-hal",
+ "enumflags2",
+ "mips-mcu",
+ "mips-rt",
+ "nb 0.1.3",
+ "pic32mx2xx",
+]
+
+[[package]]
+name = "pic32mx2xx"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c86f6c9cdae70b425c52a269bbb4b6aa3758a7c566eaf5b2c9a9aca9c29584"
+dependencies = [
+ "mips-mcu",
+ "vcell",
+]
 
 [[package]]
 name = "pin-project"
@@ -1710,6 +2269,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "polyval"
@@ -1772,6 +2337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r0"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
+
+[[package]]
 name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,19 +2358,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1847,15 +2417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1944,6 +2505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtcc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef35f9dcbf434a34dcc99b3ebba1c1945d49c70832958e932e83dc63a5273994"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,7 +2531,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.5",
 ]
 
 [[package]]
@@ -1983,7 +2562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der",
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1994,6 +2573,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "semver-parser"
@@ -2039,6 +2624,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde 1.0.136",
+ "thiserror",
+ "xml-rs",
+]
+
+[[package]]
 name = "serde_bare"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2131,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.14",
  "signal-hook",
 ]
 
@@ -2162,7 +2759,7 @@ dependencies = [
  "hmac-drbg",
  "managed",
  "pairing",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_core 0.6.3",
  "rand_xorshift",
  "serde 1.0.136",
@@ -2202,7 +2799,7 @@ dependencies = [
  "group",
  "hashbrown 0.11.2",
  "heapless",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_core 0.6.3",
  "serde 1.0.136",
  "serde-big-array",
@@ -2223,7 +2820,7 @@ dependencies = [
  "hkdf",
  "hmac-drbg",
  "pairing",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "rand_xorshift",
@@ -2246,6 +2843,16 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "spin"
@@ -2278,6 +2885,76 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stm32-device-signature"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262c8060b3ea4cc462d5b3869147e300357917bc3255dd9f0fe36ff4195bcf0"
+dependencies = [
+ "cortex-m 0.6.7",
+]
+
+[[package]]
+name = "stm32f4"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3d56009c8f32e4f208dbea17df72484154d1040a8969b75d8c73eb7b18fe8f"
+dependencies = [
+ "bare-metal 0.2.5",
+ "cortex-m 0.7.4",
+ "cortex-m-rt",
+ "vcell",
+]
+
+[[package]]
+name = "stm32f4xx-hal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b4cb13b1bb36e7381eaf8941062b1eba172542b9d4f72dc50c35c4ac6260f2"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cast",
+ "cortex-m 0.7.4",
+ "cortex-m-rt",
+ "embedded-dma",
+ "embedded-hal",
+ "nb 1.0.0",
+ "rand_core 0.6.3",
+ "rtcc",
+ "stm32f4",
+ "void",
+]
+
+[[package]]
+name = "stm32h7"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b672c837e0ee8158ecc7fce0f9a948dd0693a9c588338e728d14b73307a0b7d"
+dependencies = [
+ "bare-metal 0.2.5",
+ "cortex-m 0.7.4",
+ "cortex-m-rt",
+ "vcell",
+]
+
+[[package]]
+name = "stm32h7xx-hal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67034b80041bc33a48df1c1c435b6ae3bb18c35e42aa7e702ce8363b96793398"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cast",
+ "cortex-m 0.7.4",
+ "cortex-m-rt",
+ "embedded-dma",
+ "embedded-hal",
+ "nb 1.0.0",
+ "paste",
+ "stm32h7",
+ "void",
+]
 
 [[package]]
 name = "strsim"
@@ -2449,19 +3126,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.0",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -2489,6 +3167,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +3192,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,22 +3216,35 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.21"
+name = "tracing-attributes"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -2543,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -2561,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a24e67e2b4083a6d0beb5a98e274c3160edfb879d71cd2cd14da93786a93b"
+checksum = "2d60539445867cdd9680b2bfe2d0428f1814b7d5c9652f09d8d3eae9d19308db"
 dependencies = [
  "dissimilar",
  "glob",
@@ -2586,7 +3303,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.4",
+ "rand 0.8.5",
  "sha-1",
  "thiserror",
  "url",
@@ -2616,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -2638,7 +3355,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -2668,6 +3385,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.4",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcell"
@@ -2756,6 +3479,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054d31561409bbf7e1ee4a4f0a1233ac2bb79cfadf2a398438a04d8dda69225f"
+dependencies = [
+ "windows-sys 0.28.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ca39602d5cbfa692c4b67e3bcbb2751477355141c1ed434c94da4186836ff6"
+dependencies = [
+ "windows_aarch64_msvc 0.28.0",
+ "windows_i686_gnu 0.28.0",
+ "windows_i686_msvc 0.28.0",
+ "windows_x86_64_gnu 0.28.0",
+ "windows_x86_64_msvc 0.28.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52695a41e536859d5308cc613b4a022261a274390b25bd29dfff4bf08505f3c2"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54725ac23affef038fecb177de6c9bf065787c2f432f79e3c373da92f3e1d8a"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d5158a43cc43623c0729d1ad6647e62fa384a3d135fd15108d37c683461f64"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc31f409f565611535130cfe7ee8e6655d3fa99c1c61013981e491921b5ce954"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2b8c7cbd3bfdddd9ab98769f9746a7fad1bca236554cd032b78d768bc0e89f"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "wyz"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +3592,12 @@ dependencies = [
  "rand_core 0.5.1",
  "zeroize",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yaml-rust"

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -1,0 +1,136 @@
+[package]
+name = "ockam_transport_ble"
+version = "0.1.0"
+authors = ["Ockam Developers"]
+edition = "2018"
+license = "Apache-2.0"
+homepage = "https://github.com/ockam-network/ockam"
+repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_transport_ble"
+readme = "README.md"
+keywords = ["ockam", "crypto", "network", "bluetooth", "ble"]
+categories = ["cryptography", "asynchronous", "authentication", "embedded", "network-programming"]
+description = """
+Bluetooth Low Energy (BLE) Transport for the Ockam Routing Protocol.
+"""
+exclude = [
+    "DEVELOP.md",
+    "LICENSE"
+]
+autoexamples = false
+
+[features]
+default = ["std", "use_btleplug", "ockam/software_vault"]
+
+# Feature (enabled by default): "std" enables functionality expected to
+# be available on a standard platform.
+std = [
+    "ockam/std",
+    "ockam_core/std",
+    "ockam_node/std",
+    "ockam_transport_core/std",
+    "tracing/default",
+    "uuid",
+]
+
+# Feature: "no_std" enables functionality required for platforms
+# without the standard library.
+no_std = [
+    "ockam/no_std",
+    "ockam_core/no_std",
+    "ockam_node/no_std",
+    "ockam_transport_core/no_std",
+    "heapless",
+    "nb",
+]
+
+# Feature: "alloc" enables support for heap allocation on "no_std"
+# platforms, requires nightly.
+alloc = [
+    "ockam/alloc",
+    "ockam_core/alloc",
+    "ockam_node/alloc",
+    "ockam_transport_core/alloc",
+]
+
+# Feature: Bare-metal support for ST Micro BlueNRG-MS BLE radios (server-only)
+use_bluetooth_hci = [ "bluetooth-hci", "bluenrg" ]
+
+# Feature: Multi-platform support for BLE radios (client-only)
+use_btleplug = [ "btleplug" ]
+
+# Processor Feature: TODO move this into its own "Ockam Addon" crate
+atsame54 = [
+    "embedded-hal", # TODO atsame54_xpro declares hal::hal as private
+    "atsame54_xpro",
+]
+
+# Processor Feature: TODO move this into its own "Ockam Addon" crate
+stm32f4 = [
+    "embedded-hal", # TODO atsame54_xpro declares hal::hal as private
+    "stm32f4xx-hal",
+]
+
+# Processor Feature: TODO move this into its own "Ockam Addon" crate
+stm32h7 = [
+    "embedded-hal", # TODO atsame54_xpro declares hal::hal as private
+    "stm32h7xx-hal",
+    "stm32-device-signature/stm32h75x",
+]
+
+# Processor Feature: TODO move this into its own "Ockam Addon" crate
+pic32 = [
+    "embedded-hal", # TODO pic32-hal declares hal::hal as private
+    "pic32-hal",
+]
+pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
+pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
+
+[dependencies]
+ockam = { path = "../ockam", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.46.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.45.0", default_features = false }
+ockam_executor = { path = "../ockam_executor", version = "^0.15.0", default_features = false }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0", default_features = false }
+
+futures = { version = "0.3.19", default-features = false }
+futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "async-await-macro", "sink"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+tracing = { version = "0.1", default_features = false }
+
+# Target os: TODO move this into its own "Ockam Addon" crate
+btleplug = { version = "0.9.0", optional = true }
+uuid = { version = "0.8.2", optional = true }
+
+# Target baremetal: TODO move this into its own "Ockam Addon" crate
+bluenrg = { version = "0.1.0", default-features = false, features = ["ms"], optional = true }
+bluetooth-hci = { version = "0.1.0", default-features = false, features = ["version-4-1"], optional = true }
+nb = { version = "1.0.0", optional = true }
+heapless = { version = "0.7.7", optional = true }
+
+# Processor atsame: TODO move this into its own "Ockam Addon" crate
+atsame54_xpro = { version = "0.2.0", optional = true }
+embedded-hal = { version = "0.2.3", optional = true }
+
+# Processor stm32: TODO move this into its own "Ockam Addon" crate
+stm32-device-signature = { version = "0.3.3", optional = true }
+stm32f4xx-hal = { version = "0.9.0", features = ["rt", "stm32f407"], optional = true }
+stm32h7xx-hal = { version = "0.9.0", features = ["rt", "stm32h747cm7"], optional = true }
+
+# Processor pic32: TODO move this into its own "Ockam Addon" crate
+pic32-hal = { version = "0.4.0", optional = true }
+
+# Architecture ARM: TODO move this into its own "Ockam Addon" crate
+[target.'cfg(target_arch = "arm")'.dependencies]
+cortex-m = "0.7.3"
+
+# Architecture RISCV: TODO move this into its own "Ockam Addon" crate
+[target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
+riscv = "0.7.0"
+
+[[example]]
+name = "04-routing-over-ble-transport-initiator"
+required-features = [ "std", "use_btleplug" ]
+
+[[example]]
+name = "05-secure-channel-over-ble-transport-initiator"
+required-features = [ "std", "use_btleplug" ]

--- a/implementations/rust/ockam/ockam_transport_ble/README.md
+++ b/implementations/rust/ockam/ockam_transport_ble/README.md
@@ -1,0 +1,160 @@
+# ockam_transport_ble
+
+### Run:
+
+    cargo build --example 04-routing-over-ble-transport-initiator
+
+    cargo run --example 04-routing-over-ble-transport-initiator
+
+    cargo run --example 05-secure-channel-over-ble-transport-initiator
+
+----
+
+
+## Transport Model
+
+All Bluetooth Low Energy (BLE) devices use the Generic Attribute
+Profile (GATT).
+
+BLE transports will typically be based around GATT concepts and
+feature the following terminology:
+
+### Client
+
+The device initiating GATT commands and requests. For example, a
+computer or other device managing and collecting data from many
+embedded BLE devices.
+
+### Server
+
+The device which receives GATT commands and requests. For example, a
+small micro-controller collecting sensor data for transmission to a
+Client device.
+
+This can be confusing as we are used to the Client being the small
+device and the Server being the big one!
+
+### Characteristic
+
+A data value transferred between client and server, for example, an
+Ockam packet containing a sensor reading.
+
+### Service
+
+A collection of related characteristics, which operate together to
+perform a particular function. For instance, the Ockam UART (Universal
+Asynchronous Receiver/Transmitter) service contains the
+characteristics required to implement the receive and transmit
+channels.
+
+### Descriptor
+
+A descriptor provides additional information about a
+characteristic. Descriptors are optional and each characteristic can
+have any number of descriptors.
+
+### Identifiers
+
+Services, characteristics, and descriptors are collectively referred
+to as attributes and are identified by UUIDs.
+
+Any implementer may pick a random or pseudorandom UUID for proprietary
+uses, but the Bluetooth SIG have reserved a [range of UUIDs
+(xxxxxxxx-0000-1000-8000-00805F9B34FB)](https://www.bluetooth.com/specifications/assigned-numbers/)
+for standard attributes.
+
+#### InteroperaBLE identifier structure
+
+    xxxxxxxx-xxxx-Mxxx-9xxx-xxxxxxxxxxxx
+                  ^    ^-------------------- Upper bits must be 10_b to represent GUID Variant 1 (i.e. 8, 9, a or b)
+                  |------------------------- Must be 4 to represent Version 4 - rest are random
+
+#### Ockam Identifiers
+
+Ockam Identifiers are in the range:
+
+    xxxxxxxx-b19e-11e2-9e96-0800200c9a66
+
+https://stackoverflow.com/questions/10867405/generating-v5-uuid-what-is-name-and-namespace
+https://www.uuidtools.com/generate/v5
+https://www.uuidtools.com/decode
+
+---
+
+## Assigned Identifiers
+
+#### UART Service Identifier
+
+    d973f2e0-b19e-11e2-9e96-0800200c9a66
+
+#### UART Transmit Characteristic Identifier
+
+    d973f2e1-b19e-11e2-9e96-0800200c9a66
+    NOTIFY
+
+#### UART Receive Characteristic Identifier
+
+    d973f2e2-b19e-11e2-9e96-0800200c9a66
+    WRITE_WITHOUT_RESPONSE | WRITE
+
+---
+
+## Mandatory identifier
+
+TODO
+
+* https://reelyactive.github.io/ble-identifier-reference.html
+* https://reelyactive.github.io/diy/best-practices-ble-identifiers/
+
+ockam -> 0ca?
+
+---
+
+# Setup notes
+
+## Linux
+
+### Dependencies
+
+    apt-get install libdbus-1-dev libssl-dev
+
+### dbus permissions
+
+Edit `/etc/dbus-1/system.d/bluetooth.conf`:
+
+    <policy user="antoine">
+      <allow send_destination="org.bluez"/>
+      <allow send_interface="org.bluez.Agent1"/>
+      <allow send_interface="org.bluez.GattCharacteristic1"/>
+      <allow send_interface="org.bluez.GattDescriptor1"/>
+      <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
+      <allow send_interface="org.freedesktop.DBus.Properties"/>
+    </policy>
+
+## Mac
+
+To use Bluetooth on macOS Big Sur (11) or later, you need to either package your binary into an application bundle with an `Info.plist` including `NSBluetoothAlwaysUsageDescription`, or (for a command-line application such as the examples included with `btleplug`) enable the Bluetooth permission for your terminal.
+
+You can do the latter by going to:
+
+    System Preferences → Security & Privacy → Privacy → Bluetooth
+
+... clicking the '+' button, and selecting 'Terminal' (or iTerm or whichever terminal application you use).
+
+Update: There is currently a bug in macOS Monterey that prevents Bluetooth Discovery for unsigned apps (even if you have given permissions to them)
+
+To fix:
+
+    Keychain Access => System Menu => Certificate Assistant => Create a Certificate...
+
+        Name:             Self Signed Root
+        Identity Type:    Self Signed Root
+        Certificate Type: Code Signing
+
+    codesign -f -o runtime --timestamp -s "Self Signed Root" target/debug/examples/04-routing-over-ble-transport-initiator
+    codesign --entitlements Entitlements.plist -f -o runtime --timestamp -s "Self Signed Root" 04-routing-over-ble-transport-initiator
+    codesign --entitlements Entitlements.plist -f -o runtime --timestamp -s "Apple Development: Antoine van Gelder (R972JJ8RXX)" 04-routing-over-ble-transport-initiator
+    codesign -f -o runtime --timestamp -s "Developer ID Application: Antoine van Gelder (HLUFY5JD2L)" 04-routing-over-ble-transport-initiator
+
+
+    codesign --entitlements Entitlements.plist -f -s "Apple Distribution" 04-routing-over-ble-transport-initiator

--- a/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
@@ -1,0 +1,30 @@
+// This node routes a message, to a worker on a different node, over the ble transport.
+
+use ockam::{route, Context, Result};
+use ockam_transport_ble::{BleClient, BleTransport, BLE};
+
+use ockam_transport_ble::driver::btleplug::BleAdapter;
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    // Create a ble_client
+    let ble_adapter = BleAdapter::try_new().await?;
+    let ble_client = BleClient::with_adapter(ble_adapter);
+
+    // Initialize the BLE Transport.
+    let ble = BleTransport::create(&ctx).await?;
+
+    // Try to connect to BleServer
+    ble.connect(ble_client, "ockam_ble_1".to_string()).await?;
+
+    // Send a message to the "echoer" worker, on a different node, over a ble transport.
+    let r = route![(BLE, "ockam_ble_1"), "echoer"];
+    ctx.send(r, "Hello Ockam!".to_string()).await?;
+
+    // Wait to receive a reply and print it.
+    let reply = ctx.receive::<String>().await?;
+    println!("[main] App Received: {}", reply); // should print "Hello Ockam!"
+
+    // Stop all workers, stop the node, cleanup and return.
+    ctx.stop().await
+}

--- a/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
@@ -1,0 +1,41 @@
+// This node routes a message, to a worker on a different node, over the ble transport.
+
+use ockam::{route, Context, Identity, Result, TrustEveryonePolicy, Vault};
+use ockam_transport_ble::{BleTransport, BLE};
+
+use ockam_transport_ble::driver::btleplug::BleAdapter;
+use ockam_transport_ble::driver::BleClient;
+
+#[ockam::node]
+async fn main(mut ctx: Context) -> Result<()> {
+    // Create a ble_client
+    let ble_adapter = BleAdapter::try_new().await?;
+    let ble_client = BleClient::with_adapter(ble_adapter);
+
+    // Initialize the BLE Transport.
+    let ble = BleTransport::create(&ctx).await?;
+
+    // Create a Vault to safely store secret keys for Alice.
+    let vault = Vault::create();
+
+    // Create an Entity to represent Alice.
+    let mut alice = Identity::create(&ctx, &vault).await?;
+
+    // Connect to BLE Server
+    ble.connect(ble_client, "ockam_ble_1".to_string()).await?;
+
+    // Connect to a secure channel listener and perform a handshake.
+    let r = route![(BLE, "ockam_ble_1"), "bob_listener"];
+    let channel = alice.create_secure_channel(r, TrustEveryonePolicy).await?;
+
+    // Send a message to the "echoer" worker, on a different node, via secure channel.
+    let r = route![channel, "echoer"];
+    ctx.send(r, "Hello Ockam!".to_string()).await?;
+
+    // Wait to receive a reply and print it.
+    let reply = ctx.receive::<String>().await?;
+    println!("[main] App Received: {}", reply); // should print "Hello Ockam!"
+
+    // Stop all workers, stop the node, cleanup and return.
+    ctx.stop().await
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/ble_uart.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/ble_uart.rs
@@ -1,0 +1,529 @@
+use embedded_hal::blocking;
+use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::v2::OutputPin;
+use nb::{self, block};
+
+use core::fmt::Debug;
+use core::result::Result;
+use core::time::Duration;
+
+use bluetooth_hci::event::command::CommandComplete;
+use bluetooth_hci::event::command::ReturnParameters as HciParams;
+use bluetooth_hci::event::command::ReturnParameters::Vendor;
+use bluetooth_hci::host::uart::Hci as _;
+use bluetooth_hci::host::Hci as _;
+
+use bluenrg::event::AttributeHandle;
+use bluenrg::event::BlueNRGEvent;
+use bluenrg::gap::{AuthenticationRequirements, DiscoverableParameters, OutOfBandAuthentication};
+use bluenrg::gatt::{
+    AddCharacteristicParameters, AddServiceParameters, CharacteristicEvent,
+    CharacteristicPermission, CharacteristicProperty, EncryptionKeySize, ServiceType,
+    UpdateCharacteristicValueParameters, Uuid, Uuid::Uuid128,
+};
+use bluenrg::hal::ConfigData;
+use bluenrg::BlueNRG;
+use bluenrg::OwnAddressType;
+
+use bluenrg::event::command::ReturnParameters as Parameters;
+use bluenrg::gap::Commands as GapCommands;
+use bluenrg::gatt::Commands as GattCommands;
+use bluenrg::hal::Commands as HalCommands;
+
+use super::embedded_hal;
+use crate::error::BleError;
+use crate::BleAddr;
+
+type Packet = bluetooth_hci::host::uart::Packet<BlueNRGEvent>;
+pub type Event = bluetooth_hci::event::Event<BlueNRGEvent>;
+
+/// BleContext
+#[derive(Debug, Default)]
+pub struct BleContext {
+    pub service_handle: Option<bluenrg::gatt::ServiceHandle>,
+    pub dev_name_handle: Option<bluenrg::gatt::CharacteristicHandle>,
+    pub appearence_handle: Option<bluenrg::gatt::CharacteristicHandle>,
+
+    pub uart_service_handle: Option<bluenrg::gatt::ServiceHandle>,
+    pub uart_tx_handle: Option<bluenrg::gatt::CharacteristicHandle>,
+    pub uart_rx_handle: Option<bluenrg::gatt::CharacteristicHandle>,
+    pub uart_rx_attribute_handle: Option<AttributeHandle>,
+
+    pub conn_handle: Option<bluenrg::event::ConnectionHandle>,
+}
+
+/// Currently we only support the BLE Peripheral role on embedded
+pub const ROLE: bluenrg::gap::Role = bluenrg::gap::Role::PERIPHERAL;
+
+/// BLE encryption key size
+pub const BLE_ENCRYPTION_KEY_SIZE: usize = 16;
+
+/// If `true`, the `AddCharacteristicParameters::characteristic_value_len`
+/// parameter only takes 1 byte.
+pub const FW_VERSION_BEFORE_V72: bool = true;
+
+/// BLE Uart: Initial Setup (1/5)
+pub fn setup<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+) -> Result<(), bluenrg::Error<SPI::Error, GpioError>>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    debug!("\tsoftware controller reset");
+    block!(bluetooth.with_spi(spi, |controller| { controller.reset() }))?;
+
+    // wait for reset to complete
+    crate::wait_ms!(200);
+
+    // read first reset response (Command complete)
+    match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
+        Ok(Packet::Event(event)) => debug!("\t=> controller reset: {:?}", event),
+        Err(e) => error!("controller reset error: {:?}", e),
+    }
+
+    // read second reset response (HAL initialized)
+    controller_read(spi, bluetooth);
+
+    // configure public address
+    let bd_addr = super::get_bd_addr();
+    debug!("\twrite_config_data: public_address -> {:?}", bd_addr);
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.write_config_data(&ConfigData::public_address(bd_addr).build())
+    }))?;
+    controller_read(spi, bluetooth);
+
+    // set power level
+    debug!("\tset_tx_power_level");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.set_tx_power_level(bluenrg::hal::PowerLevel::Dbm8_0)
+    }))?;
+    controller_read(spi, bluetooth);
+
+    Ok(())
+}
+
+/// BLE Uart: Initialize GATT and GAP (2/5)
+pub fn initialize_gatt_and_gap<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    ble_addr: &BleAddr,
+) -> Result<BleContext, bluenrg::Error<SPI::Error, GpioError>>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    debug!("ble_uartinitialize_gatt_and_gap");
+
+    // init gatt
+    debug!("\tinit_gatt");
+    block!(bluetooth.with_spi(spi, |controller| { controller.init_gatt() }))?;
+    controller_read(spi, bluetooth);
+
+    // ble_context
+    let mut ble_context = BleContext::default();
+    ble_context.uart_rx_attribute_handle = Some(AttributeHandle(17)); // TODO
+
+    // init gap
+    debug!("\tinit_gap");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.init_gap(ROLE, false, ble_addr.device_name.len() as u8)
+    }))?;
+    match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
+        Ok(Packet::Event(event)) => match event {
+            Event::CommandComplete(CommandComplete {
+                return_params: Vendor(Parameters::GapInit(params)),
+                ..
+            }) => {
+                debug!("\t=> CommandComplete::init_gap -> {:?}", params);
+                ble_context.service_handle = Some(params.service_handle);
+                ble_context.dev_name_handle = Some(params.dev_name_handle);
+                ble_context.appearence_handle = Some(params.appearance_handle);
+            }
+            _ => debug!("\t=> unknown event: {:?}", event),
+        },
+        Err(e) => debug!("controller.reset error: {:?}", e),
+    }
+
+    debug!("\tupdate_characteristic_value -> {:?}", ble_context);
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.update_characteristic_value(&UpdateCharacteristicValueParameters {
+            service_handle: ble_context
+                .service_handle
+                .expect("service handle has not been set"),
+            characteristic_handle: ble_context
+                .dev_name_handle
+                .expect("device name handdle has not been set"),
+            offset: 0x00,
+            value: ble_addr.device_name.as_bytes(),
+        })
+    }))
+    .unwrap();
+    controller_read(spi, bluetooth);
+
+    Ok(ble_context)
+}
+
+/// BLE Uart: Initialize UART (3/5)
+pub fn initialize_uart<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    ble_context: &mut BleContext,
+) -> Result<(), bluenrg::Error<SPI::Error, GpioError>>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    debug!("ble_uart::initialize_uart");
+
+    // configure authorization requirements
+    debug!("\tconfigure auth");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.set_authentication_requirement(&AuthenticationRequirements {
+            mitm_protection_required: true,
+            out_of_band_auth: OutOfBandAuthentication::Disabled,
+            encryption_key_size_range: (7, 16),
+            fixed_pin: bluenrg::gap::Pin::Fixed(123456),
+            bonding_required: true,
+        })
+    }))
+    .unwrap();
+
+    // wait for command to complete
+    crate::wait_ms!(200);
+
+    controller_read(spi, bluetooth);
+
+    // add services
+    if ROLE == bluenrg::gap::Role::PERIPHERAL {
+        add_uart_service(spi, bluetooth, ble_context)?;
+    }
+
+    Ok(())
+}
+
+/// BLE Uart: Add UART service (4/5)
+pub fn add_uart_service<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    ble_context: &mut BleContext,
+) -> Result<(), bluenrg::Error<SPI::Error, GpioError>>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    debug!("nble_uart::add_uart_service");
+
+    const UUID: Uuid = Uuid128([
+        0x66, 0x9a, 0x0c, 0x20, 0x00, 0x08, 0x96, 0x9e, 0xe2, 0x11, 0x9e, 0xb1, 0xe0, 0xf2, 0x73,
+        0xd9,
+    ]);
+    const UUID_TX: Uuid = Uuid128([
+        0x66, 0x9a, 0x0c, 0x20, 0x00, 0x08, 0x96, 0x9e, 0xe2, 0x11, 0x9e, 0xb1, 0xe1, 0xf2, 0x73,
+        0xd9,
+    ]);
+    const UUID_RX: Uuid = Uuid128([
+        0x66, 0x9a, 0x0c, 0x20, 0x00, 0x08, 0x96, 0x9e, 0xe2, 0x11, 0x9e, 0xb1, 0xe2, 0xf2, 0x73,
+        0xd9,
+    ]);
+
+    // add uart service
+    debug!("\tadd uart service");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.add_service(&AddServiceParameters {
+            uuid: UUID,
+            service_type: ServiceType::Primary,
+            max_attribute_records: 9, // TODO
+        })
+    }))
+    .unwrap();
+    match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
+        Ok(Packet::Event(event)) => match event {
+            Event::CommandComplete(CommandComplete {
+                return_params: Vendor(Parameters::GattAddService(service)),
+                ..
+            }) => {
+                debug!("\t=> CommandComplete::add_service -> {:?}", service);
+                ble_context.uart_service_handle = Some(service.service_handle)
+            }
+            _ => debug!("\t=> unknown event: {:?}", event),
+        },
+        Err(e) => debug!("controller.add_service error: {:?}", e),
+    }
+
+    // add uart service tx characteristic: notify
+    debug!("\tadd uart service tx characteristic: notify");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.add_characteristic(&AddCharacteristicParameters {
+            service_handle: ble_context
+                .uart_service_handle
+                .expect("uart service handle has not been set"),
+            characteristic_uuid: UUID_TX,
+            characteristic_value_len: crate::driver::CHARACTERISTIC_VALUE_LENGTH,
+            characteristic_properties: CharacteristicProperty::NOTIFY,
+
+            // TODO https://github.com/danielgallagher0/bluenrg/pull/5
+            // security_permissions: CharacteristicPermission::NONE,
+            // gatt_event_mask: CharacteristicEvent::NONE,
+            #[allow(unsafe_code)]
+            security_permissions: unsafe { core::mem::transmute(0_u8) },
+            #[allow(unsafe_code)]
+            gatt_event_mask: unsafe { core::mem::transmute(0_u8) },
+
+            encryption_key_size: EncryptionKeySize::with_value(BLE_ENCRYPTION_KEY_SIZE)
+                .expect("wrong size encryption key"),
+            is_variable: true,
+            fw_version_before_v72: FW_VERSION_BEFORE_V72,
+        })
+    }))
+    .unwrap();
+    ble_context.uart_tx_handle = handle_event(spi, bluetooth, |event| match event {
+        Event::CommandComplete(CommandComplete {
+            return_params: Vendor(Parameters::GattAddCharacteristic(characteristic)),
+            ..
+        }) => {
+            debug!(
+                "\t=> CommandComplete::add_characteristic -> {:?}",
+                characteristic
+            );
+            Some(characteristic.characteristic_handle)
+        }
+        _ => {
+            debug!("\t=> unknown event: {:?}", event);
+            None
+        }
+    });
+
+    // add uart service rx characteristic: write
+    debug!("\tadd uart service rx characteristic: write");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.add_characteristic(&AddCharacteristicParameters {
+            service_handle: ble_context
+                .uart_service_handle
+                .expect("uart service handle has not been set"),
+            characteristic_uuid: UUID_RX,
+            characteristic_value_len: crate::driver::CHARACTERISTIC_VALUE_LENGTH,
+            characteristic_properties: CharacteristicProperty::WRITE
+                | CharacteristicProperty::WRITE_WITHOUT_RESPONSE,
+
+            // TODO https://github.com/danielgallagher0/bluenrg/pull/5
+            // security_permissions: CharacteristicPermission::NONE,
+            #[allow(unsafe_code)]
+            security_permissions: unsafe { core::mem::transmute(0_u8) },
+
+            gatt_event_mask: CharacteristicEvent::ATTRIBUTE_WRITE,
+            encryption_key_size: EncryptionKeySize::with_value(BLE_ENCRYPTION_KEY_SIZE)
+                .expect("wrong size encryption key"),
+            is_variable: true,
+            fw_version_before_v72: FW_VERSION_BEFORE_V72,
+        })
+    }))
+    .unwrap();
+    match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
+        Ok(Packet::Event(event)) => match event {
+            Event::CommandComplete(CommandComplete {
+                return_params: Vendor(Parameters::GattAddCharacteristic(characteristic)),
+                ..
+            }) => {
+                debug!(
+                    "\t=> CommandComplete::add_characteristic -> {:?}",
+                    characteristic
+                );
+                ble_context.uart_rx_handle = Some(characteristic.characteristic_handle);
+            }
+            _ => debug!("\t=> unknown event: {:?}", event),
+        },
+        Err(e) => debug!("controller.add_characteristic error: {:?}", e),
+    }
+
+    Ok(())
+}
+
+/// BLE Uart: Start advertising (5/5)
+pub fn start_advertising<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    _context: &mut BleContext,
+    ble_addr: &BleAddr,
+) -> Result<(), bluenrg::Error<SPI::Error, GpioError>>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    debug!("ble_uart::start_advertising");
+
+    debug!("\tle_set_scan_response_data (disable scan response)");
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.le_set_scan_response_data(&[])
+    }))
+    .unwrap();
+    controller_read(spi, bluetooth);
+
+    debug!("\tset_discoverable (put the device in a non-connectable mode)");
+    let result = block!(bluetooth.with_spi(spi, |controller| {
+        controller.set_discoverable(&DiscoverableParameters {
+            advertising_type: bluenrg::AdvertisingType::ConnectableUndirected,
+            advertising_interval: Some((Duration::from_millis(250), Duration::from_millis(1000))),
+            address_type: OwnAddressType::Public,
+            filter_policy: bluenrg::AdvertisingFilterPolicy::AllowConnectionAndScan,
+            local_name: Some(bluenrg::gap::LocalName::Shortened(
+                ble_addr.local_name.as_bytes(),
+            )),
+            advertising_data: &[],
+            conn_interval: (None, None),
+        })
+    }));
+    match result {
+        Ok(_) => (),
+        Err(e) => debug!("failed to block on set_discoverable: {:?}", e),
+    };
+    controller_read(spi, bluetooth);
+
+    // delete some ad types to make space
+    debug!("\tdelete_ad_type");
+
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.delete_ad_type(bluenrg::gap::AdvertisingDataType::TxPowerLevel)
+    }))?;
+    controller_read(spi, bluetooth);
+
+    block!(bluetooth.with_spi(spi, |controller| {
+        controller.delete_ad_type(bluenrg::gap::AdvertisingDataType::PeripheralConnectionInterval)
+    }))?;
+    controller_read(spi, bluetooth);
+
+    Ok(())
+}
+
+/// Generic event handler that takes a callback function
+pub fn handle_event<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError, F, T>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    handler: F,
+) -> Option<T>
+where
+    F: FnOnce(&Event) -> Option<T>,
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
+        Ok(Packet::Event(event)) => handler(&event),
+        Err(e) => {
+            debug!("controller_read error: {:?}", e);
+            None
+        }
+    }
+}
+
+/// Generic controller read for commands that do not return a value
+pub fn controller_read<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+) where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin1::Error: Debug,
+{
+    match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
+        Ok(Packet::Event(event)) => match event {
+            Event::ConnectionComplete(params) => {
+                debug!("\t=> ConnectionComplete -> {:?}", params);
+            }
+            Event::Vendor(BlueNRGEvent::HalInitialized(reason)) => {
+                debug!("\t=> Vendor::HalInitialized -> {:?}", reason);
+            }
+            _ => {
+                debug!("\t=> {:?}", event);
+            }
+        },
+        Err(e) => debug!("controller_read error: {:?}", e),
+    }
+}
+
+/// Read local version information of device
+pub fn read_local_version_information<'buf, SPI, OutputPin1, OutputPin2, InputPin, GpioError>(
+    spi: &mut SPI,
+    bluetooth: &mut BlueNRG<'buf, SPI, OutputPin1, OutputPin2, InputPin, GpioError>,
+) -> Result<(), BleError>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin: embedded_hal::digital::v2::InputPin<Error = GpioError>,
+    SPI::Error: Debug,
+    OutputPin1::Error: Debug,
+    OutputPin2::Error: Debug,
+    InputPin::Error: Debug,
+{
+    debug!("\n\tread bluenrg-ms local version information");
+    bluetooth.with_spi(spi, |controller| {
+        block!(controller.read_local_version_information())
+    })?;
+    match bluetooth.with_spi(spi, |controller| block!(controller.read())) {
+        Ok(packet) => {
+            let bluetooth_hci::host::uart::Packet::Event::<BlueNRGEvent>(event) = packet;
+            match event {
+                Event::CommandComplete(CommandComplete {
+                    return_params: HciParams::ReadLocalVersionInformation(version),
+                    ..
+                }) => {
+                    debug!(
+                        "\t=> CommandComplete::read_local_version_information -> {:?}",
+                        version
+                    );
+                    return Ok(());
+                }
+                _ => {
+                    debug!("\tunknown event => {:?}", event);
+                    return Err(BleError::HardwareError);
+                }
+            }
+        }
+        Err(e) => {
+            debug!("read_local_version_information error: {:?}", e);
+            return Err(BleError::HardwareError);
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/ble_uart.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/ble_uart.rs
@@ -33,6 +33,7 @@ use bluenrg::hal::Commands as HalCommands;
 use super::embedded_hal;
 use crate::error::BleError;
 use crate::BleAddr;
+use crate::driver;
 
 type Packet = bluetooth_hci::host::uart::Packet<BlueNRGEvent>;
 pub type Event = bluetooth_hci::event::Event<BlueNRGEvent>;
@@ -237,26 +238,13 @@ where
     OutputPin2::Error: Debug,
     InputPin1::Error: Debug,
 {
-    debug!("nble_uart::add_uart_service");
-
-    const UUID: Uuid = Uuid128([
-        0x66, 0x9a, 0x0c, 0x20, 0x00, 0x08, 0x96, 0x9e, 0xe2, 0x11, 0x9e, 0xb1, 0xe0, 0xf2, 0x73,
-        0xd9,
-    ]);
-    const UUID_TX: Uuid = Uuid128([
-        0x66, 0x9a, 0x0c, 0x20, 0x00, 0x08, 0x96, 0x9e, 0xe2, 0x11, 0x9e, 0xb1, 0xe1, 0xf2, 0x73,
-        0xd9,
-    ]);
-    const UUID_RX: Uuid = Uuid128([
-        0x66, 0x9a, 0x0c, 0x20, 0x00, 0x08, 0x96, 0x9e, 0xe2, 0x11, 0x9e, 0xb1, 0xe2, 0xf2, 0x73,
-        0xd9,
-    ]);
+    debug!("ble_uart::add_uart_service");
 
     // add uart service
     debug!("\tadd uart service");
     block!(bluetooth.with_spi(spi, |controller| {
         controller.add_service(&AddServiceParameters {
-            uuid: UUID,
+            uuid: Uuid128(driver::uuid::SERVICE.to_le_bytes()),
             service_type: ServiceType::Primary,
             max_attribute_records: 9, // TODO
         })
@@ -283,7 +271,7 @@ where
             service_handle: ble_context
                 .uart_service_handle
                 .expect("uart service handle has not been set"),
-            characteristic_uuid: UUID_TX,
+            characteristic_uuid: Uuid128(driver::uuid::WRITE.to_le_bytes()),
             characteristic_value_len: crate::driver::CHARACTERISTIC_VALUE_LENGTH,
             characteristic_properties: CharacteristicProperty::NOTIFY,
 
@@ -326,7 +314,7 @@ where
             service_handle: ble_context
                 .uart_service_handle
                 .expect("uart service handle has not been set"),
-            characteristic_uuid: UUID_RX,
+            characteristic_uuid: Uuid128(driver::uuid::READ.to_le_bytes()),
             characteristic_value_len: crate::driver::CHARACTERISTIC_VALUE_LENGTH,
             characteristic_properties: CharacteristicProperty::WRITE
                 | CharacteristicProperty::WRITE_WITHOUT_RESPONSE,

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/ble_uart.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/ble_uart.rs
@@ -74,9 +74,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     debug!("\tsoftware controller reset");
     block!(bluetooth.with_spi(spi, |controller| { controller.reset() }))?;
@@ -126,9 +124,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     debug!("ble_uartinitialize_gatt_and_gap");
 
@@ -139,7 +135,8 @@ where
 
     // ble_context
     let mut ble_context = BleContext::default();
-    ble_context.uart_rx_attribute_handle = Some(AttributeHandle(17)); // TODO
+    // TODO figure out why the bluenrg returns an invalid rx attribute handle
+    ble_context.uart_rx_attribute_handle = Some(AttributeHandle(17));
 
     // init gap
     debug!("\tinit_gap");
@@ -195,9 +192,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     debug!("ble_uart::initialize_uart");
 
@@ -208,6 +203,7 @@ where
             mitm_protection_required: true,
             out_of_band_auth: OutOfBandAuthentication::Disabled,
             encryption_key_size_range: (7, 16),
+            // we use a non-connectable mode so this pin is arbitrary
             fixed_pin: bluenrg::gap::Pin::Fixed(123456),
             bonding_required: true,
         })
@@ -238,9 +234,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     debug!("ble_uart::add_uart_service");
 
@@ -372,9 +366,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     debug!("ble_uart::start_advertising");
 
@@ -429,9 +421,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
         Ok(Packet::Event(event)) => handler(&event),
@@ -453,9 +443,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin1::Error: Debug,
+    GpioError: Debug,
 {
     match block!(bluetooth.with_spi(spi, |controller| controller.read())) {
         Ok(Packet::Event(event)) => match event {
@@ -487,9 +475,7 @@ where
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin: embedded_hal::digital::v2::InputPin<Error = GpioError>,
     SPI::Error: Debug,
-    OutputPin1::Error: Debug,
-    OutputPin2::Error: Debug,
-    InputPin::Error: Debug,
+    GpioError: Debug,
 {
     debug!("\tread bluenrg-ms local version information");
     bluetooth.with_spi(spi, |controller| {

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
@@ -26,7 +26,7 @@ use hal::time::Milliseconds as MilliSeconds;
 
 mod ble_uart;
 
-use core::fmt;
+use core::fmt::Debug;
 use embedded_hal::{
     blocking,
     digital::v2::{InputPin, OutputPin},
@@ -75,10 +75,8 @@ where
     OutputPin1: OutputPin<Error = GpioError>,
     OutputPin2: OutputPin<Error = GpioError>,
     InputPin1: InputPin<Error = GpioError>,
-    SPI::Error: fmt::Debug,
-    OutputPin1::Error: fmt::Debug,
-    OutputPin2::Error: fmt::Debug,
-    InputPin1::Error: fmt::Debug,
+    SPI::Error: Debug,
+    GpioError: Debug,
 {
     pub fn with_interface(
         spi: SPI,
@@ -159,11 +157,8 @@ where
     OutputPin1: OutputPin<Error = GpioError> + Send,
     OutputPin2: OutputPin<Error = GpioError> + Send,
     InputPin1: InputPin<Error = GpioError> + Send,
-    SPI::Error: fmt::Debug,
-    OutputPin1::Error: fmt::Debug,
-    OutputPin2::Error: fmt::Debug,
-    InputPin1::Error: fmt::Debug,
-    GpioError: Send,
+    SPI::Error: Debug,
+    GpioError: Debug + Send,
 {
     async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
         self.ble_addr = ble_addr.clone();
@@ -210,11 +205,8 @@ where
     OutputPin1: OutputPin<Error = GpioError> + Send,
     OutputPin2: OutputPin<Error = GpioError> + Send,
     InputPin1: InputPin<Error = GpioError> + Send,
-    SPI::Error: fmt::Debug,
-    OutputPin1::Error: fmt::Debug,
-    OutputPin2::Error: fmt::Debug,
-    InputPin1::Error: fmt::Debug,
-    GpioError: Send,
+    SPI::Error: Debug,
+    GpioError: Debug + Send,
 {
     async fn poll<'b>(&mut self, out_fragment: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
         // avoid deadlocking the caller
@@ -269,7 +261,8 @@ where
                         let fragment = event.data();
                         let fragment_len = event.data().len();
                         if fragment_len > out_fragment.len() {
-                            panic!("fragment too long");
+                            error!("response fragment too long");
+                            return Err(BleError::ReadError.into());
                         }
 
                         let out_fragment = &mut out_fragment[..fragment_len];
@@ -339,8 +332,8 @@ where
 /// Map bluetooth_hci::host::Error to BleError
 impl<E, VS> From<bluetooth_hci::host::Error<E, VS>> for BleError
 where
-    E: core::fmt::Debug,
-    VS: core::fmt::Debug,
+    E: Debug,
+    VS: Debug,
 {
     fn from(e: bluetooth_hci::host::Error<E, VS>) -> Self {
         trace!("bluetooth_hci::host::Error error: {:?}", e);
@@ -351,8 +344,8 @@ where
 /// Map bluetooth_hci::host::uart::Error to BleError
 impl<E, VS> From<bluetooth_hci::host::uart::Error<E, VS>> for BleError
 where
-    E: core::fmt::Debug,
-    VS: core::fmt::Debug,
+    E: Debug,
+    VS: Debug,
 {
     fn from(e: bluetooth_hci::host::uart::Error<E, VS>) -> Self {
         trace!("bluetooth_hci::host::uart::Error error: {:?}", e);
@@ -363,8 +356,8 @@ where
 /// Map bluenrg::Error to BleError
 impl<SpiError, GpioError> From<bluenrg::Error<SpiError, GpioError>> for BleError
 where
-    SpiError: core::fmt::Debug,
-    GpioError: core::fmt::Debug,
+    SpiError: Debug,
+    GpioError: Debug,
 {
     fn from(e: bluenrg::Error<SpiError, GpioError>) -> Self {
         trace!("bluenrg::Error error: {:?}", e);
@@ -375,7 +368,7 @@ where
 /// Map bluenrg::gap::Error to BleError
 impl<E> From<bluenrg::gap::Error<E>> for BleError
 where
-    E: core::fmt::Debug,
+    E: Debug,
 {
     fn from(e: bluenrg::gap::Error<E>) -> Self {
         trace!("bluenrg::gap error: {:?}", e);
@@ -386,7 +379,7 @@ where
 /// Map bluenrg::gatt::Error to BleError
 impl<E> From<bluenrg::gatt::Error<E>> for BleError
 where
-    E: core::fmt::Debug,
+    E: Debug,
 {
     fn from(e: bluenrg::gatt::Error<E>) -> Self {
         trace!("bluenrg::gatt error: {:?}", e);
@@ -397,7 +390,7 @@ where
 /// Map nb::Error to BleError
 impl<GpioError> From<nb::Error<GpioError>> for BleError
 where
-    GpioError: core::fmt::Debug,
+    GpioError: Debug,
 {
     fn from(e: nb::Error<GpioError>) -> Self {
         trace!("bluenrg::gatt error: {:?}", e);

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
@@ -336,26 +336,72 @@ where
     }
 }
 
+/// Map bluetooth_hci::host::Error to BleError
+impl<E, VS> From<bluetooth_hci::host::Error<E, VS>> for BleError
+where
+    E: core::fmt::Debug,
+    VS: core::fmt::Debug,
+{
+    fn from(e: bluetooth_hci::host::Error<E, VS>) -> Self {
+        trace!("bluetooth_hci::host::Error error: {:?}", e);
+        Self::HardwareError
+    }
+}
+
+/// Map bluetooth_hci::host::uart::Error to BleError
+impl<E, VS> From<bluetooth_hci::host::uart::Error<E, VS>> for BleError
+where
+    E: core::fmt::Debug,
+    VS: core::fmt::Debug,
+{
+    fn from(e: bluetooth_hci::host::uart::Error<E, VS>) -> Self {
+        trace!("bluetooth_hci::host::uart::Error error: {:?}", e);
+        Self::HardwareError
+    }
+}
+
 /// Map bluenrg::Error to BleError
-impl<SpiError, GpioError> From<bluenrg::Error<SpiError, GpioError>> for BleError {
+impl<SpiError, GpioError> From<bluenrg::Error<SpiError, GpioError>> for BleError
+where
+    SpiError: core::fmt::Debug,
+    GpioError: core::fmt::Debug,
+{
     fn from(e: bluenrg::Error<SpiError, GpioError>) -> Self {
-        match e {
-            bluenrg::Error::Spi(_e) => Self::HardwareError,
-            bluenrg::Error::Gpio(_e) => Self::HardwareError,
-        }
+        trace!("bluenrg::Error error: {:?}", e);
+        Self::HardwareError
+    }
+}
+
+/// Map bluenrg::gap::Error to BleError
+impl<E> From<bluenrg::gap::Error<E>> for BleError
+where
+    E: core::fmt::Debug,
+{
+    fn from(e: bluenrg::gap::Error<E>) -> Self {
+        trace!("bluenrg::gap error: {:?}", e);
+        Self::HardwareError
+    }
+}
+
+/// Map bluenrg::gatt::Error to BleError
+impl<E> From<bluenrg::gatt::Error<E>> for BleError
+where
+    E: core::fmt::Debug,
+{
+    fn from(e: bluenrg::gatt::Error<E>) -> Self {
+        trace!("bluenrg::gatt error: {:?}", e);
+        Self::HardwareError
     }
 }
 
 /// Map nb::Error to BleError
-impl<GpioError> From<nb::Error<GpioError>> for BleError {
+impl<GpioError> From<nb::Error<GpioError>> for BleError
+where
+    GpioError: core::fmt::Debug,
+{
     fn from(e: nb::Error<GpioError>) -> Self {
-        match e {
-            nb::Error::Other(_e) => Self::HardwareError,
-            nb::Error::WouldBlock => {
-                error!("ble.rs wouldblock");
-                Self::HardwareError
-            }
-        }
+        trace!("bluenrg::gatt error: {:?}", e);
+        Self::HardwareError
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
@@ -1,0 +1,410 @@
+//! Driver for ST Micro BlueNRG Bluetooth radios
+//!
+//! Uses the [bluetooth-hci](https://crates.io/crates/bluetooth-hci)
+//! and [bluenrg](https://crates.io/crates/bluetooth-hci) crates to
+//! implement the BLE specification and chip-specific commands and
+//! events for embedded targets.
+
+#[cfg(feature = "atsame54")]
+use atsame54_xpro as hal;
+#[cfg(feature = "pic32")]
+use pic32_hal as hal;
+#[cfg(feature = "stm32f4")]
+use stm32f4xx_hal as hal;
+#[cfg(feature = "stm32h7")]
+use stm32h7xx_hal as hal;
+
+#[cfg(any(feature = "atsame54", feature = "pic32"))]
+use embedded_hal;
+#[cfg(any(feature = "stm32f4", feature = "stm32h7"))]
+use hal::hal as embedded_hal;
+
+#[cfg(not(feature = "atsame54"))]
+use hal::time::MilliSeconds;
+#[cfg(feature = "atsame54")]
+use hal::time::Milliseconds as MilliSeconds;
+
+mod ble_uart;
+
+use core::fmt;
+use embedded_hal::{
+    blocking,
+    digital::v2::{InputPin, OutputPin},
+};
+use hal::time::Hertz;
+use nb::block;
+
+use bluenrg::event::{BlueNRGEvent, GattAttributeModified};
+use bluenrg::gatt::Commands;
+use bluenrg::BlueNRG;
+use bluetooth_hci::host::uart::Hci;
+
+use ockam_core::async_trait;
+use ockam_core::compat::boxed::Box;
+use ockam_core::compat::io;
+
+use crate::driver::BleEvent;
+use crate::driver::{BleServerDriver, BleStreamDriver};
+use crate::error::BleError;
+use crate::BleAddr;
+
+pub type Packet = bluetooth_hci::host::uart::Packet<BlueNRGEvent>;
+pub type Event = bluetooth_hci::event::Event<BlueNRGEvent>;
+
+#[derive(Debug, PartialEq)]
+enum State {
+    Disconnected,
+    Advertising,
+    Connected,
+}
+
+/// BleAdapter
+pub struct BleAdapter<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError> {
+    spi: SPI,
+    bluetooth: BlueNRG<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    ble_context: ble_uart::BleContext,
+    ble_addr: BleAddr,
+    state: State,
+}
+
+/// BleAdapter implementation for bluenrg_ms devices
+impl<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>
+    BleAdapter<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8>,
+    OutputPin1: OutputPin<Error = GpioError>,
+    OutputPin2: OutputPin<Error = GpioError>,
+    InputPin1: InputPin<Error = GpioError>,
+    SPI::Error: fmt::Debug,
+    OutputPin1::Error: fmt::Debug,
+    OutputPin2::Error: fmt::Debug,
+    InputPin1::Error: fmt::Debug,
+{
+    pub fn with_interface(
+        spi: SPI,
+        bluetooth: BlueNRG<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>,
+    ) -> Self {
+        let ble_context = ble_uart::BleContext::default();
+        Self {
+            spi,
+            bluetooth,
+            ble_context,
+            ble_addr: BleAddr::default(),
+            state: State::Disconnected,
+        }
+    }
+
+    pub fn reset<T, Time>(&mut self, timer: &mut T, time: Time) -> ockam::Result<()>
+    where
+        T: embedded_hal::timer::CountDown<Time = Time>,
+        Time: Copy,
+    {
+        // hardware reset
+        debug!("\n\treset bluenrg-ms device");
+        self.bluetooth
+            .reset(timer, time)
+            .map_err(|_| BleError::HardwareError)?;
+        self._handle_reset_response()
+    }
+
+    #[cfg(target_arch = "mips")]
+    pub fn reset_with_delay<D, UXX>(&mut self, delay: &mut D, time: UXX) -> ockam::Result<()>
+    where
+        D: blocking::delay::DelayMs<UXX>,
+        UXX: Copy,
+    {
+        // hardware reset
+        debug!("\n\treset bluenrg-ms device");
+        self.bluetooth
+            .reset_with_delay(delay, time)
+            .map_err(|_| BleError::HardwareError)?;
+        self._handle_reset_response()
+    }
+
+    pub fn _handle_reset_response(&mut self) -> ockam::Result<()> {
+        match self
+            .bluetooth
+            .with_spi(&mut self.spi, |controller| block!(controller.read()))
+        {
+            Ok(packet) => {
+                let bluetooth_hci::host::uart::Packet::Event(event) = packet;
+                match event {
+                    Event::Vendor(BlueNRGEvent::HalInitialized(reason)) => (),
+                    _ => {
+                        error!("\t=> reset error: unknown event {:?}", event);
+                        return Err(BleError::HardwareError.into());
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Device reset error: {:?}", e);
+                return Err(BleError::HardwareError.into());
+            }
+        }
+
+        // test device communication
+        ble_uart::read_local_version_information(&mut self.spi, &mut self.bluetooth)
+            .map_err(|_| BleError::HardwareError)?;
+
+        Ok(())
+    }
+}
+
+/// Implement trait: BleServerDriver
+#[async_trait]
+impl<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError> BleServerDriver
+    for BleAdapter<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8> + Send,
+    OutputPin1: OutputPin<Error = GpioError> + Send,
+    OutputPin2: OutputPin<Error = GpioError> + Send,
+    InputPin1: InputPin<Error = GpioError> + Send,
+    SPI::Error: fmt::Debug,
+    OutputPin1::Error: fmt::Debug,
+    OutputPin2::Error: fmt::Debug,
+    InputPin1::Error: fmt::Debug,
+    GpioError: Send,
+{
+    async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+        self.ble_addr = ble_addr.clone();
+
+        ble_uart::setup(&mut self.spi, &mut self.bluetooth)
+            .map_err(|_| BleError::ConfigurationFailed)?;
+
+        crate::wait_ms!(500);
+
+        self.ble_context =
+            ble_uart::initialize_gatt_and_gap(&mut self.spi, &mut self.bluetooth, ble_addr)
+                .map_err(|_| BleError::ConfigurationFailed)?;
+
+        crate::wait_ms!(500);
+
+        ble_uart::initialize_uart(&mut self.spi, &mut self.bluetooth, &mut self.ble_context)
+            .map_err(|_| BleError::ConfigurationFailed)?;
+
+        crate::wait_ms!(500);
+
+        Ok(())
+    }
+
+    async fn start_advertising(&mut self) -> ockam::Result<()> {
+        if let Err(e) = ble_uart::start_advertising(
+            &mut self.spi,
+            &mut self.bluetooth,
+            &mut self.ble_context,
+            &self.ble_addr,
+        ) {
+            debug!("BleAdapter::start_advertising error: {:?}", e);
+            return Err(BleError::AdvertisingFailure.into());
+        }
+        Ok(())
+    }
+}
+
+/// Implement trait: BleStreamDriver
+#[async_trait]
+impl<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError> BleStreamDriver
+    for BleAdapter<'a, SPI, OutputPin1, OutputPin2, InputPin1, GpioError>
+where
+    SPI: blocking::spi::transfer::Default<u8> + blocking::spi::write::Default<u8> + Send,
+    OutputPin1: OutputPin<Error = GpioError> + Send,
+    OutputPin2: OutputPin<Error = GpioError> + Send,
+    InputPin1: InputPin<Error = GpioError> + Send,
+    SPI::Error: fmt::Debug,
+    OutputPin1::Error: fmt::Debug,
+    OutputPin2::Error: fmt::Debug,
+    InputPin1::Error: fmt::Debug,
+    GpioError: Send,
+{
+    async fn poll<'b>(&mut self, out_fragment: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+        // avoid deadlocking the caller
+        ockam_node::tokio::task::yield_now().await;
+
+        match self.state {
+            State::Disconnected => {
+                debug!("BleStreamDriver::poll start advertising");
+                self.start_advertising().await?;
+                self.state = State::Advertising;
+                debug!("\nstate = {:?}", self.state);
+                #[cfg(feature = "debug_alloc")]
+                ockam_executor::debug_alloc::stats();
+            }
+            State::Advertising => {}
+            State::Connected => {}
+        }
+
+        let result = self
+            .bluetooth
+            .with_spi(&mut self.spi, |controller| controller.read());
+        match result {
+            Ok(Packet::Event(event)) => match event {
+                Event::LeConnectionComplete(event) => {
+                    debug!("\t=> LeConnectionComplete: -> {:?}", event);
+                    self.ble_context.conn_handle = Some(event.conn_handle);
+                    self.state = State::Connected;
+                    debug!("\nstate = {:?}", self.state);
+                    return Ok(BleEvent::ConnectionComplete);
+                }
+
+                Event::DisconnectionComplete(event) => {
+                    debug!("\t=> DisconnectionComplete: -> {:?}", event);
+                    self.ble_context.conn_handle = None;
+                    self.state = State::Disconnected;
+                    debug!("\nstate = {:?}", self.state);
+                    return Ok(BleEvent::DisconnectionComplete);
+                }
+
+                Event::Vendor(BlueNRGEvent::GattAttributeModified(event)) => {
+                    if event.attr_handle
+                        == self
+                            .ble_context
+                            .uart_rx_attribute_handle
+                            .expect("rx attribute handle is not set")
+                    {
+                        debug!(
+                            "\t=> BlueNRGEvent::GattAttributeModified event: {:?}",
+                            event.data().len()
+                        );
+
+                        let fragment = event.data();
+                        let fragment_len = event.data().len();
+                        if fragment_len > out_fragment.len() {
+                            panic!("fragment too long");
+                        }
+
+                        let out_fragment = &mut out_fragment[..fragment_len];
+                        out_fragment.copy_from_slice(&fragment[..fragment_len]);
+
+                        return Ok(BleEvent::Received(out_fragment));
+                    } else {
+                        debug!("\t=> Rx unknown attribute: -> {:?}", event);
+                        return Ok(BleEvent::None);
+                    }
+                }
+
+                _ => {
+                    warn!("\t=> unknown event: {:?}", event);
+                    return Ok(BleEvent::None);
+                }
+            },
+
+            Err(nb::Error::WouldBlock) => {
+                return Ok(BleEvent::None);
+            }
+
+            Err(e) => {
+                error!("controller read error: {:?}", e);
+                return Err(BleError::ReadError.into());
+            }
+        }
+    }
+
+    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+        debug!("BleAdapter<bluetooth_hci>::write");
+
+        let Self {
+            bluetooth,
+            spi,
+            ble_context,
+            ..
+        } = self;
+
+        let result = block!(bluetooth.with_spi(spi, |controller| {
+            controller.update_characteristic_value(
+                &bluenrg::gatt::UpdateCharacteristicValueParameters {
+                    service_handle: ble_context
+                        .uart_service_handle
+                        .expect("uart service handle has not been set"),
+                    characteristic_handle: ble_context
+                        .uart_tx_handle
+                        .expect("uart tx handle has not been set"),
+                    offset: 0x00,
+                    value: &buffer,
+                },
+            )
+        }));
+
+        match result {
+            Ok(()) => (),
+            Err(e) => {
+                error!("\t=> error writing data: {:?}", buffer);
+                return Err(BleError::WriteError.into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Map bluenrg::Error to BleError
+impl<SpiError, GpioError> From<bluenrg::Error<SpiError, GpioError>> for BleError {
+    fn from(e: bluenrg::Error<SpiError, GpioError>) -> Self {
+        match e {
+            bluenrg::Error::Spi(_e) => Self::HardwareError,
+            bluenrg::Error::Gpio(_e) => Self::HardwareError,
+        }
+    }
+}
+
+/// Map nb::Error to BleError
+impl<GpioError> From<nb::Error<GpioError>> for BleError {
+    fn from(e: nb::Error<GpioError>) -> Self {
+        match e {
+            nb::Error::Other(_e) => Self::HardwareError,
+            nb::Error::WouldBlock => {
+                error!("ble.rs wouldblock");
+                Self::HardwareError
+            }
+        }
+    }
+}
+
+#[cfg(feature = "atsame54")]
+/// get a unique hardware address for device
+pub fn get_bd_addr() -> bluetooth_hci::BdAddr {
+    let sn: [u8; 16] = atsame54_xpro::serial_number();
+    let bytes: [u8; 6] = [
+        sn[0] ^ sn[3] ^ sn[6] ^ sn[9] ^ sn[12] ^ sn[15],
+        sn[1] ^ sn[4] ^ sn[7] ^ sn[10] ^ sn[13],
+        sn[2] ^ sn[5] ^ sn[8] ^ sn[11] ^ sn[14],
+        // https://www.adminsub.net/mac-address-finder/microchip
+        0x39,
+        0x80,
+        0xD8,
+    ];
+    bluetooth_hci::BdAddr(bytes)
+}
+
+#[cfg(any(feature = "stm32f4", feature = "stm32h7"))]
+/// get a unique hardware address for device
+pub fn get_bd_addr() -> bluetooth_hci::BdAddr {
+    let sn: &[u8; 12] = stm32_device_signature::device_id();
+    let bytes: [u8; 6] = [
+        sn[0] ^ sn[3] ^ sn[6] ^ sn[9],
+        sn[1] ^ sn[4] ^ sn[7] ^ sn[10],
+        sn[2] ^ sn[5] ^ sn[8] ^ sn[11],
+        // https://www.adminsub.net/mac-address-finder/stmicroelectronics
+        0xE1,
+        0x80,
+        0x00,
+    ];
+    bluetooth_hci::BdAddr(bytes)
+}
+
+#[cfg(feature = "pic32")]
+/// get a unique hardware address for device
+pub fn get_bd_addr() -> bluetooth_hci::BdAddr {
+    let sn: &[u8; 12] = &[
+        // TODO get serial number from processor
+        01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12,
+    ];
+    let bytes: [u8; 6] = [
+        sn[0] ^ sn[3] ^ sn[6] ^ sn[9],
+        sn[1] ^ sn[4] ^ sn[7] ^ sn[10],
+        sn[2] ^ sn[5] ^ sn[8] ^ sn[11],
+        0x39,
+        0x80,
+        0xD8,
+    ];
+    bluetooth_hci::BdAddr(bytes)
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/btleplug/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/btleplug/mod.rs
@@ -14,15 +14,15 @@ use uuid::Uuid;
 
 use ockam_core::async_trait;
 
-use crate::driver::BleEvent;
+use crate::driver::{self, BleEvent};
 use crate::driver::{BleClientDriver, BleStreamDriver};
 use crate::error::BleError;
 use crate::BleAddr;
 
 /// UUID's
-pub const UUID: Uuid = Uuid::from_u128_le(0x669a0c20_0008_969e_e211_9eb1e0f273d9);
-pub const RX_UUID: Uuid = Uuid::from_u128_le(0x669a0c20_0008_969e_e211_9eb1e1f273d9);
-pub const TX_UUID: Uuid = Uuid::from_u128_le(0x669a0c20_0008_969e_e211_9eb1e2f273d9);
+pub const UUID: Uuid = Uuid::from_u128(driver::uuid::SERVICE);
+const RX_UUID: Uuid = Uuid::from_u128(driver::uuid::WRITE);
+const TX_UUID: Uuid = Uuid::from_u128(driver::uuid::READ);
 
 /// Convert btleplug::Error to BleError
 impl From<btleplug::Error> for BleError {
@@ -155,7 +155,7 @@ impl BleClientDriver for BleAdapter {
         }
 
         if self.rx.is_none() || self.tx.is_none() {
-            debug!("No compatible devices found");
+            error!("No compatible devices found");
             return Err(BleError::NotSupported.into());
         }
 

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/btleplug/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/btleplug/mod.rs
@@ -1,0 +1,299 @@
+//! Driver for OS targets
+//!
+//! Uses the [btleplug](https://crates.io/crates/btleplug/) crate to
+//! provide a cross-platform interface to BLE API's on Linux, macOS
+//! and Windows.
+
+use core::pin::Pin;
+
+use btleplug::api::{Central, Manager as _, Peripheral};
+use btleplug::api::{CharPropFlags, Characteristic, ValueNotification};
+use btleplug::platform::{Adapter, Manager};
+use futures::stream::{Stream, StreamExt};
+use uuid::Uuid;
+
+use ockam_core::async_trait;
+
+use crate::driver::BleEvent;
+use crate::driver::{BleClientDriver, BleStreamDriver};
+use crate::error::BleError;
+use crate::BleAddr;
+
+/// UUID's
+pub const UUID: Uuid = Uuid::from_u128_le(0x669a0c20_0008_969e_e211_9eb1e0f273d9);
+pub const RX_UUID: Uuid = Uuid::from_u128_le(0x669a0c20_0008_969e_e211_9eb1e1f273d9);
+pub const TX_UUID: Uuid = Uuid::from_u128_le(0x669a0c20_0008_969e_e211_9eb1e2f273d9);
+
+/// Convert btleplug::Error to BleError
+impl From<btleplug::Error> for BleError {
+    fn from(e: btleplug::Error) -> BleError {
+        trace!("From<btleplug::Error> -> {:?}", e);
+        match e {
+            btleplug::Error::PermissionDenied => BleError::PermissionDenied,
+            btleplug::Error::DeviceNotFound => BleError::NotFound,
+            btleplug::Error::NotConnected => BleError::NotConnected,
+            btleplug::Error::NotSupported(_) => BleError::NotSupported,
+            btleplug::Error::TimedOut(_) => BleError::TimedOut,
+            btleplug::Error::Uuid(_) => BleError::ConfigurationFailed,
+            btleplug::Error::InvalidBDAddr(_) => BleError::ConfigurationFailed,
+            btleplug::Error::Other(e) => BleError::Other,
+        }
+    }
+}
+
+/// BleAdaptor
+pub struct BleAdapter {
+    manager: Manager,
+    peripheral: Option<btleplug::platform::Peripheral>,
+    rx: Option<Characteristic>,
+    tx: Option<Characteristic>,
+
+    notification_stream: Option<Pin<Box<dyn Stream<Item = ValueNotification> + Send>>>,
+}
+
+impl BleAdapter {
+    pub async fn try_new() -> ockam::Result<BleAdapter> {
+        let manager = Manager::new().await.map_err(BleError::from)?;
+        Ok(Self {
+            manager,
+            peripheral: None,
+            rx: None,
+            tx: None,
+            notification_stream: None,
+        })
+    }
+}
+
+#[async_trait]
+impl BleClientDriver for BleAdapter {
+    async fn scan(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+        let adapters = self.manager.adapters().await.map_err(BleError::from)?;
+        if adapters.is_empty() {
+            error!("No Bluetooth adapters found");
+            return Err(BleError::HardwareError.into());
+        }
+        debug!("BleAdapter::scan scanning adapters: {:?}", adapters.len());
+
+        let mut retry_count = 0;
+        let local_name_filter = ble_addr.to_string();
+        self.peripheral = loop {
+            match scan_for_peripheral_name(&adapters, &local_name_filter).await {
+                Ok(peripheral) => break Some(peripheral),
+                Err(e) => {
+                    warn!("Could not find peripheral, resuming scan: {:?}", e);
+                }
+            }
+            retry_count += 1;
+            if retry_count > 20 {
+                warn!(
+                    "Could not find peripheral, aborting scan after {} retries",
+                    retry_count
+                );
+                return Err(BleError::NotFound.into());
+            }
+        };
+
+        Ok(())
+    }
+
+    async fn connect(&mut self) -> ockam::Result<()> {
+        if self.peripheral.is_none() {
+            return Err(BleError::NotFound.into());
+        }
+
+        let peripheral = self.peripheral.as_mut().unwrap();
+        let properties = peripheral.properties().await.map_err(BleError::from)?;
+        let is_connected = peripheral.is_connected().await.map_err(BleError::from)?;
+        let local_name = properties
+            .unwrap()
+            .local_name
+            .unwrap_or_else(|| String::from("(peripheral name unknown)"));
+        debug!("Found matching peripheral {:?}...", local_name);
+
+        if !is_connected {
+            if let Err(err) = peripheral.connect().await {
+                warn!(
+                    "Error connecting to peripheral, continuing: {}",
+                    err.to_string()
+                );
+            } else {
+                debug!("Connected to peripheral");
+            }
+        } else {
+            debug!("Already connected");
+        }
+        let is_connected = peripheral.is_connected().await.map_err(BleError::from)?;
+        debug!(
+            "Peripheral: {:?} connection status: {:?}",
+            local_name, is_connected
+        );
+
+        // discover characteristics
+        peripheral
+            .discover_services()
+            .await
+            .map_err(BleError::from)?;
+        debug!("Discover peripheral {:?} services...", &local_name);
+        for service in peripheral.services() {
+            trace!(
+                "Service UUID {}, primary: {}",
+                service.uuid,
+                service.primary
+            );
+            for characteristic in service.characteristics {
+                trace!("  {:?}", characteristic);
+                if characteristic.uuid == RX_UUID
+                    && characteristic.properties.contains(CharPropFlags::NOTIFY)
+                {
+                    self.rx = Some(characteristic);
+                } else if characteristic.uuid == TX_UUID
+                    && characteristic.properties.contains(CharPropFlags::WRITE)
+                {
+                    self.tx = Some(characteristic);
+                }
+            }
+        }
+
+        if self.rx.is_none() || self.tx.is_none() {
+            debug!("No compatible devices found");
+            return Err(BleError::NotSupported.into());
+        }
+
+        // subscribe to notifications
+        peripheral
+            .subscribe(self.rx.as_ref().unwrap())
+            .await
+            .map_err(BleError::from)?;
+        let notification_stream = peripheral.notifications().await.map_err(BleError::from)?;
+        self.notification_stream = Some(notification_stream);
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BleStreamDriver for BleAdapter {
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+        // avoid deadlocking the caller
+        ockam_node::tokio::task::yield_now().await;
+
+        if self.peripheral.is_none() {
+            return Err(BleError::NotConnected.into());
+        }
+
+        let mut rx_stream = self.notification_stream.as_mut().unwrap();
+        let waker = futures::task::noop_waker();
+        let mut context = core::task::Context::from_waker(&waker);
+
+        if let core::task::Poll::Ready(Some(item)) = rx_stream.poll_next_unpin(&mut context) {
+            match item.uuid {
+                RX_UUID => {
+                    trace!("\t=> Rx: -> {:?}", item);
+                    let data = item.value;
+                    let len = core::cmp::min(data.len(), buffer.len() - 1);
+                    buffer[..len].copy_from_slice(&data[..len]);
+                    return Ok(BleEvent::Received(&buffer[..len]));
+                }
+                _ => {
+                    warn!("[btleplug]\t=> Rx unknown characteristic: -> {:?}", item);
+                    //return Err(BleError::NotSupported.into());
+                    return Ok(BleEvent::None);
+                }
+            }
+        }
+
+        Ok(BleEvent::None)
+    }
+
+    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+        trace!("write {} bytes", buffer.len());
+
+        if self.peripheral.is_none() {
+            error!("No peripheral found");
+            return Err(BleError::NotConnected.into());
+        } else if self.rx.is_none() || self.tx.is_none() {
+            error!("No compatible devices found");
+            return Err(BleError::NotSupported.into());
+        }
+
+        let peripheral = self.peripheral.as_ref().unwrap();
+        let tx = self.tx.as_ref().unwrap();
+
+        let result = peripheral
+            .write(tx, buffer, btleplug::api::WriteType::WithoutResponse)
+            .await;
+
+        match result {
+            Err(e) => {
+                error!("Error writing data: {:?}", e);
+            }
+            Ok(()) => {
+                trace!("Success writing data: {:?}", buffer);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn scan_for_peripheral_name(
+    adapters: &[Adapter],
+    local_name_filter: &str,
+) -> ockam::Result<btleplug::platform::Peripheral> {
+    for (count, adapter) in adapters.iter().enumerate() {
+        let peripherals = adapter.peripherals().await.map_err(BleError::from)?;
+        debug!(
+            "Scanning adapter {}: {} peripherals",
+            count,
+            peripherals.len()
+        );
+        let mut scan_filter = btleplug::api::ScanFilter::default();
+        match adapter.start_scan(scan_filter).await {
+            Ok(_) => (),
+            Err(e) => {
+                warn!(
+                    "Can't scan BLE adapter for connected devices: {:?}",
+                    adapter
+                );
+                continue;
+            }
+        }
+
+        crate::wait_ms!(5_000);
+
+        adapter.stop_scan().await.map_err(BleError::from)?;
+
+        let peripherals = match adapter.peripherals().await {
+            Ok(peripherals) => peripherals,
+            Err(e) => {
+                warn!("No BLE peripherals found on adapter: {:?}", adapter);
+                continue;
+            }
+        };
+        if peripherals.is_empty() {
+            warn!("No BLE peripherals found on adapter: {:?}", adapter);
+            continue;
+        }
+
+        for peripheral in peripherals {
+            let properties = peripheral.properties().await.map_err(BleError::from)?;
+            let local_name = properties
+                .unwrap()
+                .local_name
+                .unwrap_or_else(|| String::from("(peripheral name unknown)"));
+
+            // check if it's the peripheral we want.
+            if local_name.contains(local_name_filter) {
+                let is_connected = peripheral.is_connected().await.map_err(BleError::from)?;
+
+                debug!(
+                    "Found peripheral: {:?}\tconnected: {:?}\n",
+                    &local_name, is_connected
+                );
+                return Ok(peripheral);
+            }
+        }
+    }
+
+    Err(BleError::NotFound.into())
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
@@ -36,8 +36,33 @@ pub const MTU: usize = 23;
 /// MTU - 5 (packet fields) = 18 bytes of payload
 pub const CHARACTERISTIC_VALUE_LENGTH: usize = MTU - 5;
 
-/// maximum length of ockam messages
+/// Maximum length of ockam messages
 pub const MAX_OCKAM_MESSAGE_LENGTH: usize = 1024;
+
+/// Ockam BLE service and endpoints are encoded as UUID v5 identifiers
+/// within the ns:OID namespace:
+///
+///     iso.identified-organization.ockam.transport.ble (1.3.214.9.4)
+///
+/// Ockam OID information can be obtained at:
+///
+///     http://oid-info.com/get/1.3.214.9.4
+pub mod uuid {
+    /// BLE Service UUID (rfc1700 / big-endian)
+    /// Namespace: ns:OID
+    /// Name: iso.identified-organization.ockam.transport.ble.service (1.3.214.9.4.1)
+    pub const SERVICE: u128 = 0x424c001f_48f6_5fff_bc3e_84e00c335dbb;
+
+    /// BLE Read UUID (rfc1700 / big-endian)
+    /// Namespace: ns:OID
+    /// Name: iso.identified-organization.ockam.transport.ble.read (1.3.214.9.4.2)
+    pub const READ: u128 = 0xbc911b36_320c_5d3f_90ed_842a6e57cefb;
+
+    /// Default BLE Write UUID (rfc1700 / big-endian)
+    /// Namespace: ns:OID
+    /// Name: iso.identified-organization.ockam.transport.ble.write (1.3.214.9.4.3)
+    pub const WRITE: u128 = 0x18c90ff2_8d94_5f20_8084_c16ae3f6a9a2;
+}
 
 /// BleEvent
 #[derive(Debug)]

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
@@ -1,0 +1,166 @@
+//! Bluetooth platform drivers
+
+#![allow(unused_imports, unused_mut, unused_variables)]
+
+/// support for ST Micro BlueNRG Bluetooth radios
+#[cfg(feature = "use_bluetooth_hci")]
+pub mod bluetooth_hci;
+
+/// support for OS bluetooth
+#[cfg(all(
+    feature = "use_btleplug",
+    any(target_os = "linux", target_os = "macos", target_os = "windows")
+))]
+pub mod btleplug;
+
+#[cfg(not(feature = "std"))]
+mod mutex;
+mod packet;
+mod stream;
+
+pub(crate) use packet::PacketBuffer;
+pub(crate) use stream::{AsyncStream, Sink, Source};
+
+use crate::BleAddr;
+use ockam_core::{async_trait, compat::boxed::Box};
+
+/// The minimum MTU required by the BLE spec. Many devices
+/// (e.g. bluenrg_ms) don't allow for configuration higher than this.
+pub const MTU: usize = 23;
+
+/// Maximum length of characteristic values (250 is the longest
+/// allowed by the BLE specification)
+///
+/// Hard-limited for now according to MTU:
+///
+/// MTU - 5 (packet fields) = 18 bytes of payload
+pub const CHARACTERISTIC_VALUE_LENGTH: usize = MTU - 5;
+
+/// maximum length of ockam messages
+pub const MAX_OCKAM_MESSAGE_LENGTH: usize = 1024;
+
+/// BleEvent
+#[derive(Debug)]
+pub enum BleEvent<'a> {
+    None,
+    Unknown,
+    ConnectionComplete,
+    Received(&'a [u8]),
+    DisconnectionComplete,
+}
+
+/// Implement the BleClientDriver trait if you want to allow your
+/// hardware to function as a BLE Client
+#[async_trait]
+pub trait BleClientDriver {
+    async fn scan(&mut self, ble_addr: &BleAddr) -> ockam::Result<()>;
+    async fn connect(&mut self) -> ockam::Result<()>;
+}
+
+/// Implement the BleServerDriver trait if you want to allow your
+/// hardware to function as a BLE Client
+#[async_trait]
+pub trait BleServerDriver {
+    async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()>;
+    async fn start_advertising(&mut self) -> ockam::Result<()>;
+}
+
+/// Implement the BleStreamDriver to transmit and receive data from
+/// your hardware
+#[async_trait]
+pub trait BleStreamDriver {
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>>;
+    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()>;
+}
+
+/// A BLE client that initiates GATT commands and requests, and
+/// accepts responses from a BLE server.
+pub struct BleClient<A>
+where
+    A: BleClientDriver + BleStreamDriver + Send,
+{
+    inner: A,
+}
+
+impl<A> BleClient<A>
+where
+    A: BleClientDriver + BleStreamDriver + Send,
+{
+    pub fn with_adapter(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<A> BleClientDriver for BleClient<A>
+where
+    A: BleClientDriver + BleStreamDriver + Send,
+{
+    async fn scan(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+        self.inner.scan(ble_addr).await
+    }
+
+    async fn connect(&mut self) -> ockam::Result<()> {
+        self.inner.connect().await
+    }
+}
+
+#[async_trait]
+impl<A> BleStreamDriver for BleClient<A>
+where
+    A: BleClientDriver + BleStreamDriver + Send,
+{
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+        self.inner.poll(buffer).await
+    }
+
+    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+        self.inner.write(buffer).await
+    }
+}
+
+/// A BLE server that receives GATT commands and requests, and returns
+/// responses to a BLE client.
+pub struct BleServer<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send,
+{
+    inner: A,
+}
+
+impl<A> BleServer<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send,
+{
+    pub fn with_adapter(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<A> BleServerDriver for BleServer<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send,
+{
+    async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+        self.inner.bind(ble_addr).await
+    }
+
+    async fn start_advertising(&mut self) -> ockam::Result<()> {
+        self.inner.start_advertising().await
+    }
+}
+
+#[async_trait]
+impl<A> BleStreamDriver for BleServer<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send,
+{
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+        self.inner.poll(buffer).await
+    }
+
+    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+        self.inner.write(buffer).await
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
@@ -42,11 +42,9 @@ pub const MAX_OCKAM_MESSAGE_LENGTH: usize = 1024;
 /// Ockam BLE service and endpoints are encoded as UUID v5 identifiers
 /// within the ns:OID namespace:
 ///
-///     iso.identified-organization.ockam.transport.ble (1.3.214.9.4)
+/// iso.identified-organization.ockam.transport.ble (1.3.214.9.4)
 ///
-/// Ockam OID information can be obtained at:
-///
-///     http://oid-info.com/get/1.3.214.9.4
+/// Ockam OID information can be obtained at: http://oid-info.com/get/1.3.214.9.4
 pub mod uuid {
     /// BLE Service UUID (rfc1700 / big-endian)
     /// Namespace: ns:OID
@@ -100,10 +98,7 @@ pub trait BleStreamDriver {
 
 /// A BLE client that initiates GATT commands and requests, and
 /// accepts responses from a BLE server.
-pub struct BleClient<A>
-where
-    A: BleClientDriver + BleStreamDriver + Send,
-{
+pub struct BleClient<A> {
     inner: A,
 }
 
@@ -146,10 +141,7 @@ where
 
 /// A BLE server that receives GATT commands and requests, and returns
 /// responses to a BLE client.
-pub struct BleServer<A>
-where
-    A: BleServerDriver + BleStreamDriver + Send,
-{
+pub struct BleServer<A> {
     inner: A,
 }
 

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/mutex.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/mutex.rs
@@ -1,0 +1,272 @@
+//! A naive, single-threaded Async Mutex implementation
+//!
+//! It is used by the embedded implementation and is only safe on
+//! single-core systems.
+//!
+//! It should only ever be used in processor "thread" mode. (i.e. not in irq
+//! contexts, exception handlers etc.)
+//!
+//! NOTE based on async-std v1.5.0
+
+use core::{
+    cell::{Cell, UnsafeCell},
+    future::Future,
+    ops,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+use heapless::LinearMap;
+use ockam_core::compat::sync::Mutex as CriticalSection;
+
+/// WakerSet
+pub struct WakerSet {
+    inner: CriticalSection<Inner>,
+}
+
+impl WakerSet {
+    pub fn new() -> Self {
+        Self {
+            inner: CriticalSection::new(Inner::new()),
+        }
+    }
+
+    pub fn cancel(&self, key: usize) -> bool {
+        let mut guard = self.inner.lock().unwrap();
+        guard.cancel(key)
+    }
+
+    pub fn notify_any(&self) -> bool {
+        let mut guard = self.inner.lock().unwrap();
+        guard.notify_any()
+    }
+
+    #[allow(dead_code)]
+    pub fn notify_one(&self) -> bool {
+        let mut guard = self.inner.lock().unwrap();
+        guard.notify_one()
+    }
+
+    pub fn insert(&self, cx: &Context<'_>) -> usize {
+        let mut guard = self.inner.lock().unwrap();
+        guard.insert(cx)
+    }
+
+    pub fn remove(&self, key: usize) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.remove(key)
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum Notify {
+    /// Make sure at least one entry is notified.
+    Any,
+    /// Notify one additional entry.
+    One,
+}
+
+struct Inner {
+    counter: usize,
+    // NOTE the number of entries are capped at 8
+    entries: LinearMap<usize, Option<Waker>, 8>,
+    notifiable: usize,
+}
+
+impl Inner {
+    const fn new() -> Self {
+        Self {
+            counter: 0,
+            entries: LinearMap::new(),
+            notifiable: 0,
+        }
+    }
+
+    /// Removes the waker of a cancelled operation.
+    ///
+    /// Returns `true` if another blocked operation from the set was notified.
+    fn cancel(&mut self, key: usize) -> bool {
+        match self.entries.remove(&key) {
+            Some(_) => self.notifiable -= 1,
+            None => {
+                // The operation was cancelled and notified so notify another operation instead.
+                for (_, opt_waker) in self.entries.iter_mut() {
+                    // If there is no waker in this entry, that means it was already woken.
+                    if let Some(w) = opt_waker.take() {
+                        w.wake();
+                        self.notifiable -= 1;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Notifies a blocked operation if none have been notified already.
+    ///
+    /// Returns `true` if an operation was notified.
+    fn notify_any(&mut self) -> bool {
+        self.notify(Notify::Any)
+    }
+
+    /// Notifies one additional blocked operation.
+    ///
+    /// Returns `true` if an operation was notified.
+    fn notify_one(&mut self) -> bool {
+        self.notify(Notify::One)
+    }
+
+    /// Notifies blocked operations, either one or all of them.
+    ///
+    /// Returns `true` if at least one operation was notified.
+    fn notify(&mut self, n: Notify) -> bool {
+        let mut notified = false;
+
+        for (_, opt_waker) in self.entries.iter_mut() {
+            // If there is no waker in this entry, that means it was already woken.
+            if let Some(w) = opt_waker.take() {
+                w.wake();
+                self.notifiable -= 1;
+                notified = true;
+
+                if n == Notify::One {
+                    break;
+                }
+            }
+
+            if n == Notify::Any {
+                break;
+            }
+        }
+
+        notified
+    }
+
+    fn insert(&mut self, cx: &Context<'_>) -> usize {
+        let w = cx.waker().clone();
+        let key = self.counter;
+        self.entries.insert(key, Some(w)).expect("OOM");
+        self.counter += 1;
+        self.notifiable += 1;
+        key
+    }
+
+    /// Removes the waker of an operation.
+    fn remove(&mut self, key: usize) {
+        if self.entries.remove(&key).is_some() {
+            self.notifiable -= 1;
+        }
+    }
+}
+
+/// A mutual exclusion primitive for protecting shared data
+///
+/// NOTE waker logic is based on async-std v1.5.0
+pub struct Mutex<T> {
+    locked: Cell<bool>,
+    value: UnsafeCell<T>,
+    wakers: WakerSet,
+}
+
+// NOTE(unsafe) single-threaded context only
+#[allow(unsafe_code)]
+unsafe impl<T> Send for Mutex<T> {}
+// NOTE(unsafe) single-threaded context only
+#[allow(unsafe_code)]
+unsafe impl<T> Sync for Mutex<T> {}
+
+impl<T> Mutex<T> {
+    /// Creates a new mutex
+    pub fn new(t: T) -> Self {
+        Self {
+            locked: Cell::new(false),
+            value: UnsafeCell::new(t),
+            wakers: WakerSet::new(),
+        }
+    }
+
+    /// Acquires the lock
+    ///
+    /// Returns a guard that release the lock when dropped
+    pub async fn lock(&self) -> MutexGuard<'_, T> {
+        struct Lock<'a, T> {
+            mutex: &'a Mutex<T>,
+            opt_key: Option<usize>,
+        }
+
+        impl<'a, T> Future for Lock<'a, T> {
+            type Output = MutexGuard<'a, T>;
+
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                // If the current task is in the set, remove it.
+                if let Some(key) = self.opt_key.take() {
+                    self.mutex.wakers.remove(key);
+                }
+
+                // Try acquiring the lock.
+                match self.mutex.try_lock() {
+                    Some(guard) => Poll::Ready(guard),
+                    None => {
+                        // Insert this lock operation.
+                        self.opt_key = Some(self.mutex.wakers.insert(cx));
+
+                        Poll::Pending
+                    }
+                }
+            }
+        }
+
+        impl<T> Drop for Lock<'_, T> {
+            fn drop(&mut self) {
+                // If the current task is still in the set, that means it is being cancelled now.
+                if let Some(key) = self.opt_key {
+                    self.mutex.wakers.cancel(key);
+                }
+            }
+        }
+
+        Lock {
+            mutex: self,
+            opt_key: None,
+        }
+        .await
+    }
+
+    /// Attempts to acquire the lock
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        if !self.locked.get() {
+            self.locked.set(true);
+            Some(MutexGuard(self))
+        } else {
+            None
+        }
+    }
+}
+
+/// A guard that releases the lock when dropped
+pub struct MutexGuard<'a, T>(&'a Mutex<T>);
+
+impl<T> Drop for MutexGuard<'_, T> {
+    fn drop(&mut self) {
+        self.0.locked.set(false);
+        self.0.wakers.notify_any();
+    }
+}
+
+impl<T> ops::Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    #[allow(unsafe_code)]
+    fn deref(&self) -> &T {
+        unsafe { &*self.0.value.get() }
+    }
+}
+
+impl<T> ops::DerefMut for MutexGuard<'_, T> {
+    #[allow(unsafe_code)]
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.0.value.get() }
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/packet.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/packet.rs
@@ -1,0 +1,175 @@
+use core::cmp::Ordering;
+
+use crate::driver::BleEvent;
+use crate::driver::CHARACTERISTIC_VALUE_LENGTH;
+use crate::driver::MAX_OCKAM_MESSAGE_LENGTH;
+use crate::error::BleError;
+
+/// PacketBuffer
+pub struct PacketBuffer {
+    fragment_len: usize,
+    buffer: [u8; MAX_OCKAM_MESSAGE_LENGTH],
+    packet_len: usize,
+    offset: usize,
+}
+
+impl Default for PacketBuffer {
+    fn default() -> Self {
+        Self {
+            fragment_len: CHARACTERISTIC_VALUE_LENGTH,
+            buffer: [0_u8; MAX_OCKAM_MESSAGE_LENGTH],
+            packet_len: 0,
+            offset: 0,
+        }
+    }
+}
+
+impl PacketBuffer {
+    pub fn packet_len(&self) -> usize {
+        self.packet_len
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// PacketBuffer send implementation
+impl PacketBuffer {
+    pub fn from_packet(packet: &[u8]) -> PacketBuffer {
+        if packet.len() > MAX_OCKAM_MESSAGE_LENGTH {
+            error!(
+                "Packet too long for PacketBuffer: {} > {} ",
+                packet.len(),
+                MAX_OCKAM_MESSAGE_LENGTH
+            );
+            panic!(
+                "Packet too long for PacketBuffer: {} > {} ",
+                packet.len(),
+                MAX_OCKAM_MESSAGE_LENGTH
+            );
+        }
+
+        let mut pb = PacketBuffer {
+            packet_len: packet.len(),
+            ..Default::default()
+        };
+
+        let destination = &mut pb.buffer[..pb.packet_len];
+        destination.copy_from_slice(&packet[..pb.packet_len]);
+
+        pb
+    }
+
+    pub fn send_packet_length(&mut self) -> [u8; 8] {
+        let bytes: [u8; 8] = (self.packet_len as u64).to_be_bytes();
+        bytes
+    }
+
+    pub fn send_next_fragment(&mut self) -> Option<&[u8]> {
+        let bytes_left: isize = self.packet_len as isize - self.offset as isize;
+        match bytes_left.cmp(&0) {
+            Ordering::Less => panic!("Packet buffer has no more packets left to give"),
+            Ordering::Greater => {
+                // copy packet data to fragment
+                let fragment_len = core::cmp::min(self.fragment_len, bytes_left as usize);
+                let end = self.offset + fragment_len;
+                let fragment = &self.buffer[self.offset..end];
+                self.offset += fragment_len;
+                Some(fragment)
+            }
+            Ordering::Equal => {
+                trace!("Received complete packet");
+                None
+            }
+        }
+    }
+}
+
+/// PacketBuffer receive implementation
+impl PacketBuffer {
+    pub fn receive_packet_length(&mut self, fragment: &[u8]) -> Option<usize> {
+        if fragment.len() != 8 {
+            return None;
+        }
+
+        let mut buffer = [0_u8; 8];
+        buffer.copy_from_slice(&fragment[..8]);
+        let packet_len = u64::from_be_bytes(buffer);
+        if packet_len > self.buffer.len() as u64 {
+            error!("Packet is too long for packet buffer: {}", packet_len);
+            return None;
+        }
+
+        // TODO Currently we only support packet lenghts up to 2^16
+        // bits long.
+        //
+        // The reason for this is that I'm too lazy right now to setup
+        // a control channel for this BLE UART implementation and
+        // instead rely on the probability of receiving an 8 byte long
+        // packet consisting of 6 zero bytes followed by two bytes
+        // that can be non-zero.
+        if packet_len > (2 << 16) {
+            error!(
+                "Packet is too long for this implementation.\n \
+                    See `ockam_transport_ble/src/packet.rs` for more \
+                    information: {}",
+                fragment.len()
+            );
+            return None;
+        }
+
+        trace!("Received packet length: {} bytes", packet_len);
+
+        self.reset();
+        self.packet_len = packet_len as usize;
+
+        Some(self.packet_len)
+    }
+
+    pub fn receive_next_fragment(&mut self, fragment: &[u8]) -> ockam::Result<Option<&[u8]>> {
+        if self.offset >= self.packet_len {
+            panic!("packet buffer already has enough fragments")
+        }
+
+        let fragment_len = fragment.len();
+        if self.offset + fragment_len > self.buffer.len() {
+            error!(
+                "Received packet fragment is too long for packet buffer: {}",
+                self.buffer.len()
+            );
+            return Err(BleError::ReadError.into());
+        }
+
+        // append fragment to packet buffer
+        self.buffer[self.offset..self.offset + fragment_len]
+            .copy_from_slice(&fragment[..fragment_len]);
+        self.offset += fragment_len;
+
+        trace!(
+            "PacketBuffer::receive_next_fragment received: {} of {}",
+            self.offset,
+            self.packet_len
+        );
+
+        // check if we have a complete packet
+        let bytes_left: isize = self.packet_len as isize - self.offset as isize;
+        if bytes_left <= 0 {
+            trace!(
+                "PacketBuffer::receive_next_fragment has a complete packet, bytes_left: {}",
+                bytes_left
+            );
+            let packet = &self.buffer[..self.packet_len];
+            return Ok(Some(packet));
+        }
+
+        Ok(None)
+    }
+}
+
+impl core::fmt::Debug for PacketBuffer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let packet = &self.buffer[..self.packet_len];
+        write!(f, "PacketBuffer[..{}] = {:?}", self.offset, packet)
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/packet.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/packet.rs
@@ -101,7 +101,7 @@ impl PacketBuffer {
             return None;
         }
 
-        // TODO Currently we only support packet lenghts up to 2^16
+        // TODO Currently we only support packet lengths up to 2^16
         // bits long.
         //
         // The reason for this is that I'm too lazy right now to setup
@@ -109,6 +109,8 @@ impl PacketBuffer {
         // instead rely on the probability of receiving an 8 byte long
         // packet consisting of 6 zero bytes followed by two bytes
         // that can be non-zero.
+        //
+        // https://github.com/ockam-network/ockam/issues/2514
         if packet_len > (2 << 16) {
             error!(
                 "Packet is too long for this implementation.\n \

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/stream.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/stream.rs
@@ -1,0 +1,103 @@
+use ockam_core::compat::sync::Arc;
+
+#[cfg(feature = "std")]
+use futures::lock::Mutex;
+
+#[cfg(not(feature = "std"))]
+use super::mutex::Mutex;
+
+use crate::driver::BleStreamDriver;
+
+pub(crate) struct AsyncStream<A>
+where
+    A: BleStreamDriver + Send,
+{
+    inner: Arc<Mutex<A>>,
+}
+
+impl<A> Clone for AsyncStream<A>
+where
+    A: BleStreamDriver + Send,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<A> AsyncStream<A>
+where
+    A: BleStreamDriver + Send,
+{
+    pub(crate) fn with_ble_device(ble_device: A) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ble_device)),
+        }
+    }
+
+    pub(crate) fn split(self) -> (Sink<A>, Source<A>) {
+        let sink = Sink {
+            inner: Arc::new(self.clone()),
+        };
+        let source = Source {
+            inner: Arc::new(self),
+        };
+        (sink, source)
+    }
+}
+
+impl<A> AsyncStream<A>
+where
+    A: BleStreamDriver + Send,
+{
+    async fn write(&self, buffer: &[u8]) -> ockam::Result<()> {
+        let mut guard = self.inner.lock().await;
+        (*guard).write(buffer).await
+    }
+
+    async fn poll<'a, 'b>(
+        &'a self,
+        buffer: &'b mut [u8],
+    ) -> ockam::Result<crate::driver::BleEvent<'b>> {
+        let mut guard = self.inner.lock().await;
+        (*guard).poll(buffer).await
+    }
+}
+
+/// A Sink for writing data buffers to the Ble adapter
+pub(crate) struct Sink<A>
+where
+    A: BleStreamDriver + Send,
+{
+    inner: Arc<AsyncStream<A>>,
+}
+
+impl<A> Sink<A>
+where
+    A: BleStreamDriver + Send,
+{
+    pub async fn write(&self, buffer: &[u8]) -> ockam::Result<()> {
+        self.inner.write(buffer).await
+    }
+}
+
+/// A Source for reading data buffers from the Ble adapter
+pub(crate) struct Source<A>
+where
+    A: BleStreamDriver + Send,
+{
+    inner: Arc<AsyncStream<A>>,
+}
+
+impl<A> Source<A>
+where
+    A: BleStreamDriver + Send,
+{
+    pub async fn poll<'a, 'b>(
+        &'a self,
+        buffer: &'b mut [u8],
+    ) -> ockam::Result<crate::driver::BleEvent<'b>> {
+        self.inner.poll(buffer).await
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/stream.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/stream.rs
@@ -8,10 +8,7 @@ use super::mutex::Mutex;
 
 use crate::driver::BleStreamDriver;
 
-pub(crate) struct AsyncStream<A>
-where
-    A: BleStreamDriver + Send,
-{
+pub(crate) struct AsyncStream<A> {
     inner: Arc<Mutex<A>>,
 }
 
@@ -66,10 +63,7 @@ where
 }
 
 /// A Sink for writing data buffers to the Ble adapter
-pub(crate) struct Sink<A>
-where
-    A: BleStreamDriver + Send,
-{
+pub(crate) struct Sink<A> {
     inner: Arc<AsyncStream<A>>,
 }
 
@@ -83,10 +77,7 @@ where
 }
 
 /// A Source for reading data buffers from the Ble adapter
-pub(crate) struct Source<A>
-where
-    A: BleStreamDriver + Send,
-{
+pub(crate) struct Source<A> {
     inner: Arc<AsyncStream<A>>,
 }
 

--- a/implementations/rust/ockam/ockam_transport_ble/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/error.rs
@@ -1,0 +1,90 @@
+use core::fmt::{Display, Formatter};
+
+/// A Bluetooth Low Energy connection worker specific error type
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum BleError {
+    PermissionDenied,
+    /// Functionality is not supported for this platform
+    NotSupported,
+    /// Failed to initialize or communicate with ble hardware
+    HardwareError,
+    NotFound,
+    TimedOut,
+    NotConnected,
+    /// Device configuration failed
+    ConfigurationFailed,
+    /// Device failed to advertise itself
+    AdvertisingFailure,
+    ConnectionClosed,
+    ReadError,
+    WriteError,
+    Other,
+    Unknown,
+}
+
+impl BleError {
+    /// Integer code associated with the error domain.
+    pub const DOMAIN_CODE: u32 = 22_000;
+    /// Error domain
+    pub const DOMAIN_NAME: &'static str = "OCKAM_TRANSPORT_BLE";
+
+    pub fn code(&self) -> u32 {
+        match self {
+            BleError::PermissionDenied => 0,
+            BleError::NotSupported => 1,
+            BleError::HardwareError => 2,
+            BleError::NotFound => 3,
+            BleError::TimedOut => 4,
+            BleError::NotConnected => 5,
+            BleError::ConfigurationFailed => 6,
+            BleError::AdvertisingFailure => 7,
+            BleError::ConnectionClosed => 8,
+            BleError::ReadError => 9,
+            BleError::WriteError => 10,
+            BleError::Other => 11,
+            BleError::Unknown => 12,
+        }
+    }
+}
+
+impl Display for BleError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let err: ockam_core::Error = (*self).into();
+        err.fmt(f)
+    }
+}
+
+impl From<BleError> for ockam_core::Error {
+    fn from(e: BleError) -> ockam_core::Error {
+        ockam_core::Error::new(BleError::DOMAIN_CODE + e.code(), BleError::DOMAIN_NAME)
+    }
+}
+
+#[test]
+fn code_and_domain() {
+    use core::array::IntoIter;
+    use ockam_core::compat::collections::HashMap;
+
+    let ble_errors_map = IntoIter::new([
+        (000, BleError::PermissionDenied),
+        (001, BleError::NotSupported),
+        (002, BleError::HardwareError),
+        (003, BleError::NotFound),
+        (004, BleError::TimedOut),
+        (005, BleError::NotConnected),
+        (006, BleError::ConfigurationFailed),
+        (007, BleError::AdvertisingFailure),
+        (008, BleError::ConnectionClosed),
+        (009, BleError::ReadError),
+        (010, BleError::WriteError),
+        (011, BleError::Other),
+        (012, BleError::Unknown),
+    ])
+    .collect::<HashMap<_, _>>();
+    for (expected_code, ble_err) in ble_errors_map {
+        let err: ockam_core::Error = ble_err.into();
+        assert_eq!(err.domain(), BleError::DOMAIN_NAME);
+        assert_eq!(err.code(), BleError::DOMAIN_CODE + expected_code);
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/lib.rs
@@ -1,0 +1,50 @@
+//! Bluetooth Low Energy (BLE) Transport for Ockam's routing framework
+//!
+//! The `ockam_node` (or `ockam_node_no_std`) crate sits at the core
+//! of the Ockam routing framework, with transport specific
+//! abstraction plugins.  This crate implements a Bluetooth connection
+//! plugin for this architecture.
+//!
+//! You can use Ockam's routing mechanism for cryptographic protocols,
+//! key lifecycle, credential exchange, enrollment, etc, without having
+//! to worry about the transport specifics.
+//!
+
+#![deny(
+    //missing_docs,
+    dead_code,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unused_import_braces,
+    unused_qualifications
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(target = "mips", feature(asm))]
+#![cfg_attr(target = "mips", feature(asm_experimental_arch))]
+
+#[cfg(feature = "std")]
+extern crate core;
+
+#[cfg_attr(feature = "alloc", macro_use)]
+extern crate alloc;
+
+#[macro_use]
+extern crate tracing;
+
+pub mod driver;
+mod error;
+mod macros;
+mod router;
+mod transport;
+mod types;
+mod workers;
+
+pub use driver::{BleClient, BleServer};
+pub use transport::BleTransport;
+pub use types::*;
+
+/// BLE address type constant
+pub const BLE: u8 = 4;
+
+pub(crate) const CLUSTER_NAME: &str = "_internals.transport.ble";

--- a/implementations/rust/ockam/ockam_transport_ble/src/macros.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/macros.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! wait_ms {
+    ($millis:expr) => {
+        std::thread::sleep(core::time::Duration::from_millis($millis));
+    };
+}
+
+// TODO convert baremetal implementations to real ms delays
+
+#[cfg(all(not(feature = "std"), target_arch = "arm"))]
+#[macro_export]
+macro_rules! wait_ms {
+    ($millis:expr) => {
+        let cycles: u32 = 10_000 * $millis;
+        for _ in 0..cycles {
+            cortex_m::asm::nop();
+        }
+    };
+}
+
+#[cfg(all(not(feature = "std"), target_arch = "mips"))]
+#[macro_export]
+macro_rules! wait_ms {
+    ($millis:expr) => {
+        let cycles = 50_000 * $millis;
+        let n = cycles / 2;
+        for _ in 0..n {
+            unsafe {
+                asm!("NOP");
+            }
+        }
+    };
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
@@ -1,0 +1,112 @@
+use crate::{
+    driver::{BleClientDriver, BleServerDriver, BleStreamDriver},
+    workers::{BleListenProcessor, BleSendWorker, WorkerPair},
+    BleAddr, BleClient, BleServer,
+};
+
+use ockam_core::{
+    async_trait,
+    compat::{boxed::Box, string::String, vec::Vec},
+};
+use ockam_core::{Address, AsyncTryClone, Result, RouterMessage};
+use ockam_node::Context;
+use ockam_transport_core::TransportError;
+
+/// A handle to connect to a BleRouter
+///
+/// Dropping this handle is harmless.
+pub(crate) struct BleRouterHandle {
+    ctx: Context,
+    addr: Address,
+}
+
+#[async_trait]
+impl AsyncTryClone for BleRouterHandle {
+    async fn async_try_clone(&self) -> Result<Self> {
+        let child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        Ok(Self::new(child_ctx, self.addr.clone()))
+    }
+}
+
+impl BleRouterHandle {
+    pub(crate) fn new(ctx: Context, addr: Address) -> Self {
+        BleRouterHandle { ctx, addr }
+    }
+}
+
+impl BleRouterHandle {
+    /// Register a new connection worker with this router
+    pub async fn register(&self, pair: &WorkerPair) -> Result<()> {
+        let ble_address: Address = format!("{}#{}", crate::BLE, pair.peer()).into();
+        let mut accepts = vec![ble_address];
+        accepts.extend(
+            pair.servicenames()
+                .iter()
+                .map(|x| Address::from_string(format!("{}#{}", crate::BLE, x))),
+        );
+        let self_addr = pair.tx_addr();
+
+        trace!("BleRouterHandle accepts: {:?} -> {:?}", accepts, self_addr);
+
+        self.ctx
+            .send(
+                self.addr.clone(),
+                RouterMessage::Register { accepts, self_addr },
+            )
+            .await
+    }
+
+    /// Bind an incoming connection listener for this router
+    pub async fn bind<A: BleServerDriver + BleStreamDriver + Send + 'static, S: Into<BleAddr>>(
+        &self,
+        ble_server: BleServer<A>,
+        addr: S,
+    ) -> Result<()> {
+        let ble_addr = addr.into();
+        BleListenProcessor::start(
+            ble_server,
+            &self.ctx,
+            self.async_try_clone().await?,
+            ble_addr,
+        )
+        .await
+    }
+
+    pub(crate) fn resolve_peer(peer: impl Into<String>) -> Result<(BleAddr, Vec<String>)> {
+        let peer_str = peer.into();
+        let peer_addr;
+        let servicenames;
+
+        // Try to parse as BleAddr
+        if let Ok(p) = crate::parse_ble_addr(peer_str) {
+            peer_addr = p;
+            servicenames = vec![];
+        } else {
+            return Err(TransportError::InvalidAddress.into());
+        }
+
+        Ok((peer_addr, servicenames))
+    }
+
+    /// Establish an outgoing BLE connection on an existing transport
+    pub async fn connect<A: BleClientDriver + BleStreamDriver + Send + 'static, S: AsRef<str>>(
+        &self,
+        mut ble_client: BleClient<A>,
+        peer: S,
+    ) -> Result<()> {
+        let (peer_addr, servicenames) = Self::resolve_peer(peer.as_ref())?;
+
+        debug!("scanning all available adapters");
+        ble_client.scan(&peer_addr).await?;
+
+        debug!("connecting to server peripheral");
+        ble_client.connect().await?;
+
+        let stream = crate::driver::AsyncStream::with_ble_device(ble_client);
+        let pair = BleSendWorker::start_pair(&self.ctx, stream, peer_addr, servicenames).await?;
+
+        self.register(&pair).await?;
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -1,0 +1,142 @@
+mod handle;
+
+use ockam::LocalMessage;
+use ockam_core::{
+    async_trait,
+    compat::{boxed::Box, collections::BTreeMap, vec::Vec},
+};
+use ockam_core::{Address, Result, Routed, RouterMessage, Worker};
+use ockam_node::Context;
+use ockam_transport_core::TransportError;
+
+pub(crate) use handle::BleRouterHandle;
+
+/// A Bluetooth Low Energy address router and connection listener
+///
+/// In order to create new BLE connection workers you need a router to
+/// map remote addresses of `type = BLE` to worker addresses.  This type
+/// facilitates this.
+///
+/// Optionally you can also start listening for incoming connections
+/// if the local node is part of a server architecture.
+pub struct BleRouter {
+    _ctx: Context,
+    addr: Address,
+    map: BTreeMap<Address, Address>,
+}
+
+impl BleRouter {
+    async fn create_self_handle(&self, ctx: &Context) -> Result<BleRouterHandle> {
+        let handle_ctx = ctx.new_context(Address::random(0)).await?;
+        let handle = BleRouterHandle::new(handle_ctx, self.addr.clone());
+        Ok(handle)
+    }
+
+    async fn handle_register(&mut self, accepts: Vec<Address>, self_addr: Address) -> Result<()> {
+        if let Some(f) = accepts.first().cloned() {
+            debug!("BLE registration request: {} => {}", f, self_addr);
+        } else {
+            return Err(TransportError::InvalidAddress.into());
+        }
+
+        for accept in &accepts {
+            if self.map.contains_key(accept) {
+                return Err(TransportError::AlreadyConnected.into());
+            }
+        }
+
+        for accept in accepts {
+            self.map.insert(accept.clone(), self_addr.clone());
+        }
+
+        Ok(())
+    }
+
+    async fn handle_route(&mut self, ctx: &Context, mut msg: LocalMessage) -> Result<()> {
+        debug!("Ble route request: {:?}", msg.transport().onward_route);
+
+        // Get the next hop
+        let onward = msg.transport().onward_route.next()?;
+
+        // Look up the connection worker responsible
+        let next;
+        if let Some(addr) = self.map.get(onward) {
+            next = addr.clone();
+        } else {
+            error!("unknown route: {:?}", onward);
+            return Err(TransportError::UnknownRoute.into());
+        }
+
+        let _ = msg.transport_mut().onward_route.step()?;
+
+        // Modify the transport message route
+        msg.transport_mut()
+            .onward_route
+            .modify()
+            .prepend(next.clone());
+
+        // Send the transport message to the connection worker
+        ctx.send(next.clone(), msg).await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Worker for BleRouter {
+    type Context = Context;
+    type Message = RouterMessage;
+
+    async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        debug!("Registering Ble router for type = {}", crate::BLE);
+        ctx.register(crate::BLE, ctx.address()).await?;
+        ctx.set_cluster(crate::CLUSTER_NAME).await?;
+        Ok(())
+    }
+
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        msg: Routed<RouterMessage>,
+    ) -> Result<()> {
+        let msg = msg.body();
+        use RouterMessage::*;
+        match msg {
+            Route(msg) => {
+                trace!("handle_message route: {:?}", msg.transport().onward_route);
+                self.handle_route(ctx, msg).await?;
+            }
+            Register { accepts, self_addr } => {
+                trace!("handle_message register: {:?} => {:?}", accepts, self_addr);
+                self.handle_register(accepts, self_addr).await?;
+            }
+        };
+
+        Ok(())
+    }
+}
+
+impl BleRouter {
+    /// Create and register a new Ble router with the node context
+    ///
+    /// To also handle incoming connections, use
+    /// [`BleRouter::bind`](BleRouter::bind)
+    pub(crate) async fn register(ctx: &Context) -> Result<BleRouterHandle> {
+        let addr = Address::random(0);
+        debug!("Registering new BleRouter with address {}", &addr);
+
+        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let router = Self {
+            _ctx: child_ctx,
+            addr: addr.clone(),
+            map: BTreeMap::new(),
+        };
+
+        let handle = router.create_self_handle(ctx).await?;
+
+        trace!("BleRouter start_worker({:?})", addr.clone());
+        ctx.start_worker(addr.clone(), router).await?;
+
+        Ok(handle)
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -88,8 +88,6 @@ impl Worker for BleRouter {
     type Message = RouterMessage;
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
-        debug!("Registering Ble router for type = {}", crate::BLE);
-        ctx.register(crate::BLE, ctx.address()).await?;
         ctx.set_cluster(crate::CLUSTER_NAME).await?;
         Ok(())
     }
@@ -134,8 +132,11 @@ impl BleRouter {
 
         let handle = router.create_self_handle(ctx).await?;
 
-        trace!("BleRouter start_worker({:?})", addr.clone());
+        trace!("Start Ble router for address = {:?}", addr.clone());
         ctx.start_worker(addr.clone(), router).await?;
+
+        trace!("Registering Ble router for type = {}", crate::BLE);
+        ctx.register(crate::BLE, ctx.address()).await?;
 
         Ok(handle)
     }

--- a/implementations/rust/ockam/ockam_transport_ble/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/transport.rs
@@ -1,0 +1,103 @@
+use core::str::FromStr;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ockam::AsyncTryClone;
+use ockam_core::compat::boxed::Box;
+use ockam_core::{async_trait, Result};
+use ockam_node::Context;
+
+use crate::driver::{BleClient, BleServer};
+use crate::driver::{BleClientDriver, BleServerDriver, BleStreamDriver};
+use crate::router::{BleRouter, BleRouterHandle};
+use crate::BleAddr;
+
+/// High level management interface for BLE transports
+///
+/// Be aware that only one `BleTransport` can exist per node, as it
+/// registers itself as a router for the `BLE` address type.  Multiple
+/// calls to [`BleTransport::create`](crate::BleTransport::create)
+/// will panic.
+///
+/// To register additional connections on an already initialised
+/// `BleTransport`, use
+/// [`ble.connect()`](crate::BleTransport::connect).  To listen for
+/// incoming connections use
+/// [`ble.listen()`](crate::BleTransport::listen)
+///
+/// ```rust
+/// use ockam_transport_ble::{BleClient, BleTransport};
+/// use ockam_transport_ble::driver::btleplug::BleAdapter;
+/// # use ockam_node::Context;
+/// # use ockam_core::Result;
+/// # async fn test(ctx: Context) -> Result<()> {
+///     // Create a ble_client
+///     let ble_adapter = BleAdapter::try_new().await?;
+///     let ble_client = BleClient::with_adapter(ble_adapter);
+///
+///     // Initialize the BLE Transport.
+///     let ble = BleTransport::create(&ctx).await?;
+///
+///     // Try to connect to BleServer
+///     ble.connect(ble_client, "ockam_ble_1".to_string()).await?;
+/// # Ok(()) }
+/// ```
+pub struct BleTransport {
+    router_handle: BleRouterHandle,
+}
+
+#[async_trait]
+impl AsyncTryClone for BleTransport {
+    async fn async_try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            router_handle: self.router_handle.async_try_clone().await?,
+        })
+    }
+}
+
+impl BleTransport {
+    /// Create a new BLE transport and router for the current node
+    pub async fn create(ctx: &Context) -> Result<Self> {
+        static CREATED: AtomicBool = AtomicBool::new(false);
+        if CREATED.swap(true, Ordering::SeqCst) {
+            panic!("You may only create one BleTransport per node.");
+        }
+
+        let router_handle = BleRouter::register(ctx).await?;
+
+        Ok(Self { router_handle })
+    }
+
+    /// Establish an outgoing BLE connection on an existing transport
+    ///
+    /// Starts a new pair of Ble connection workers
+    ///
+    /// One worker handles outgoing messages, while another handles
+    /// incoming messages. The local worker address is chosen based on
+    /// the peer the worker is meant to be connected to.
+    pub async fn connect<
+        A: BleClientDriver + BleStreamDriver + Send + 'static,
+        S: AsRef<str> + core::fmt::Debug,
+    >(
+        &self,
+        ble_client: BleClient<A>,
+        peer: S,
+    ) -> Result<()> {
+        self.router_handle.connect(ble_client, peer.as_ref()).await
+    }
+
+    /// Start listening to incoming connections on an existing transport
+    pub async fn listen<
+        A: BleServerDriver + BleStreamDriver + Send + 'static,
+        S: AsRef<str> + core::fmt::Debug,
+    >(
+        &self,
+        ble_server: BleServer<A>,
+        listen_addr: S,
+    ) -> Result<()> {
+        let bind_addr = BleAddr::from_str(listen_addr.as_ref())?;
+        debug!("BleTransport::listen -> {:?}", listen_addr);
+        self.router_handle.bind(ble_server, bind_addr).await?;
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/types.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/types.rs
@@ -1,0 +1,40 @@
+use core::fmt;
+use core::str::FromStr;
+use ockam_core::compat::string::{String, ToString};
+use ockam_core::Result;
+use ockam_transport_core::TransportError;
+
+#[derive(Clone, Debug, Default)]
+pub struct BleAddr {
+    pub device_name: String,
+    pub local_name: String,
+}
+
+impl fmt::Display for BleAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.local_name)
+    }
+}
+
+impl From<&BleAddr> for String {
+    fn from(other: &BleAddr) -> Self {
+        other.to_string()
+    }
+}
+
+impl FromStr for BleAddr {
+    type Err = ockam_core::Error;
+
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        Ok(Self {
+            device_name: s.to_string(),
+            local_name: s.to_string(),
+        })
+    }
+}
+
+pub fn parse_ble_addr<S: AsRef<str>>(s: S) -> Result<BleAddr> {
+    Ok(s.as_ref()
+        .parse()
+        .map_err(|_| TransportError::InvalidAddress)?)
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/listener.rs
@@ -1,0 +1,98 @@
+use ockam_core::compat::boxed::Box;
+use ockam_core::{async_trait, Address, Processor, Result};
+use ockam_node::Context;
+
+use crate::driver::AsyncStream;
+use crate::driver::{BleEvent, BleServer};
+use crate::driver::{BleServerDriver, BleStreamDriver};
+use crate::router::BleRouterHandle;
+use crate::workers::sender::BleSendWorker;
+use crate::BleAddr;
+
+/// BleListenProcessor
+pub struct BleListenProcessor<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send + 'static,
+{
+    inner: Option<BleServer<A>>,
+    router_handle: BleRouterHandle,
+}
+
+impl<A> BleListenProcessor<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send + 'static,
+{
+    pub(crate) async fn start(
+        mut ble_server: BleServer<A>,
+        ctx: &Context,
+        router_handle: BleRouterHandle,
+        addr: BleAddr,
+    ) -> Result<()> {
+        debug!("BleRouterHandle::bind binding BleServer to: {}", addr);
+        ble_server.bind(&addr).await?;
+
+        let processor = Self {
+            inner: Some(ble_server),
+            router_handle,
+        };
+        let waddr = Address::random(0);
+
+        debug!(
+            "BleListenProcessor::start Starting processor with address: {:?}",
+            waddr
+        );
+        ctx.start_processor(waddr, processor).await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Processor for BleListenProcessor<A>
+where
+    A: BleServerDriver + BleStreamDriver + Send + 'static,
+{
+    type Context = Context;
+
+    async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
+        ctx.set_cluster(crate::CLUSTER_NAME).await
+    }
+
+    async fn process(&mut self, ctx: &mut Self::Context) -> Result<bool> {
+        if self.inner.is_none() {
+            return Ok(true);
+        }
+
+        // Wait for an incoming connection from a BleClient
+        let mut buffer = [0_u8; 64];
+        let result = self.inner.as_mut().unwrap().poll(&mut buffer).await;
+
+        // TODO some BLE devices can pair with multiple clients
+        // TODO some targets have multiple BLE devices
+
+        if let Ok(BleEvent::ConnectionComplete) = result {
+            trace!("Spawning WorkerPair for BleServer");
+            // Spawn a WorkerPair for it
+            let ble_server = self.inner.take().unwrap();
+            let stream = AsyncStream::with_ble_device(ble_server);
+            let pair = BleSendWorker::start_pair(
+                ctx,
+                stream,
+                // TODO resolve connecting BleClient's addresses
+                crate::parse_ble_addr("ble_client_addr").unwrap(),
+                vec![],
+            )
+            .await?;
+
+            // Register the connection with the local BleRouter
+            trace!("Registering WorkerPair tx stream with BleRouterHandle");
+            self.router_handle.register(&pair).await?;
+        } else if let Ok(BleEvent::None) = result {
+            // TODO sleep
+        } else {
+            error!("Unhandled event: {:?}", result);
+        }
+
+        Ok(true)
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/listener.rs
@@ -10,10 +10,7 @@ use crate::workers::sender::BleSendWorker;
 use crate::BleAddr;
 
 /// BleListenProcessor
-pub struct BleListenProcessor<A>
-where
-    A: BleServerDriver + BleStreamDriver + Send + 'static,
-{
+pub struct BleListenProcessor<A> {
     inner: Option<BleServer<A>>,
     router_handle: BleRouterHandle,
 }

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/mod.rs
@@ -1,0 +1,7 @@
+mod listener;
+mod receiver;
+mod sender;
+
+pub(crate) use listener::*;
+pub(crate) use receiver::*;
+pub(crate) use sender::*;

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/receiver.rs
@@ -1,0 +1,133 @@
+use ockam_core::async_trait;
+use ockam_core::compat::boxed::Box;
+use ockam_core::compat::vec::Vec;
+use ockam_core::{Address, Decodable, LocalMessage, Processor, Result, TransportMessage};
+use ockam_node::Context;
+use ockam_transport_core::TransportError;
+
+use crate::driver::Source;
+use crate::driver::{BleEvent, BleStreamDriver, PacketBuffer};
+
+/// A BLE receiving message worker
+///
+/// This half of the worker is created when spawning a new worker
+/// pair, and listens for incoming BLE events, to relay into the node
+/// message system.
+pub struct BleRecvProcessor<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    rx_stream: Source<A>,
+    peer_addr: Address,
+    packet_buffer: PacketBuffer,
+}
+
+impl<A> BleRecvProcessor<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    pub(crate) fn new(rx_stream: Source<A>, peer_addr: Address) -> Self {
+        Self {
+            rx_stream,
+            peer_addr,
+            packet_buffer: PacketBuffer::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl<A> Processor for BleRecvProcessor<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    type Context = Context;
+
+    async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        ctx.set_cluster(crate::CLUSTER_NAME).await
+    }
+
+    async fn process(&mut self, ctx: &mut Context) -> Result<bool> {
+        let mut buffer = [0_u8; crate::driver::MAX_OCKAM_MESSAGE_LENGTH];
+
+        match self.rx_stream.poll(&mut buffer).await {
+            Ok(BleEvent::None) => {}
+            Ok(BleEvent::Unknown) => {
+                debug!("\t=> BleEvent::Unknown");
+            }
+            Ok(BleEvent::ConnectionComplete) => {
+                debug!("\t=> BleEvent::ConnectionComplete");
+            }
+            Ok(BleEvent::DisconnectionComplete) => {
+                debug!("\t=> BleEvent::DisconnectionComplete");
+            }
+            Ok(BleEvent::Received(fragment)) => {
+                debug!("\t=> BleEvent::ReceivedData -> {:?} bytes", fragment.len());
+
+                self.handle_received(ctx, fragment).await?;
+            }
+            Err(e) => {
+                error!("BleRecvProcessor::process poll error: {:?}", e);
+                return Err(crate::error::BleError::ReadError.into());
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+impl<A> BleRecvProcessor<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    async fn handle_received(&mut self, ctx: &mut Context, fragment: &[u8]) -> Result<()> {
+        // first fragment contains the expected packet length
+        if let Some(packet_len) = self.packet_buffer.receive_packet_length(fragment) {
+            debug!("Received packet length: {} bytes", packet_len);
+            return Ok(());
+        }
+
+        match self.packet_buffer.receive_next_fragment(fragment) {
+            Ok(Some(packet)) => {
+                trace!("Received packet: {:?}", packet);
+
+                // Try to deserialize a message
+                let result =
+                    TransportMessage::decode(packet).map_err(|_| TransportError::RecvBadMessage);
+                let mut msg = match result {
+                    Err(e) => {
+                        error!("Error decoding message: {:?}", e);
+                        return Err(e.into());
+                    }
+                    Ok(msg) => msg,
+                };
+
+                trace!("Deserialized message successfully: {:?}", msg);
+
+                // Insert the peer address into the return route so that
+                // reply routing can be properly resolved
+                msg.return_route.modify().prepend(self.peer_addr.clone());
+
+                // Some verbose logging we may want to remove
+                debug!("Message onward route: {}", msg.onward_route);
+                debug!("Message return route: {}", msg.return_route);
+
+                // Forward the message to the final destination worker,
+                // which consumes the TransportMessage and yields the
+                // final message type
+                ctx.forward(LocalMessage::new(msg, Vec::new())).await?;
+
+                // reset packet buffer
+                self.packet_buffer.reset();
+            }
+            Ok(None) => {
+                trace!("Added fragment to packet buffer -> {:?}", fragment);
+            }
+            Err(e) => {
+                error!("Invalid packet fragment: {:?} -> {:?}", e, fragment);
+                self.packet_buffer.reset();
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/receiver.rs
@@ -13,10 +13,7 @@ use crate::driver::{BleEvent, BleStreamDriver, PacketBuffer};
 /// This half of the worker is created when spawning a new worker
 /// pair, and listens for incoming BLE events, to relay into the node
 /// message system.
-pub struct BleRecvProcessor<A>
-where
-    A: BleStreamDriver + Send + 'static,
-{
+pub struct BleRecvProcessor<A> {
     rx_stream: Source<A>,
     peer_addr: Address,
     packet_buffer: PacketBuffer,

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
@@ -1,0 +1,159 @@
+use ockam::Address;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
+use ockam_core::{async_trait, Encodable, Result, Routed, TransportMessage, Worker};
+use ockam_node::Context;
+use ockam_transport_core::TransportError;
+
+use crate::driver::{AsyncStream, BleStreamDriver, PacketBuffer, Sink, Source};
+use crate::workers::BleRecvProcessor;
+use crate::BleAddr;
+
+/// Transmit and receive peers of a BLE connection
+pub(crate) struct WorkerPair {
+    servicenames: Vec<String>,
+    peer: BleAddr,
+    tx_addr: Address,
+}
+
+impl WorkerPair {
+    pub fn servicenames(&self) -> &[String] {
+        &self.servicenames
+    }
+    pub fn peer(&self) -> BleAddr {
+        self.peer.clone()
+    }
+    pub fn tx_addr(&self) -> Address {
+        self.tx_addr.clone()
+    }
+}
+
+/// A BLE sending message worker
+///
+/// This half of the worker is created when spawning a new connection
+/// worker pair, and listens for messages from the node message system
+/// to dispatch to a remote peer.
+pub(crate) struct BleSendWorker<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    rx_stream: Option<Source<A>>,
+    tx_stream: Option<Sink<A>>,
+    peer: BleAddr,
+}
+
+impl<A> BleSendWorker<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    fn new(stream: AsyncStream<A>, peer: BleAddr) -> Self {
+        let (tx, rx) = stream.split();
+        Self {
+            rx_stream: Some(rx),
+            tx_stream: Some(tx),
+            peer,
+        }
+    }
+
+    pub(crate) async fn start_pair(
+        ctx: &Context,
+        stream: AsyncStream<A>,
+        peer: BleAddr,
+        servicenames: Vec<String>,
+    ) -> Result<WorkerPair> {
+        debug!("Creating new BLE worker pair");
+
+        let tx_addr = Address::random(0);
+        let sender = BleSendWorker::new(stream, peer.clone());
+
+        debug!("start send worker({:?})", tx_addr.clone());
+        ctx.start_worker(tx_addr.clone(), sender).await?;
+
+        Ok(WorkerPair {
+            servicenames,
+            peer,
+            tx_addr,
+        })
+    }
+}
+
+#[async_trait]
+impl<A> Worker for BleSendWorker<A>
+where
+    A: BleStreamDriver + Send + 'static,
+{
+    type Context = Context;
+    type Message = TransportMessage;
+
+    async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
+        ctx.set_cluster(crate::CLUSTER_NAME).await?;
+
+        debug!("initialize for peer: {:?}", self.peer);
+
+        if let Some(rx_stream) = self.rx_stream.take() {
+            let rx_addr = Address::random(0);
+            let receiver =
+                BleRecvProcessor::new(rx_stream, format!("{}#{}", crate::BLE, self.peer).into());
+            ctx.start_processor(rx_addr.clone(), receiver).await?;
+            debug!("started receiver");
+        } else {
+            error!("TransportError::GenericIo");
+            return Err(TransportError::GenericIo.into());
+        }
+
+        Ok(())
+    }
+
+    // BleSendWorker will receive messages from the BleRouter to send
+    // across the TcpStream to the next remote peer.
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        mut msg: Routed<TransportMessage>,
+    ) -> Result<()> {
+        trace!("BleSendWorker::handle_message -> {:?}", msg);
+
+        // Remove our own address from the route so the other end
+        // knows what to do with the incoming message
+        msg.onward_route.step()?;
+
+        // encode message
+        let msg = msg
+            .body()
+            .encode()
+            .map_err(|_| TransportError::SendBadMessage)?;
+
+        // create packet buffer
+        debug!("creating packet buffer");
+        let mut packet_buffer = PacketBuffer::from_packet(&msg);
+
+        // send packet length
+        debug!("sending packet length: {}", packet_buffer.packet_len());
+        let fragment = packet_buffer.send_packet_length();
+        match self.tx_stream.as_ref().unwrap().write(&fragment).await {
+            Ok(_) => (),
+            Err(e) => {
+                error!("Failed to send fragment to peer {}: {:?}", self.peer, e);
+                ctx.stop_worker(ctx.address()).await?;
+            }
+        }
+
+        // send packet buffer
+        debug!("sending packet fragments");
+        while let Some(fragment) = packet_buffer.send_next_fragment() {
+            debug!("sending packet fragment: {}", fragment.len());
+            match self.tx_stream.as_ref().unwrap().write(fragment).await {
+                Ok(_) => (),
+                Err(e) => {
+                    error!("Failed to send fragment to peer {}: {:?}", self.peer, e);
+                    ctx.stop_worker(ctx.address()).await?;
+                }
+            }
+
+            crate::wait_ms!(100);
+
+            ockam_node::tokio::task::yield_now().await;
+        }
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
@@ -32,10 +32,7 @@ impl WorkerPair {
 /// This half of the worker is created when spawning a new connection
 /// worker pair, and listens for messages from the node message system
 /// to dispatch to a remote peer.
-pub(crate) struct BleSendWorker<A>
-where
-    A: BleStreamDriver + Send + 'static,
-{
+pub(crate) struct BleSendWorker<A> {
     rx_stream: Option<Source<A>>,
     tx_stream: Option<Sink<A>>,
     peer: BleAddr,


### PR DESCRIPTION
## Proposed Changes

* A new crate adding  Bluetooth Low Energy support to Ockam

### Features:

* BLE Client support on Linux, macOS, Windows
* BLE Server support on `atsame54`, `nucleo_h7xx`
* Support for STMicroElectronics bluenrg radios

### Blocking Issues:

* [x] `cargo deny` currently fails with an advisory affecting the `dashmap` crate used by the `btleplug` crate. There is not yet a safe upgrade available. More information: https://github.com/xacrimon/dashmap/issues/167
* [x] Updated docker image with libdbus dependency added needs to be deployed

### Known Issues:

* [ ] https://github.com/ockam-network/ockam/issues/2497
* [ ] macOS 12.x aka Monterey ships with a bug that prevents console applications from enumerating devices that don't advertise a service uuid. More information: https://github.com/deviceplug/btleplug/issues/224

