### PR TITLE
fix(rust): fix variable name in check_documentation.sh and update use case

### DIFF
--- a/documentation/use-cases/secure-remote-access-tunnels/README.md
+++ b/documentation/use-cases/secure-remote-access-tunnels/README.md
@@ -225,8 +225,8 @@ async fn main(ctx: Context) -> Result<()> {
     // Initialize the TCP Transport.
     let tcp = TcpTransport::create(&ctx).await?;
 
-    // We know network address of the node with an Outlet, we also know that Outlet lives at "outlet"
-    // address at that node.
+    // We know the network address of the node with an Outlet, we also know that the Outlet is
+    // running at Ockam Worker address "outlet" on that node.
 
     let route_to_outlet = route![(TCP, "127.0.0.1:4000"), "outlet"];
 
@@ -314,12 +314,13 @@ async fn main(ctx: Context) -> Result<()> {
     // Create:
     //   1. A Vault to store our cryptographic keys
     //   2. An Identity to represent this Node
-    //   3. A Secure Channel Listener at Worker address - secure_channel_listener_service
+    //   3. A Secure Channel Listener at Worker address - secure_channel_listener
     //      that will wait for requests to start an Authenticated Key Exchange.
 
     let vault = Vault::create();
     let mut e = Identity::create(&ctx, &vault).await?;
-    e.create_secure_channel_listener("secure_channel_listener_service", TrustEveryonePolicy).await?;
+    e.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)
+        .await?;
 
     // Expect first command line argument to be the TCP address of a target TCP server.
     // For example: 127.0.0.1:5000
@@ -368,11 +369,11 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // For this example, we know that the Outlet node is listening for Ockam Routing Messages
     // over TCP at "127.0.0.1:4000" and its secure channel listener is
-    // at address: "secure_channel_listener_service".
+    // at address: "secure_channel_listener".
 
     let vault = Vault::create();
     let mut e = Identity::create(&ctx, &vault).await?;
-    let r = route![(TCP, "127.0.0.1:4000"), "secure_channel_listener_service"];
+    let r = route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"];
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,
@@ -473,7 +474,8 @@ async fn main(ctx: Context) -> Result<()> {
 
     let vault = Vault::create();
     let mut e = Identity::create(&ctx, &vault).await?;
-    e.create_secure_channel_listener("secure_channel_listener_service", TrustEveryonePolicy).await?;
+    e.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)
+        .await?;
 
     // Expect first command line argument to be the TCP address of a target TCP server.
     // For example: 127.0.0.1:5000
@@ -537,7 +539,11 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Expect second command line argument to be the Outlet node forwarder address
     let forwarding_address = std::env::args().nth(2).expect("no outlet forwarding address given");
-    let r = route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "secure_channel_listener_service"];
+    let r = route![
+        (TCP, "1.node.ockam.network:4000"),
+        forwarding_address,
+        "secure_channel_listener"
+    ];
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,

--- a/tools/docs/check_documentation.sh
+++ b/tools/docs/check_documentation.sh
@@ -46,6 +46,6 @@ function check_directory {
 check_directory $GUIDE_DOCS $GUIDE_EXAMPLES
 check_directory $KAFKA_DOCS $KAFKA_EXAMPLES
 check_directory $E2E_DOCS $E2E_EXAMPLES
-check_directory $INLET_SOURCE $INLET_EXAMPLES
+check_directory $INLET_DOCS $INLET_EXAMPLES
 
 exit $ERR


### PR DESCRIPTION
While looking at #2256, found a variable was misnamed in tools/docs/check_documentation.sh.

1. Fixed variable in check_documenation.sh that was preventing checks on secure-remote-access-tunnels use case.
2. Updated example code in secure-remote-access-tunnels use case;  check_documentation detected it was out of date.
