### PR TITLE
fix: remove tokio and ockam_node imports on ockam_macros::test.

### DIFF
--- a/implementations/rust/ockam/ockam/tests/main.rs
+++ b/implementations/rust/ockam/ockam/tests/main.rs
@@ -19,6 +19,6 @@ fn node_test() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/node_test/fail*.rs");
     // When the node_test macro is compiled successfully, it will return the error "the main function doesn't exist" because this macro
-    // is only valid within a test context. Therefore, the "pass" tests is considered valid if it returns only that error.
+    // is only valid within a test context. Therefore, the "pass" tests is considered valid only if it returns that specific error.
     t.compile_fail("tests/node_test/pass*.rs");
 }

--- a/implementations/rust/ockam/ockam_macros/src/node_test_attribute/mod.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_test_attribute/mod.rs
@@ -1,4 +1,4 @@
-//! The `#[ockam::test]` macro transform an async input function into a test
+//! The `#[ockam::test]` macro transforms an async input function into a test
 //! output function that sets up an ockam node and executes the body of
 //! the input function inside the node.
 

--- a/implementations/rust/ockam/ockam_macros/src/node_test_attribute/parser.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_test_attribute/parser.rs
@@ -27,8 +27,7 @@ pub(crate) fn node_test(input: ItemFn, args: AttributeArgs) -> Result<TokenStrea
             .into_iter();
         // `Span` on stable Rust has a limitation that only points to the first
         // token, not the whole tokens. We can work around this limitation by
-        // using the first/last span of the tokens like
-        // `Error::new_spanned` does.
+        // using the first/last span of the tokens like `Error::new_spanned` does.
         let start = last_stmt.next().map_or_else(Span::call_site, |t| t.span());
         last_stmt.last().map_or(start, |t| t.span())
     };
@@ -50,9 +49,8 @@ fn output_node_test(
     input.block = parse2(quote_spanned! {last_stmt_end_span=>
         {
             use core::time::Duration;
-            use ockam_node::tokio::time::timeout;
 
-            let (mut #ctx_ident, mut executor) = ockam_node::start_node();
+            let (mut #ctx_ident, mut executor) = start_node();
             executor
                 .execute(async move {
                     match timeout(Duration::from_millis(#timeout_ms as u64), #test_input_ident(&mut #ctx_ident)).await {

--- a/implementations/rust/ockam/ockam_node/src/tests.rs
+++ b/implementations/rust/ockam/ockam_node/src/tests.rs
@@ -371,22 +371,20 @@ impl Worker for WaitForWorker {
     }
 }
 
-#[test]
-fn wait_for_worker() {
-    let (mut ctx, mut executor) = start_node();
-    executor
-        .execute(async move {
-            let t1 = tokio::time::Instant::now();
-            ctx.start_worker("slow", WaitForWorker).await.unwrap();
+#[ockam_macros::test]
+async fn wait_for_worker(ctx: &mut Context) -> Result<()> {
+    let t1 = tokio::time::Instant::now();
+    ctx.start_worker("slow", WaitForWorker).await.unwrap();
 
-            info!("Waiting for worker...");
-            ctx.wait_for("slow").await.unwrap();
-            info!("Done waiting :)");
+    info!("Waiting for worker...");
+    ctx.wait_for("slow").await.unwrap();
+    info!("Done waiting :)");
 
-            let t2 = tokio::time::Instant::now();
-            assert!((t2 - t1) > Duration::from_secs(1));
+    let t2 = tokio::time::Instant::now();
+    assert!((t2 - t1) > Duration::from_secs(1));
 
-            ctx.stop().await.unwrap();
-        })
-        .unwrap();
+    if let Err(e) = ctx.stop().await {
+        println!("Unclean stop: {}", e)
+    }
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -1,7 +1,7 @@
 use core::iter;
 
 use ockam_core::{route, Address, Result, Routed, Worker};
-use ockam_node::Context;
+use ockam_node::{start_node, tokio::time::timeout, Context};
 use rand::Rng;
 
 use ockam_transport_tcp::{TcpTransport, TCP};


### PR DESCRIPTION
Now the macro's user is responsible for importing the appropriate modules that include the timeout and start_node methods.

From ockam_node, start_node is a local method and it can be used straight away. When using another internal crate from this repository, the user may import these methods from ockam or ockam_node. This also would allow us to use a non-tokio implementation for the timeout method.

Related issue: https://github.com/ockam-network/ockam/issues/2500