### PR TITLE
ci: bump crates using name specified in cargo.toml

### DIFF
--- a/tools/scripts/release/crate-bump.sh
+++ b/tools/scripts/release/crate-bump.sh
@@ -26,13 +26,14 @@ for word in ${crate_array[@]}; do
     specified_crate_version[$key]=$value
 done
 
-for to_update in ${updated_crates[@]}; do
+for crate in ${updated_crates[@]}; do
     version=$RELEASE_VERSION
+    name=$(eval "tomlq package.name -f implementations/rust/ockam/$crate/Cargo.toml")
 
-    if [[ ! -z "${specified_crate_version[$to_update]}" ]]; then
-        echo "bumping $to_update as ${specified_crate_version[$to_update]}"
-        version="${specified_crate_version[$to_update]}"
+    if [[ ! -z "${specified_crate_version[$crate]}" ]]; then
+        echo "bumping $crate as ${specified_crate_version[$crate]}"
+        version="${specified_crate_version[$crate]}"
     fi
 
-    echo y | cargo release $version --no-push --no-publish --no-tag --no-dev-version --package $to_update --execute
+    echo y | cargo release $version --no-push --no-publish --no-tag --no-dev-version --package $name --execute
 done

--- a/tools/scripts/release/crate-publish.sh
+++ b/tools/scripts/release/crate-publish.sh
@@ -28,8 +28,9 @@ done
 for crate in $(ls "implementations/rust/ockam"); do
     # Add crate to excluded crate
     if [[ -z ${bumped_crates[$crate]} ]]; then
-        echo "Excluding $crate from publishing"
-        exclude_string="$exclude_string --exclude $crate";
+        name=$(eval "tomlq package.name -f implementations/rust/ockam/$crate/Cargo.toml")
+        echo "Excluding $name from publishing"
+        exclude_string="$exclude_string --exclude $name";
     fi
 done
 

--- a/tools/scripts/release/dev-bump.sh
+++ b/tools/scripts/release/dev-bump.sh
@@ -3,9 +3,10 @@
 for crate in $(ls "implementations/rust/ockam"); do
     # Check if crate is a -dev version
     version=$(eval "tomlq package.version -f implementations/rust/ockam/$crate/Cargo.toml")
+    name=$(eval "tomlq package.name -f implementations/rust/ockam/$crate/Cargo.toml")
 
     if [[ "$version" != *"-dev"* ]]; then
-        echo "bumping crate $crate to dev"
-        echo y | cargo release release --no-push --no-publish --no-tag --package $crate --execute
+        echo "bumping crate $name to dev"
+        echo y | cargo release release --no-push --no-publish --no-tag --package $name --execute
     fi
 done


### PR DESCRIPTION
[There are crates in the Ockam directory that are not named after its directory](https://github.com/ockam-network/ockam/blob/ce14e532962f335c68cd369ac65638fa07ce53c7/implementations/rust/ockam/ockam_ffi/Cargo.toml#L2). This PR gets the package name from Cargo.toml