### PR TITLE
Release for 2022-03-07 (ockam_v0.48.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "hashbrown 0.9.1",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_test_suite"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "arrayref",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_ble"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "atsame54_xpro",
  "bluenrg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bunt",
  "clap 3.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "ockam-ffi"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "lazy_static",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_identity"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_sync_core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "ockam_core",
  "ockam_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "futures 0.3.21",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "ockam_core",
  "zeroize",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -94,7 +94,7 @@ path = "tests/main.rs"
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -102,7 +102,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_featur
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.42.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }
-ockam_identity = { path = "../ockam_identity", version = "^0.36.0", default_features = false }
+ockam_identity = { path = "../ockam_identity", version = "^0.37.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.36.0", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -98,7 +98,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features 
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.42.0", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.42.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -97,7 +97,7 @@ ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.43.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -100,7 +100,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.42.0", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.37.0", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.47.0"
+version = "0.48.0"
 rust-version = "1.56.0"
 publish = true
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -101,7 +101,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features =
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.42.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.37.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
@@ -118,7 +118,7 @@ dyn-clone = "1.0"
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -99,7 +99,7 @@ ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = f
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.42.0", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.43.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.37.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -96,7 +96,7 @@ path = "tests/main.rs"
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.43.0", optional = true }
@@ -117,7 +117,7 @@ hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -93,7 +93,7 @@ name = "tests"
 path = "tests/main.rs"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -95,7 +95,7 @@ path = "tests/main.rs"
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default_features = false }

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -68,7 +68,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.47.0"
+ockam = "0.48.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -75,7 +75,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features 
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
@@ -86,7 +86,7 @@ tracing = { version = "0.1", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.39.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -73,7 +73,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
@@ -84,7 +84,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.39.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -71,7 +71,7 @@ alloc = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -76,14 +76,14 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.39.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -70,7 +70,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -85,7 +85,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0"}
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.38.0"}
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.39.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -72,7 +72,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -74,7 +74,7 @@ ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default_features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.42.0"
+ockam_channel = "0.43.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -21,7 +21,7 @@ exitcode = "1.1.2"
 human-panic = "1.0.3"
 indicatif = "0.16.2"
 log = "0.4.14"
-ockam = { version = "^0.47.0", path = "../ockam" }
+ockam = { version = "^0.48.0", path = "../ockam" }
 ockam_core = { path = "../ockam_core" }
 ockam_vault = { path = "../ockam_vault" }
 serde = "1.0.130"

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -50,7 +50,7 @@ alloc = [
 bls = []
 
 [dependencies]
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 async-trait = "0.1.42"
 hashbrown = { version = "0.11", default-features = false, features = [
     "ahash",

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.47.0"
+ockam_core = "0.48.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.47.0" , default-features = false }
+ockam_core = { version = "0.48.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.15.0"
+version = "0.16.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.15", default-features = false, features = [
     "async-await",
 ] }
 heapless = { version = "0.7", features = ["mpmc_large"] }
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_executor = "0.15.0"
+ockam_executor = "0.16.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 bls = ["ockam_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0"}
+ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 lazy_static = "1.4"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -30,6 +30,6 @@ bls = ["ockam_core/bls"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -29,7 +29,7 @@ bls = ["ockam_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam-ffi = "0.35.0"
+ockam-ffi = "0.36.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -77,7 +77,7 @@ credentials = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default-features = false }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -78,7 +78,7 @@ credentials = [
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = false }
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default-features = false, optional = true }
@@ -100,6 +100,6 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0"}
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -80,7 +80,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default-features 
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default-features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.42.0", default-features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_identity"
-version = "0.36.0"
+version = "0.37.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -82,7 +82,7 @@ ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default-features = false, optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -79,7 +79,7 @@ ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default-features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default-features = false }
@@ -99,7 +99,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -81,7 +81,7 @@ ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = f
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.43.0", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.39.0", default-features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.40.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -76,7 +76,7 @@ credentials = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -75,7 +75,7 @@ credentials = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default-features = false }
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_identity/README.md
+++ b/implementations/rust/ockam/ockam_identity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_identity = "0.36.0"
+ockam_identity = "0.37.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.38.0"
+version = "0.39.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -34,5 +34,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.38.0"
+ockam_key_exchange_core = "0.39.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -42,5 +42,5 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_node = { path = "../ockam_node", version = "^0.47.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -43,4 +43,4 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
-ockam_node = { path = "../ockam_node", version = "^0.46.0"}
+ockam_node = { path = "../ockam_node", version = "^0.47.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.38.0"
+version = "0.39.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -41,6 +41,6 @@ arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_node = { path = "../ockam_node", version = "^0.47.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.38.0"
+ockam_key_exchange_x3dh = "0.39.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -39,6 +39,6 @@ ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = f
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 
 [dev-dependencies]
-ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
+ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.39.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_node = { path = "../ockam_node", version = "^0.47.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -40,5 +40,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_node = { path = "../ockam_node", version = "^0.47.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -41,4 +41,4 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.3
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
-ockam_node = { path = "../ockam_node", version = "^0.46.0"}
+ockam_node = { path = "../ockam_node", version = "^0.47.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.39.0", default_features = false }
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.38.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.38.0", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.39.0"
+ockam_key_exchange_xx = "0.40.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.9.0 - 2022-03-07
 
 ### Added
 

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Added
+
+- Add "crate" attribute to ockam_macros::test macro
+
 ## 0.8.0 - 2022-02-22
 
 ### Fixed

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_macros"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Ockam Developers"]

--- a/implementations/rust/ockam/ockam_macros/README.md
+++ b/implementations/rust/ockam/ockam_macros/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_macros = "0.8.0"
+ockam_macros = "0.9.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc", "futures/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0"}
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -44,7 +44,7 @@ dump_internals = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0"}
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0"}
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",
     "time",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.46.0"
+version = "0.47.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -59,4 +59,4 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.15.0", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.16.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.46.0"
+ockam_node = "0.47.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -88,7 +88,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 [dependencies]
 ockam = { path = "../ockam", version = "^0.48.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.16.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0", default_features = false }
 

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -87,7 +87,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
 ockam = { path = "../ockam", version = "^0.48.0", default_features = false }
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.15.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0", default_features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_ble"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ockam Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -89,7 +89,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 ockam = { path = "../ockam", version = "^0.48.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
-ockam_executor = { path = "../ockam_executor", version = "^0.15.0", default_features = false }
+ockam_executor = { path = "../ockam_executor", version = "^0.16.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -86,7 +86,7 @@ pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
 pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
-ockam = { path = "../ockam", version = "^0.47.0", default_features = false }
+ockam = { path = "../ockam", version = "^0.48.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.15.0", default_features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -90,7 +90,7 @@ ockam = { path = "../ockam", version = "^0.48.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.16.0", default_features = false }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0", default_features = false }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.21.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "async-await-macro", "sink"] }

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -31,5 +31,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_core = "0.20.0"
+ockam_transport_core = "0.21.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -30,7 +30,7 @@ alloc = []
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_node = { path = "../ockam_node", version = "^0.46.0"}
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0"}
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -28,7 +28,7 @@ std = ["ockam_macros/std"]
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0"}
+ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_node = { path = "../ockam_node", version = "^0.46.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -29,7 +29,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
-ockam_node = { path = "../ockam_node", version = "^0.46.0"}
+ockam_node = { path = "../ockam_node", version = "^0.47.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -31,7 +31,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_node = { path = "../ockam_node", version = "^0.47.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.21.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.42.0"
+ockam_transport_tcp = "0.43.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_node = { path = "../ockam_node", version = "^0.47.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.21.0"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",
     "sync",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -28,7 +28,7 @@ futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.48.0"}
-ockam_node = { path = "../ockam_node", version = "^0.46.0"}
+ockam_node = { path = "../ockam_node", version = "^0.47.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -27,7 +27,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
-ockam_core = { path = "../ockam_core", version = "^0.47.0"}
+ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 ockam_node = { path = "../ockam_node", version = "^0.46.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.20.0"}
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.35.0"
+ockam_transport_websocket = "0.36.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -63,7 +63,7 @@ no_std = [
 alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.36.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.36.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -64,7 +64,7 @@ alloc = ["ockam_core/alloc", "aes-gcm/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default-features = false }
 signature_core = { path = "../signature_core", version = "^0.36.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.36.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.34.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -82,5 +82,5 @@ cfg-if = "1.0"
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.35.0"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.36.0"}
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.40.0"
+ockam_vault = "0.41.0"
 ```
 
 ## Crate Features
@@ -33,7 +33,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault = { version = "0.40.0" , default-features = false }
+ockam_vault = { version = "0.41.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -62,5 +62,5 @@ rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
-ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.35.0"}
+ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.36.0"}
 tokio = { version = "1.8", default-features = false, features = ["sync"]}

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault_sync_core"
-version = "0.38.0"
+version = "0.39.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -50,7 +50,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -51,7 +51,7 @@ alloc = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.8.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -53,7 +53,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.46.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_sync_core/Cargo.toml
@@ -52,7 +52,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.48.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.9.0", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.47.0", default_features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.3"
@@ -61,6 +61,6 @@ rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.40.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.41.0"}
 ockam_vault_test_suite = { path = "../ockam_vault_test_suite", version = "^0.35.0"}
 tokio = { version = "1.8", default-features = false, features = ["sync"]}

--- a/implementations/rust/ockam/ockam_vault_sync_core/README.md
+++ b/implementations/rust/ockam/ockam_vault_sync_core/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_sync_core = "0.38.0"
+ockam_vault_sync_core = "0.39.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -9,7 +9,7 @@ categories = [
 ]
 description = """Ockam Vault test suite.
 """
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_test_suite/Cargo.toml
@@ -27,5 +27,5 @@ publish = true
 rust-version = "1.56.0"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.47.0"}
+ockam_core = { path = "../ockam_core", version = "^0.48.0"}
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault_test_suite/README.md
+++ b/implementations/rust/ockam/ockam_vault_test_suite/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault_test_suite = "0.35.0"
+ockam_vault_test_suite = "0.36.0"
 ```
 
 ## License


### PR DESCRIPTION
This doesn't have complete changelogs because git-cliff at least as of 0.4.2 (updating is tracked in #2528) really believes that tags always mean releases (you can specify a commit range, but it still will only generate changelogs from either the latest tag, or for commits not present in a tag. Neither of these are useful, and they're essentially the same AFAICT). A newer version may have a fix.

(... I honestly feel like the git-cliff tool causes us more trouble than it saves us)