### PR TITLE
investigate caching

### DIFF
--- a/.github/actions/cargo_home_cache/action.yml
+++ b/.github/actions/cargo_home_cache/action.yml
@@ -6,10 +6,10 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: |
-          ~/.cargo/bin
-          ~/.cargo/registry/index
-          ~/.cargo/registry/cache
-          ~/.cargo/git/db
+          /usr/rust/cargo/bin
+          /usr/rust/cargo/registry/index
+          /usr/rust/cargo/registry/cache
+          /usr/rust/cargo/git/db
         key: cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
 
 # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci

--- a/.github/actions/cargo_home_cache/action.yml
+++ b/.github/actions/cargo_home_cache/action.yml
@@ -10,6 +10,6 @@ runs:
           /usr/rust/cargo/registry/index
           /usr/rust/cargo/registry/cache
           /usr/rust/cargo/git/db
-        key: cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
+        key: cache-cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
 
 # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: target
-        key: cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-
+        key: cache-cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -7,6 +7,6 @@ runs:
       with:
         path: target
         key: cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-
+        restore-keys: cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html

--- a/.github/actions/cargo_target_dir_pre_cache/action.yml
+++ b/.github/actions/cargo_target_dir_pre_cache/action.yml
@@ -7,8 +7,14 @@ runs:
       run: |
         crates=($(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members[] | split(" ")  | .[0] | gsub("-";"_")'))
 
+        # Get target folder size
+        du -sh target
+
+        rm -rf ./target/debug/examples
+        rm -rf ./target/debug/incremental
+
         for mode in debug release; do
-          for dir in deps .fingerprint; do
+          for dir in deps .fingerprint build; do
             if [ -d "target/$mode/$dir" ]; then
               cd "target/$mode/$dir"
               for crate in "${crates[@]}"; do rm -rf $crate* lib$crate*; done
@@ -16,3 +22,5 @@ runs:
             fi
           done
         done
+
+        du -sh target

--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -6,6 +6,6 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: '**/deps'
-        key: elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-${{ hashFiles('**/mix.lock') }}
+        key: cache-elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-
+          cache-elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae-

--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -5,10 +5,10 @@ runs:
   steps:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
-        path: ~/.gradle/wrapper/dists
-        key: gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
+        path: /root/.gradle/wrapper/dists
+        key: gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
         restore-keys: |
-          gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
-          gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-${{ github.job }}-
-          gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-${{ github.workflow }}-
-          gradle-${{ hashFiles('**/gradle-wrapper.properties') }}-
+          gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
+          gradle-${{ github.workflow }}-${{ github.job }}-
+          gradle-${{ github.workflow }}-
+          gradle-

--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -6,9 +6,9 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: /root/.gradle/wrapper/dists
-        key: gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
+        key: cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
         restore-keys: |
-          gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
-          gradle-${{ github.workflow }}-${{ github.job }}-
-          gradle-${{ github.workflow }}-
-          gradle-
+          cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/ockam-network/ockam/builder@sha256:e874d5c6323736e18c666aa26d15188b17f2342fee41bf20bdff463ace9bc4ae
+          cache-gradle-${{ github.workflow }}-${{ github.job }}-
+          cache-gradle-${{ github.workflow }}-
+          cache-gradle-

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -155,11 +155,8 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
-      - uses: ./.github/actions/cargo_home_cache
-      - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
       - run: cd implementations/elixir && ../../gradlew test_ockam
-      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   test_ockam_kafka:
     name: Elixir - test_ockam_kafka
@@ -169,11 +166,8 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
-      - uses: ./.github/actions/cargo_home_cache
-      - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
       - run: cd implementations/elixir && ../../gradlew test_ockam_kafka
-      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   test_ockam_hub:
     name: Elixir - test_ockam_hub
@@ -183,8 +177,5 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - uses: ./.github/actions/gradle_cache
-      - uses: ./.github/actions/cargo_home_cache
-      - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
       - run: cd implementations/elixir && ../../gradlew test_ockam_hub
-      - uses: ./.github/actions/cargo_target_dir_pre_cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,10 +48,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/gradle_cache
-      - uses: ./.github/actions/cargo_home_cache
-      - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew lint_cargo_fmt_check
-      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   lint_cargo_clippy:
     name: Rust - Lint with Cargo Clippy
@@ -78,10 +75,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/gradle_cache
-      - uses: ./.github/actions/cargo_home_cache
-      - uses: ./.github/actions/cargo_target_dir_cache
       - run: cd implementations/rust && ../../gradlew lint_cargo_deny
-      - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   build_docs:
     name: Rust - Build Documentation


### PR DESCRIPTION
## Caching Issue

1. [Post caching](https://github.com/ockam-network/ockam/runs/4768381360?check_suite_focus=true) of Rust build was tasking a significant amount 
2. Gradle and `cargo_home` are caching empty folders causing Gradle and deps to download for every action

## Investigation

1. Github post job caching entails
   - Compressing all folders/files specified in [cache path](https://github.com/ockam-network/ockam/blob/c2ed08140edbbf90b9cd1117ef15f269583d54a4/.github/actions/cargo_home_cache/action.yml#L8)
   - Uploading compressed cache
Downloading `target` cache, [compressed size indicates ~1.9GB](https://github.com/ockam-network/ockam/runs/4829774888?check_suite_focus=true#step:6:19) which means `post cache` had to compressed `chunk` of files (comprising KBs of files) down to 1.9GB leading to delay in time of `target post caching`. We can further delete folders in the target folder.
        - [Deleting the /target/debug/examples folder](https://github.com/ockam-network/ockam/blob/b751800d68de3017331d3f01abc2f180d6a92b94/.github/actions/cargo_target_dir_pre_cache/action.yml#L13) which consists of Ockam built examples more here https://doc.rust-lang.org/cargo/reference/cargo-targets.html#examples
        - [Deleting the /target/debug/incremental folder](https://github.com/ockam-network/ockam/blob/b751800d68de3017331d3f01abc2f180d6a92b94/.github/actions/cargo_target_dir_pre_cache/action.yml#L14) more [here](https://doc.rust-lang.org/cargo/guide/build-cache.html)
Deleting these folders further reduces target folder from [8.4G to 2.5G](https://github.com/ockam-network/ockam/runs/4954668943?check_suite_focus=true#step:8:24) and takes approximately 2m 13s to compress and upload cache compared to recent [13m](https://github.com/ockam-network/ockam/runs/4768381360?check_suite_focus=true#step:14:1) to cache.

2. For Gradle, we were caching from the $HOME (~) directory which is specified as [/github/home](https://github.com/ockam-network/ockam/runs/4954849713?check_suite_focus=true#step:2:100), an invalid path even on docker. Hardcoding the path fixes this issues and gets caching working both on Gradle and cargo directory.

Note: I appended a `cache-` string to the keys so that caching of new paths dont clash with the old ones. We can always revert after.