### PR TITLE
script further fix

### DIFF
--- a/tools/scripts/release/README.md
+++ b/tools/scripts/release/README.md
@@ -37,6 +37,12 @@ MODIFIED_RELEASE="signature_core:patch ockam_entity:major" RELEASE_VERSION=relea
 ```
 only signature_core and ockam_entity crates are bumped.
 
+Crates whose transitive dependencies were `only` bumped can be version-bumped with a specified version using the `BUMPED_DEP_CRATES_VERSION` definition so as to follow a different release version
+```bash
+BUMPED_DEP_CRATES_VERSION=patch RELEASE_VERSION=minor tools/scripts/release/crate-bump.sh
+```
+If `BUMPED_DEP_CRATES_VERSION` is not defined then transitive dependent crates are bumped as `minor`.
+
 
 ## Crate Publish
 


### PR DESCRIPTION
This fixes the issue below
crateA -> crateB -> crateC -> crateD
Where -> means "is a dependency of", we need to still bump crates whose cyclic dependencies are updated. 
To do this, we `recursively check for crates that are modified`, `bump their versions` and then `store bumped crates names to a state`. On the next iteration we check for modified crates and `only bump crates whose version has not been bumped yet`, recursively checking and bumping till `old state is same as new state` (there are no newly bumped cyclic-deps whose version hasn't been bumped yet).

We can also specify versions that cyclic dependent crates will be bumped to by defining var `BUMPED_DEP_CRATES_VERSION` if not defined all cyclic dependent crate that their source code were not modified will be bumped as a `minor` version.