### PR TITLE
feat(rust): add worker ready status

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -13,10 +13,8 @@ pub enum Error {
     FailedStartProcessor,
     /// Worker start failed because the address was already taken
     WorkerAddressTaken,
-    /// The requested worker address is unknown
-    UnknownWorker,
-    /// The requested processor address is unknown
-    UnknownProcessor,
+    /// The requested address is unknown
+    UnknownAddress,
     /// Unable to stop a worker
     FailedStopWorker,
     /// Unable to list available workers
@@ -58,8 +56,7 @@ impl From<crate::NodeError> for ockam_core::Error {
     fn from(err: crate::NodeError) -> Self {
         use crate::NodeError::*;
         match err {
-            NoSuchWorker(_) => Error::UnknownWorker,
-            NoSuchProcessor(_) => Error::UnknownProcessor,
+            NoSuchAddress(_) => Error::UnknownAddress,
             WorkerExists(_) => Error::WorkerAddressTaken,
             RouterExists => Error::InternalIOFailure,
             Rejected(_) => Error::CommandRejected,

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -26,6 +26,9 @@ pub use ockam_executor::tokio;
 #[cfg(feature = "std")]
 pub use tokio;
 
+#[cfg(test)]
+mod tests;
+
 /// Async Mutex and RwLock
 pub mod compat;
 

--- a/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
@@ -36,6 +36,10 @@ where
             }
         }
 
+        if let Err(e) = ctx.set_ready().await {
+            error!("Failed to mark processor '{}' as 'ready': {}", ctx_addr, e);
+        }
+
         // This future encodes the main processor run loop logic
         let run_loop = async {
             loop {

--- a/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
@@ -125,6 +125,10 @@ where
 
         let address = self.ctx.address();
 
+        if let Err(e) = self.ctx.set_ready().await {
+            error!("Failed to mark worker '{}' as 'ready': {}", address, e);
+        }
+
         #[cfg(feature = "std")]
         loop {
             let _ = crate::tokio::select! {

--- a/implementations/rust/ockam/ockam_node/src/router/stop_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_processor.rs
@@ -16,7 +16,7 @@ pub(super) async fn exec(
         Some(proc) => proc,
         None => {
             reply
-                .send(NodeReply::no_such_processor(main_addr.clone()))
+                .send(NodeReply::no_such_address(main_addr.clone()))
                 .await
                 .map_err(|_| Error::InternalIOFailure)?;
 

--- a/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
@@ -16,7 +16,7 @@ pub(super) async fn exec(
         primary_address = p.clone();
     } else {
         reply
-            .send(NodeReply::no_such_worker(addr.clone()))
+            .send(NodeReply::no_such_address(addr.clone()))
             .await
             .map_err(|_| Error::InternalIOFailure)?;
 
@@ -29,7 +29,7 @@ pub(super) async fn exec(
     } else {
         // Actually should not happen
         reply
-            .send(NodeReply::no_such_worker(addr.clone()))
+            .send(NodeReply::no_such_address(addr.clone()))
             .await
             .map_err(|_| Error::InternalIOFailure)?;
 

--- a/implementations/rust/ockam/ockam_node/src/router/utils.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/utils.rs
@@ -23,7 +23,7 @@ pub(super) async fn resolve(
     } else {
         trace!("{} FAILED; no such worker", base);
         reply
-            .send(NodeReply::no_such_worker(addr.clone()))
+            .send(NodeReply::no_such_address(addr.clone()))
             .await
             .map_err(|_| Error::InternalIOFailure)?;
 
@@ -41,7 +41,7 @@ pub(super) async fn resolve(
         }
         None => {
             trace!("{} FAILED; no such worker", base);
-            reply.send(NodeReply::no_such_worker(addr.clone()))
+            reply.send(NodeReply::no_such_address(addr.clone()))
         }
     }
     .await


### PR DESCRIPTION
## Current Behaviour

A problem we repeatedly run into is that initialisation code of one
worker takes longer than another worker is waiting for.  This is a
common problem in multi-processor environments and one that is not
easy to solve.

## Proposed Changes

This commit adds a draft API that allows workers to wait for the
readiness of other addresses.  This is done by marking an address as
"ready" only after its initialization function has been called.

The way that this is currently implemented in the Router breaks a lot
of existing tests because we have implicit race conditions in the
existing examples and tests.

An alternative implementation of this feature doesn't use the router
state value and instead adds a separate 'ready' boolean that can only
be checked by this one test.

@SanjoDeundiak @antoinevg @thomcc thougths?
