### PR TITLE
chore(rust): fixup `ockam_transport_ble` for publish (missing crate version)

### DIFF
--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -86,7 +86,7 @@ pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
 pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
-ockam = { path = "../ockam", default_features = false }
+ockam = { path = "../ockam", version = "^0.47.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.15.0", default_features = false }


### PR DESCRIPTION
This is blocking release of about half of the crates 😓 