### PR TITLE
ignore `RUSTSEC-2020-0159` advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,3 +20,6 @@ allow = [
 unmaintained = "deny"
 vulnerability = "deny"
 yanked = "warn"
+ignore = [
+    "RUSTSEC-2020-0159"
+]

--- a/deny.toml
+++ b/deny.toml
@@ -21,5 +21,6 @@ unmaintained = "deny"
 vulnerability = "deny"
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2020-0159"
+    "RUSTSEC-2020-0159",
+    "RUSTSEC-2022-0008"
 ]

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -37,7 +37,7 @@ task lint_cargo_clippy {
 task lint_cargo_deny {
   doLast {
     exec { commandLine cargo('install', '--locked', '--version', '0.11.0', 'cargo-deny') }
-    exec { commandLine cargo('deny', '--manifest-path=../../Cargo.toml', 'check', 'licenses', 'advisories') }
+    exec { commandLine cargo('deny', '--all-features', '--manifest-path=../../Cargo.toml', 'check', 'licenses', 'advisories') }
   }
 }
 


### PR DESCRIPTION
- Ignore `RUSTSEC-2020-0159` advisory till fixed #2541 
- Ignore `RUSTSEC-2022-0008` advisory till fixed #2540
- Cargo deny now checks for all features in CI