### PR TITLE
feat(elixir): make pub_sub service reply after subscription

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/responder.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/responder.ex
@@ -23,15 +23,20 @@ defmodule Ockam.Messaging.PipeChannel.Responder do
     sender_options = Keyword.get(options, :sender_options, [])
     receiver_options = Keyword.get(options, :receiver_options, [])
 
+    address_options = Keyword.take(options, [:address, :inner_address])
+
     Session.Responder.create(
-      init_message: init_message,
-      worker_mod: PipeChannel.Simple,
-      handshake: PipeChannel.Handshake,
-      handshake_options: [
-        pipe_mod: pipe_mod,
-        sender_options: sender_options,
-        receiver_options: receiver_options
-      ]
+      address_options ++
+        [
+          init_message: init_message,
+          worker_mod: PipeChannel.Simple,
+          handshake: PipeChannel.Handshake,
+          handshake_options: [
+            pipe_mod: pipe_mod,
+            sender_options: sender_options,
+            receiver_options: receiver_options
+          ]
+        ]
     )
   end
 end
@@ -50,11 +55,16 @@ defmodule Ockam.Messaging.PipeChannel.Spawner do
   """
 
   def create(options) do
+    ## TODO: addresses for other workers
+    address_options = Keyword.take(options, [:address, :inner_address])
     responder_options = Keyword.fetch!(options, :responder_options)
 
     Ockam.Session.Spawner.create(
-      worker_mod: Ockam.Messaging.PipeChannel.Responder,
-      worker_options: responder_options
+      address_options ++
+        [
+          worker_mod: Ockam.Messaging.PipeChannel.Responder,
+          worker_options: responder_options
+        ]
     )
   end
 end


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

Currently pub_sub_service will create a topic worker without replying to the caller

## Proposed Changes

Add a reply in format of: `"name:topic"` (same as subscription call) from the topic worker address, which allows the subscribing client to use the return route to see address of the pubsub topic worker. Similarly to the forwarding workers reply.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
