### PR TITLE
Metaclips/git cliff fix

### DIFF
--- a/tools/scripts/release/README.md
+++ b/tools/scripts/release/README.md
@@ -7,15 +7,6 @@ GIT_TAG="a_more_recent_git_tag_v0.0.0" tools/scripts/release/changelog.sh
 ```
 This is same for crate bump, crate publish and tagging scripts.
 
-## Changelog Generation
-
-Changelogs are generated using [git-cliff](https://github.com/orhun/git-cliff). To generate changelogs, we call the [changelog.sh script](https://github.com/ockam-network/ockam/blob/develop/tools/scripts/release/changelog.sh) which will generate changelogs and append to their CHANGELOG.md file.
-To run changelog generator, from the Ockam root path, call
-```bash
-tools/scripts/release/changelog.sh
-```
-Generated changelogs should be reviewed and then commited before crate bump is done.
-
 ## Crate Bump
 
 Crates versions are bumped using [cargo-release](https://github.com/crate-ci/cargo-release/issues) >= v0.18.6. While bumping crates, CHANGELOG.md and README.md files are also updated with the bumped version.
@@ -37,6 +28,21 @@ MODIFIED_RELEASE="signature_core:patch ockam_entity:major" RELEASE_VERSION=relea
 ```
 only signature_core and ockam_entity crates are bumped.
 
+Crates whose circular dependencies were `only` bumped can be version-bumped with a specified version using the `BUMPED_DEP_CRATES_VERSION` definition so as to follow a different release version
+```bash
+BUMPED_DEP_CRATES_VERSION=patch RELEASE_VERSION=minor tools/scripts/release/crate-bump.sh
+```
+If `BUMPED_DEP_CRATES_VERSION` is not defined then circular dependent crates are bumped as `minor`.
+
+## Changelog Generation (Requires zsh)
+
+Changelogs are generated using [git-cliff](https://github.com/orhun/git-cliff). To generate changelogs, we call the [changelog.sh script](https://github.com/ockam-network/ockam/blob/develop/tools/scripts/release/changelog.sh) which will generate changelogs and append to their CHANGELOG.md file.
+To run changelog generator, from the Ockam root path, call
+```bash
+tools/scripts/release/changelog.sh
+```
+Generated changelogs should be called after `crate-bump` so we can log crates whose dependencies was only bumped.
+We can also generate changelog from a referenced `git tag`, changelog should be reviewed before commit.
 
 ## Crate Publish
 
@@ -65,7 +71,7 @@ TAG_SINGLE_CRATE=ockam COMMIT_SHA=000000000 tools/scripts/release/tagging.sh
 
 For a manual release to be done, we should
 
-- Generate Changelogs
 - Bump Crates
+- Generate Changelogs
 - Publish Crates
 - Tag Crates

--- a/tools/scripts/release/changelog.sh
+++ b/tools/scripts/release/changelog.sh
@@ -1,13 +1,35 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env zsh -e
 
 # This script generates changelog for all Ockam crates that
 # are to be published.
 
 source tools/scripts/release/crates-to-publish.sh
 
-for crate in ${updated_crates[@]}; do
-    echo "Generating changelog for $crate"
-    git cliff --unreleased --commit-path implementations/rust/ockam/$crate --prepend implementations/rust/ockam/$crate/CHANGELOG.md
+for crate in $( echo "$updated_crates" ); do
+    # There are crates whose versions are only bumped due to updates
+    # in their dependencies, so as not to have empty changelogs we indicate
+    # the below message.
+    with_commit_msg="feat: updated dependencies"
+
+    # Delete the first 5 lines
+    echo "Deleting old changelog in $crate"
+    sed -e '1,6d' implementations/rust/ockam/$crate/CHANGELOG.md > CHANGELOG.md.old
+
+    echo "Generating changelog for $crate with tag $last_git_tag"
+    git-cliff $last_git_tag.. --with-commit $with_commit_msg --include-path implementations/rust/ockam/$crate/**/*.rs --output implementations/rust/ockam/$crate/CHANGELOG.md
+
+    echo "Updating changelog with recent"
+    # Pipe old changelogs
+    cat CHANGELOG.md.old >> implementations/rust/ockam/$crate/CHANGELOG.md
+    rm CHANGELOG.md.old
+
+    # Replace ## unreleased text to bumped version
+    version=$(eval "tomlq package.version -f implementations/rust/ockam/$crate/Cargo.toml")
+
+    search="## unreleased"
+    replace="## $version - $(date +'%Y-%m-%d')"
+    sed -i -e "s/$search/$replace/" implementations/rust/ockam/$crate/CHANGELOG.md
+    rm implementations/rust/ockam/$crate/CHANGELOG.md-e
 done
 
 echo "Changelog has been generated. Please review and commit."


### PR DESCRIPTION
This is a temporary fix for changelog generation with `git-cliff` (update to v0.6.1). To run this script requires `zsh` terminal and script must be called after `crate-bump` script is called.