### PR TITLE
docs(rust): document `JSON` `TokenLeaseManager` client

### DIFF
--- a/implementations/rust/ockam/ockam_entity/src/lease/json_proto.rs
+++ b/implementations/rust/ockam/ockam_entity/src/lease/json_proto.rs
@@ -1,14 +1,21 @@
+//! JSON Client for the Ockam Cloud InfluxDB TokenLeaseManager service. The client supports
+//! requesting a lease with a given TTL, organization and bucket. The service implementation is
+//! limited to standalone InfluxDB instances, not Influx Cloud.
 use crate::{Lease, TTL};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::error;
 
+/// Fine grained permissions for a resource such as "read" and "write" for a bucket.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct LeaseProtocolPermissions {
+    /// read or write
     action: String,
+    /// type = bucket, name = the_bucket_name
     resource: HashMap<String, String>,
 }
 
+/// Options passed in a token lease request.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(untagged)]
 pub enum LeaseProtocolOption {
@@ -17,18 +24,22 @@ pub enum LeaseProtocolOption {
     Permissions(Vec<LeaseProtocolPermissions>),
 }
 
+/// Top level request structure to initiate creation of a lease.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct LeaseProtocolRequest {
+    /// create, get, revoke
     action: String,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     options: HashMap<String, LeaseProtocolOption>,
 
+    /// Lease manager token id for referencing a token. Not the token itself.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     token_id: String,
 }
 
 impl LeaseProtocolRequest {
+    /// Builds a new lease request of the given action, options and token id. Token is null for create.
     pub fn new<A: ToString, T: ToString>(
         action: A,
         options: HashMap<String, LeaseProtocolOption>,
@@ -41,10 +52,12 @@ impl LeaseProtocolRequest {
         }
     }
 
+    /// Create a lease request without options. Used for get and revoke which require only token id.
     pub fn new_no_opts<A: ToString, T: ToString>(action: A, token_id: T) -> Self {
         Self::new(action, HashMap::new(), token_id)
     }
 
+    /// Deserializes a lease request from JSON.
     pub fn from_json(json: &str) -> Option<Self> {
         match serde_json::from_str(json) {
             Ok(request) => Some(request),
@@ -52,14 +65,17 @@ impl LeaseProtocolRequest {
         }
     }
 
+    /// Get a previously leased token given the token id.
     pub fn get<T: ToString>(token_id: T) -> Self {
         Self::new_no_opts("get", token_id)
     }
 
+    /// Revoke a leased token by id.
     pub fn revoke<T: ToString>(token_id: T) -> Self {
         Self::new_no_opts("revoke", token_id)
     }
 
+    /// Create a new token lease for the given org and bucket.
     pub fn create<S: ToString, B: ToString>(ttl: TTL, org_id: S, bucket: B) -> Self {
         let mut options = HashMap::<String, LeaseProtocolOption>::new();
 
@@ -100,23 +116,30 @@ impl LeaseProtocolRequest {
         LeaseProtocolRequest::new("create", options, "")
     }
 
+    /// Serialize a lease request into JSON.
     pub fn as_json(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
 }
 
+/// TokenLeaseManager lease response.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct LeaseProtocolResponse {
+    /// success or failure
     result: String,
+
+    /// value and TTL
     #[serde(default)]
     lease: Lease,
 }
 
 impl LeaseProtocolResponse {
+    /// Retrieve the lease.
     pub fn lease(&self) -> Lease {
         self.lease.clone()
     }
 
+    /// Deserialize a lease response from JSON.
     pub fn from_json(json: &str) -> Self {
         match serde_json::from_str(json) {
             Ok(response) => response,
@@ -127,6 +150,7 @@ impl LeaseProtocolResponse {
         }
     }
 
+    /// Builds a failure response for testing.
     pub fn failure() -> Self {
         LeaseProtocolResponse {
             result: "failure".to_string(),
@@ -134,6 +158,7 @@ impl LeaseProtocolResponse {
         }
     }
 
+    /// Builds a success response for testing.
     pub fn success(lease: Lease) -> Self {
         LeaseProtocolResponse {
             result: "success".to_string(),
@@ -141,10 +166,12 @@ impl LeaseProtocolResponse {
         }
     }
 
+    /// Returns true if the response is success.
     pub fn is_success(&self) -> bool {
         self.result == "success"
     }
 
+    /// Serialize a response to JSON.
     pub fn as_json(&self) -> String {
         serde_json::to_string(self).unwrap()
     }


### PR DESCRIPTION
Documents the prototypical JSON client for Ockam Cloud TokenLeaseManager service