### PR TITLE
fix(rust) - node macro - imports ockam context as used in the input function

### DIFF
--- a/implementations/rust/ockam/ockam/tests/node/std/pass_with_imported_context.rs
+++ b/implementations/rust/ockam/ockam/tests/node/std/pass_with_imported_context.rs
@@ -1,8 +1,8 @@
 #![deny(unused_imports)]
 
-use ockam::{self as o};
+use ockam::Context;
 
 #[ockam::node]
-async fn main(mut c: o::Context) {
+async fn main(mut c: Context) {
     c.stop().await.unwrap();
 }


### PR DESCRIPTION
It also modifies tests to correctly catch this error.