### PR TITLE
Update crate edition to 2021

### DIFF
--- a/examples/rust/file_transfer/Cargo.toml
+++ b/examples/rust/file_transfer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "file_transfer"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 publish = false
 rust-version = "1.56.0"

--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello_ockam"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 publish = false
 rust-version = "1.56.0"

--- a/examples/rust/ockam_kafka/Cargo.toml
+++ b/examples/rust/ockam_kafka/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_kafka"
 license = "Apache-2.0"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 rust-version = "1.56.0"
 

--- a/examples/rust/tcp_inlet_and_outlet/Cargo.toml
+++ b/examples/rust/tcp_inlet_and_outlet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tcp_inlet_and_outlet"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 publish = false
 rust-version = "1.56.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "embedded",
 ]
 description = "End-to-end encryption and mutual authentication for distributed applications."
-edition = "2018"
+edition = "2021"
 exclude = ["tests/**"]
 homepage = "https://github.com/ockam-network/ockam"
 keywords = [

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_channel"
 version = "0.41.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_core"
 version = "0.45.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_core"

--- a/implementations/rust/ockam/ockam_examples/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Ockam Developers"]
 description = """Example projects using the Ockam APIs"""
 version = "0.28.0"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/ockam-network/ockam"
 keywords = ["ockam", "crypto", "cryptography"]
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "channel_examples"
 version = "0.0.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 autobins = false
 publish = false
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/Cargo.toml
@@ -2,7 +2,7 @@
 name = "credentials_example"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 autobins = false
 description = """

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/bin/bob.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/bin/bob.rs
@@ -7,7 +7,6 @@ use ockam::{
     CredentialProtocol, Identity, Identity, IdentityIdentifier, Result, TcpTransport,
     TrustIdentifierPolicy, Vault, TCP,
 };
-use std::convert::TryFrom;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/bin/door.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/bin/door.rs
@@ -7,7 +7,6 @@ use ockam::{
     Identity, IdentityIdentifier, Result, TcpTransport, TrustEveryonePolicy, TrustIdentifierPolicy,
     Vault, TCP,
 };
-use std::convert::TryFrom;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/bin/office.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/credentials/src/bin/office.rs
@@ -5,7 +5,6 @@ use ockam::{
     credential_type, Context, CredentialProtocol, Identity, Identity, IdentityIdentifier,
     IdentityTrait, Result, TcpTransport, TrustEveryonePolicy, TrustIdentifierPolicy, Vault,
 };
-use std::convert::TryFrom;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hub_inlet"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 publish = false

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 resolver = "2"
 readme = "README.md"
 name = "hello_ockam_no_std"

--- a/implementations/rust/ockam/ockam_examples/example_projects/node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "node_examples"
 version = "0.0.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 autobins = false
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Ockam Developers"]
 name = "okta-plugin"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "okta_example_management_app"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/management_service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "okta_example_management_service"
 version = "0.1.0"
 authors = ["Michael Lodder <mike@ockam.io>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/okta/truck/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/okta/truck/Cargo.toml
@@ -2,7 +2,7 @@
 name = "okta_example_truck"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/ports/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ports/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ports_example"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 publish = false

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/Cargo.toml
@@ -2,7 +2,7 @@
 name = "credentials_example"
 version = "0.1.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 autobins = false
 description = """

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tcp_examples"
 version = "0.0.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/tunnel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tunnel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tunnel_example"
 version = "0.0.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "worker_examples"
 version = "0.0.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "Ockam async executor crate"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_executor"
 keywords = ["ockam", "crypto", "encryption", "authentication"]

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam-ffi"
 version = "0.34.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_ffi"

--- a/implementations/rust/ockam/ockam_ffi/src/vault.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault.rs
@@ -1,7 +1,6 @@
 use crate::vault_types::{FfiSecretAttributes, SecretKeyHandle};
 use crate::{check_buffer, FfiError, FfiOckamError};
 use crate::{FfiVaultFatPointer, FfiVaultType};
-use core::convert::{TryFrom, TryInto};
 use core::slice;
 use lazy_static::lazy_static;
 use ockam_core::compat::sync::Arc;

--- a/implementations/rust/ockam/ockam_ffi/src/vault_types.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault_types.rs
@@ -1,20 +1,19 @@
 #![allow(conflicting_repr_hints)]
 
 use crate::FfiError;
-use core::convert::TryFrom;
 use ockam_core::vault::{SecretAttributes, SecretPersistence, SecretType};
 
 /// Represents a handle id for the secret key
 pub type SecretKeyHandle = u64;
 
-#[derive(Clone, Copy, Debug)]
 #[repr(C, u8)]
+#[derive(Clone, Copy, Debug)]
 pub enum FfiVaultType {
     Software = 1,
 }
 
-#[derive(Clone, Copy, Debug)]
 #[repr(C)]
+#[derive(Clone, Copy, Debug)]
 pub struct FfiVaultFatPointer {
     handle: u64,
     vault_type: FfiVaultType,

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_identity"
 version = "0.35.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_identity"

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -58,7 +58,6 @@ mod test {
     use ockam_core::{route, Any, Route, Routed, Worker};
     use ockam_node::Context;
     use ockam_vault_sync_core::Vault;
-    use std::convert::TryInto;
     use std::time::Duration;
     use tokio::time::sleep;
 

--- a/implementations/rust/ockam/ockam_identity/src/credential/identity_credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/identity_credentials.rs
@@ -11,7 +11,6 @@ use crate::{
     OfferId, PresentationFinishedMessage, PresentationManifest, PresenterWorker, ProofRequestId,
     SigningPublicKey, TrustPolicy, TrustPolicyImpl, VerifierWorker,
 };
-use core::convert::TryInto;
 use ockam_core::{async_trait, compat::boxed::Box};
 use ockam_core::{Address, Result, Route};
 use signature_bls::SecretKey;

--- a/implementations/rust/ockam/ockam_identity/src/credential/identity_state_credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/identity_state_credentials.rs
@@ -5,7 +5,6 @@ use crate::{
     CredentialSchema, CredentialVerifier, ExtPokSignatureProof, IdentityCredential, IdentityError,
     IdentityState, OfferId, PresentationManifest, ProofBytes, ProofRequestId, SigningPublicKey,
 };
-use core::convert::TryInto;
 use ockam_core::compat::collections::{HashMap, HashSet};
 use ockam_core::vault::SecretVault;
 use ockam_core::{allow, deny, Result};

--- a/implementations/rust/ockam/ockam_identity/src/credential/traits.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/traits.rs
@@ -4,7 +4,6 @@ use crate::{
     IdentityIdentifier, OfferId, PresentationManifest, ProofBytes, ProofRequestId,
     SigningPublicKey, TrustPolicy,
 };
-use core::convert::TryFrom;
 use core::fmt::{Display, Formatter};
 use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::{async_trait, compat::boxed::Box};

--- a/implementations/rust/ockam/ockam_identity/src/credential/workers/holder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/workers/holder.rs
@@ -4,7 +4,6 @@ use crate::{
     IdentityError, IdentityIdentifier, IdentitySecureChannelLocalInfo, IdentityTrait,
     SigningPublicKey,
 };
-use core::convert::TryInto;
 use ockam_core::async_trait;
 use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, vec::Vec};

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -1,5 +1,4 @@
 use crate::{IdentityError, IdentityStateConst};
-use core::convert::TryFrom;
 use core::fmt::{Display, Formatter};
 use ockam_core::compat::string::String;
 use ockam_core::hex::encode;
@@ -88,7 +87,6 @@ impl EventIdentifier {
 #[cfg(test)]
 mod test {
     use super::*;
-    use core::convert::TryInto;
     use rand::{thread_rng, RngCore};
 
     impl IdentityIdentifier {

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_key_exchange_core"
 version = "0.37.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_core"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_key_exchange_x3dh"
 version = "0.37.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_x3dh"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
@@ -1,5 +1,4 @@
 use crate::{PreKeyBundle, X3DHError, X3dhVault, CSUITE};
-use core::convert::TryFrom;
 use ockam_core::compat::{
     string::{String, ToString},
     vec::Vec,

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -7,7 +7,6 @@ extern crate core;
 extern crate alloc;
 
 use arrayref::array_ref;
-use core::convert::TryFrom;
 use ockam_core::vault::{
     AsymmetricVault, Hasher, PublicKey, SecretType, SecretVault, Signer, SymmetricVault, Verifier,
 };

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_key_exchange_xx"
 version = "0.38.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_key_exchange_xx"

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ockam_macros"
 version = "0.6.0"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 authors = ["Ockam Developers"]
 categories = [

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "network-programming",
 ]
 description = "Ockam Node implementation crate"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_node"
 keywords = [

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_transport_core"
 version = "0.19.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_transport_core"

--- a/implementations/rust/ockam/ockam_transport_core/src/error_test.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/error_test.rs
@@ -1,11 +1,10 @@
-use core::array::IntoIter;
 use ockam_core::compat::collections::HashMap;
 
 use crate::TransportError;
 
 #[test]
 fn code_and_domain() {
-    let tr_errors_map = IntoIter::new([
+    let tr_errors_map = [
         (1, TransportError::SendBadMessage),
         (2, TransportError::RecvBadMessage),
         (3, TransportError::BindFailed),
@@ -19,7 +18,8 @@ fn code_and_domain() {
         (11, TransportError::Encoding),
         (12, TransportError::Protocol),
         (13, TransportError::GenericIo),
-    ])
+    ]
+    .into_iter()
     .collect::<HashMap<_, _>>();
     for (expected_code, tr_err) in tr_errors_map {
         let err: ockam_core::Error = tr_err.into();
@@ -40,10 +40,11 @@ fn from_unmapped_io_error() {
 
 #[test]
 fn from_mapped_io_errors() {
-    let mapped_io_err_kinds = IntoIter::new([(
+    let mapped_io_err_kinds = [(
         std::io::ErrorKind::ConnectionRefused,
         TransportError::PeerNotFound,
-    )])
+    )]
+    .into_iter()
     .collect::<HashMap<_, _>>();
     for (io_err_kind, expected_tr_err) in mapped_io_err_kinds {
         let io_err = std::io::Error::new(io_err_kind, "io::Error");

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_transport_tcp"
 version = "0.40.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_transport_tcp"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_transport_websocket"
 version = "0.34.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_transport_websocket"

--- a/implementations/rust/ockam/ockam_transport_websocket/src/error_test.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/error_test.rs
@@ -1,5 +1,3 @@
-use std::array::IntoIter;
-
 use ockam_core::compat::collections::HashMap;
 use ockam_transport_core::TransportError;
 use tokio_tungstenite::tungstenite::{http::Response, Error as TungsteniteError};
@@ -8,11 +6,12 @@ use crate::WebSocketError;
 
 #[test]
 fn code_and_domain() {
-    let ws_errors_map = IntoIter::new([
+    let ws_errors_map = [
         (13, WebSocketError::Transport(TransportError::GenericIo)),
         (0, WebSocketError::Http),
         (1, WebSocketError::Tls),
-    ])
+    ]
+    .into_iter()
     .collect::<HashMap<_, _>>();
     for (expected_code, ws_err) in ws_errors_map {
         let err: ockam_core::Error = ws_err.into();

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_vault"
 version = "0.39.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault"

--- a/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/secret_impl.rs
@@ -54,8 +54,6 @@ impl SoftwareVault {
             }
             #[cfg(feature = "bls")]
             SecretType::Bls => {
-                use core::convert::TryInto;
-
                 let bls_secret_key = BlsSecretKey::from_bytes(secret.try_into().unwrap()).unwrap();
                 let public_key = PublicKey::new(
                     BlsPublicKey::from(&bls_secret_key).to_bytes().into(),
@@ -72,8 +70,6 @@ impl SoftwareVault {
         match attributes.stype() {
             #[cfg(feature = "bls")]
             SecretType::Bls => {
-                use core::convert::TryInto;
-
                 let bytes = TryInto::<[u8; BlsSecretKey::BYTES]>::try_into(secret)
                     .map_err(|_| VaultError::InvalidBlsSecretLength)?;
                 if BlsSecretKey::from_bytes(&bytes).is_none().into() {
@@ -204,8 +200,6 @@ impl SecretVault for SoftwareVault {
             }
             #[cfg(feature = "bls")]
             SecretType::Bls => {
-                use core::convert::TryInto;
-
                 let bls_secret_key =
                     BlsSecretKey::from_bytes(&entry.key().as_ref().try_into().unwrap()).unwrap();
                 Ok(PublicKey::new(

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_vault_sync_core"
 version = "0.37.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam_vault_sync_core"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -11,7 +11,7 @@ description = """Ockam Vault test suite.
 """
 version = "0.34.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 keywords = [
     "ockam",

--- a/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
+++ b/implementations/rust/ockam/signature_bbs_plus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signature_bbs_plus"
 version = "0.35.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/blob/develop/implementations/rust/ockam/signature_bbs_plus"

--- a/implementations/rust/ockam/signature_bbs_plus/src/blind_signature.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/blind_signature.rs
@@ -1,7 +1,6 @@
 use crate::{MessageGenerators, Signature, MAX_MSGS};
 use blake2::Blake2b;
 use bls12_381_plus::{G1Projective, Scalar};
-use core::convert::TryFrom;
 use digest::Digest;
 use ff::Field;
 use group::Curve;

--- a/implementations/rust/ockam/signature_bbs_plus/src/blind_signature_context.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/blind_signature_context.rs
@@ -1,7 +1,6 @@
 use crate::MessageGenerators;
 use blake2::VarBlake2b;
 use bls12_381_plus::{G1Projective, Scalar};
-use core::convert::TryFrom;
 use digest::{Update, VariableOutput};
 use group::{Curve, GroupEncoding};
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/signature_bbs_plus/src/message_generator.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/message_generator.rs
@@ -1,5 +1,4 @@
 use bls12_381_plus::{ExpandMsgXmd, G1Projective};
-use core::convert::TryFrom;
 use group::Curve;
 use signature_bls::{PublicKey, SecretKey};
 use signature_core::lib::*;

--- a/implementations/rust/ockam/signature_bbs_plus/src/pok_signature_proof.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/pok_signature_proof.rs
@@ -1,6 +1,5 @@
 use crate::MessageGenerators;
 use bls12_381_plus::{multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, Scalar};
-use core::convert::TryFrom;
 use core::ops::Neg;
 use digest::Update;
 use group::{Curve, Group, GroupEncoding};

--- a/implementations/rust/ockam/signature_bbs_plus/src/signature.rs
+++ b/implementations/rust/ockam/signature_bbs_plus/src/signature.rs
@@ -3,7 +3,6 @@ use blake2::Blake2b;
 use bls12_381_plus::{
     multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Scalar,
 };
-use core::convert::TryFrom;
 use core::ops::Neg;
 use digest::Digest;
 use ff::Field;

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signature_bls"
 version = "0.33.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/signature_bls"

--- a/implementations/rust/ockam/signature_bls/src/partial_signature.rs
+++ b/implementations/rust/ockam/signature_bls/src/partial_signature.rs
@@ -1,7 +1,6 @@
 use crate::{SecretKeyShare, Signature};
 use bls12_381_plus::{G1Affine, G1Projective, Scalar};
 use core::{
-    convert::TryFrom,
     fmt::{self, Display},
     ops::{BitOr, Not},
 };

--- a/implementations/rust/ockam/signature_bls/src/partial_signature_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/partial_signature_vt.rs
@@ -1,7 +1,6 @@
 use crate::{SecretKeyShare, SignatureVt};
 use bls12_381_plus::{G2Affine, G2Projective, Scalar};
 use core::{
-    convert::TryFrom,
     fmt::{self, Display},
     ops::{BitOr, Not},
 };

--- a/implementations/rust/ockam/signature_core/Cargo.toml
+++ b/implementations/rust/ockam/signature_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signature_core"
 version = "0.35.0"
 authors = ["Ockam Deveopers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/signatures_core"

--- a/implementations/rust/ockam/signature_ps/Cargo.toml
+++ b/implementations/rust/ockam/signature_ps/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signature_ps"
 version = "0.33.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://github.com/ockam-network/ockam"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/signature_ps"

--- a/implementations/rust/ockam/signature_ps/src/blind_signature.rs
+++ b/implementations/rust/ockam/signature_ps/src/blind_signature.rs
@@ -1,7 +1,6 @@
 use crate::{SecretKey, Signature};
 use blake2::Blake2b;
 use bls12_381_plus::{G1Affine, G1Projective, Scalar};
-use core::convert::TryFrom;
 use digest::Digest;
 use group::Curve;
 use hmac_drbg::HmacDRBG;

--- a/implementations/rust/ockam/signature_ps/src/blind_signature_context.rs
+++ b/implementations/rust/ockam/signature_ps/src/blind_signature_context.rs
@@ -1,7 +1,6 @@
 use crate::SecretKey;
 use blake2::VarBlake2b;
 use bls12_381_plus::{G1Projective, Scalar};
-use core::convert::TryFrom;
 use digest::{Update, VariableOutput};
 use group::{Curve, GroupEncoding};
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/signature_ps/src/message_generator.rs
+++ b/implementations/rust/ockam/signature_ps/src/message_generator.rs
@@ -88,8 +88,6 @@ impl MessageGenerators {
         }
 
         fn from_be_bytes(d: &[u8]) -> G1Projective {
-            use core::convert::TryFrom;
-
             let t = <[u8; MessageGenerators::POINT_SIZE]>::try_from(d).expect("invalid length");
             G1Affine::from_compressed(&t)
                 .map(G1Projective::from)

--- a/implementations/rust/ockam/signature_ps/src/pok_signature_proof.rs
+++ b/implementations/rust/ockam/signature_ps/src/pok_signature_proof.rs
@@ -2,7 +2,6 @@ use crate::PublicKey;
 use bls12_381_plus::{
     multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective, Scalar,
 };
-use core::convert::TryFrom;
 use core::ops::BitOr;
 use digest::Update;
 use group::{Curve, Group, GroupEncoding};

--- a/implementations/rust/ockam/signature_ps/src/public_key.rs
+++ b/implementations/rust/ockam/signature_ps/src/public_key.rs
@@ -107,8 +107,6 @@ impl PublicKey {
         }
 
         fn from_be_bytes(d: &[u8]) -> G2Projective {
-            use core::convert::TryFrom;
-
             let t = <[u8; PublicKey::POINT_SIZE]>::try_from(d).expect("invalid length");
             G2Affine::from_compressed(&t)
                 .map(G2Projective::from)

--- a/implementations/rust/ockam/signature_ps/src/secret_key.rs
+++ b/implementations/rust/ockam/signature_ps/src/secret_key.rs
@@ -119,8 +119,6 @@ impl SecretKey {
         }
 
         fn from_be_bytes(d: &[u8]) -> Scalar {
-            use core::convert::TryFrom;
-
             let mut t = <[u8; SecretKey::SCALAR_SIZE]>::try_from(d).expect("invalid length");
             t.reverse();
             Scalar::from_bytes(&t).unwrap()

--- a/implementations/rust/ockam/signature_ps/src/signature.rs
+++ b/implementations/rust/ockam/signature_ps/src/signature.rs
@@ -4,7 +4,6 @@ use bls12_381_plus::{
     multi_miller_loop, ExpandMsgXmd, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective,
     Scalar,
 };
-use core::convert::TryFrom;
 use digest::{Update, VariableOutput};
 use group::{Curve, Group};
 use serde::{

--- a/implementations/typescript/ockam/ockam_nodejs_native/Cargo.toml
+++ b/implementations/typescript/ockam/ockam_nodejs_native/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "ockam_nodejs_native"
 version = "0.0.0"
 publish = false

--- a/implementations/typescript/ockam/ockam_wasm/rust/Cargo.toml
+++ b/implementations/typescript/ockam/ockam_wasm/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ockam_wasm"
 version = "0.0.0"
 authors = ["Ockam Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/integrations/suborbital/helloworld-rs/Cargo.toml
+++ b/integrations/suborbital/helloworld-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "helloworld-rs"
 version = "0.1.0"
 authors = ["Suborbital Runnable <info@suborbital.dev>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/docs/example_blocks/Cargo.toml
+++ b/tools/docs/example_blocks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example_blocks"
 license = "Apache-2.0"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 rust-version = "1.56.0"
 

--- a/tools/docs/example_runner/Cargo.toml
+++ b/tools/docs/example_runner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example_runner"
 license = "Apache-2.0"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 rust-version = "1.56.0"
 


### PR DESCRIPTION
This was bugging me, and is an easy update. I'm not sure if we need to update the Rust version in Docker (seems possible).

Fixes #2249