### PR TITLE
test(rust): add test for examples/rust/tcp_inlet_and_outlet

### DIFF
--- a/tools/docs/example_runner/get_started.ron
+++ b/tools/docs/example_runner/get_started.ron
@@ -1,12 +1,43 @@
 (
     title: "Getting Started Guide",
     stages: [
-        ["01-node"],
-        ["02-worker"],
-        ["03-routing"],
-        ["03-routing-many-hops"],
-        ["04-routing-over-transport-responder", "04-routing-over-transport-initiator"],
-        ["04-routing-over-transport-two-hops-responder", "sleep 5", "04-routing-over-transport-two-hops-middle","sleep 5", "04-routing-over-transport-two-hops-initiator"],
-        ["05-secure-channel-over-two-transport-hops-responder", "sleep 5", "05-secure-channel-over-two-transport-hops-middle", "sleep 5", "05-secure-channel-over-two-transport-hops-initiator"]
+        [
+            "01-node",
+            "match goodbye",
+        ],
+        [
+            "02-worker",
+            "match goodbye",
+        ],
+        [
+            "03-routing",
+            "match goodbye",
+        ],
+        [
+            "03-routing-many-hops",
+            "match goodbye",
+        ],
+        [
+            "04-routing-over-transport-responder",
+            "match Initializing ockam node",
+            "04-routing-over-transport-initiator",
+            "match goodbye",
+        ],
+        [
+            "04-routing-over-transport-two-hops-responder",
+            "match Initializing ockam node",
+            "04-routing-over-transport-two-hops-middle",
+            "match Initializing ockam node",
+            "04-routing-over-transport-two-hops-initiator",
+            "match goodbye",
+        ],
+        [
+            "05-secure-channel-over-two-transport-hops-responder",
+            "match Starting SecureChannel",
+            "05-secure-channel-over-two-transport-hops-middle",
+            "match Initializing ockam node",
+            "05-secure-channel-over-two-transport-hops-initiator",
+            "match goodbye",
+        ],
     ]
 )

--- a/tools/docs/example_runner/kafka.ron
+++ b/tools/docs/example_runner/kafka.ron
@@ -1,14 +1,14 @@
 (
     title: "Kafka Use Case",
     stages: [
-        [   "ockam_kafka_bob",
-            "sleep 5",
-            "match alice_to_bob_", "match bob_to_alice_",
+        [
+            "ockam_kafka_bob",
+            "match alice_to_bob_",
+            "match bob_to_alice_",
             "out 1",
             "out 0",
             "ockam_kafka_alice",
             "match End-to-end encrypted secure channel was established.",
-            "quit"
         ],
     ]
 )

--- a/tools/docs/example_runner/tcp_inlet_and_outlet.ron
+++ b/tools/docs/example_runner/tcp_inlet_and_outlet.ron
@@ -1,0 +1,42 @@
+(
+    title: "Secure Remote Access Tunnels Use Case",
+
+    // 24Mar2020
+    // Docker image 'base' does not appear to include python3.
+    // So, use ockam.io:80 as a HTTP endpoint instead of launching a
+    // local python3 http server.
+
+    stages: [
+        [
+            "01-inlet-outlet 127.0.0.1:4001 ockam.io:80",
+            "match Initializing ockam node",
+            "cmd curl -s http://127.0.0.1:4001",
+            "match <html",
+        ],
+        [
+            "02-outlet ockam.io:80",
+            "match Initializing ockam node",
+            "02-inlet 127.0.0.1:4001",
+            "match Initializing ockam node",
+            "cmd curl -s http://127.0.0.1:4001",
+            "match <html",
+        ],
+        [
+            "03-outlet ockam.io:80",
+            "match Initializing ockam node",
+            "03-inlet 127.0.0.1:4001",
+            "match Initialized IdentitySecureChannel",
+            "cmd curl -s http://127.0.0.1:4001",
+            "match <html",
+        ],
+        [
+            "04-outlet ockam.io:80",
+            "match FWD_",
+            "arg 0",
+            "04-inlet 127.0.0.1:4001",
+            "match Initialized IdentitySecureChannel",
+            "cmd curl -s http://127.0.0.1:4001",
+            "match <html",
+        ],
+    ]
+)

--- a/tools/docs/run_examples.sh
+++ b/tools/docs/run_examples.sh
@@ -6,18 +6,20 @@ if [ -z $OCKAM_HOME ]; then
 fi
 
 export TOOLS_DIR="$OCKAM_HOME/tools/docs"
-export GET_STARTED="$OCKAM_HOME/examples/rust/get_started/"
+
+export GET_STARTED_CODE="$OCKAM_HOME/examples/rust/get_started/"
 export GET_STARTED_SCRIPT="$TOOLS_DIR/example_runner/get_started.ron"
 
-if [ -z $(which example_runner) ]; then
-    echo "Building example_runner utility"
-    pushd "$TOOLS_DIR/example_runner" &>/dev/null
-    cargo -q install --path . || exit 1
+export TCP_INLET_AND_OUTLET_CODE="$OCKAM_HOME/examples/rust/tcp_inlet_and_outlet/"
+export TCP_INLET_AND_OUTLET_SCRIPT="$TOOLS_DIR/example_runner/tcp_inlet_and_outlet.ron"
+
+# Run example_runner for each case
+function do_run {
+    pushd $1 &>/dev/null
+    echo "============================================================"
+    echo "Running $2"
+    cargo run -p example_runner -- $2
     popd &>/dev/null
-fi
-
-
-pushd $GET_STARTED
-echo $GET_STARTED_SCRIPT
-example_runner $GET_STARTED_SCRIPT
-popd
+}
+do_run $GET_STARTED_CODE $GET_STARTED_SCRIPT
+do_run $TCP_INLET_AND_OUTLET_CODE $TCP_INLET_AND_OUTLET_SCRIPT

--- a/tools/docs/run_kafka_example.sh
+++ b/tools/docs/run_kafka_example.sh
@@ -9,14 +9,6 @@ export TOOLS_DIR="$OCKAM_HOME/tools/docs"
 export KAFKA="$OCKAM_HOME/examples/rust/ockam_kafka/"
 export KAFKA_SCRIPT="$TOOLS_DIR/example_runner/kafka.ron"
 
-if [ -z $(which example_runner) ]; then
-    echo "Building example_runner utility"
-    pushd "$TOOLS_DIR/example_runner" &>/dev/null
-    cargo -q install --path .
-    popd &>/dev/null
-fi
-
-
 pushd $KAFKA
-example_runner $KAFKA_SCRIPT
+cargo run -p example_runner -- $KAFKA_SCRIPT
 popd


### PR DESCRIPTION
## Current Behaviour
The script ockam/tools/docs/run_examples.sh tests some example code but does not run tests on ockam/examples/rust/tcp_inlet_and_outlet.

## Proposed Changes
Add tests so that tcp_inlet_and_outlet code is tested. This is related to #2256. This requires updating the shell script (run_examples.sh), the test runner (example_runner), and the scripts read by the test runner (*.ron).

Some notes...
- It appears the Docker image does not include python3, so, just in case, these new tests use ockam.io:80 as a HTTP endpoint when testing (instead of launching a local python3 HTTP server, as Ockam guides suggest).
- The test harness will now stop as soon as a test fails and will exit with a non-0 code.
- A test (aka stage) will fail if a spawned process exits with an error, or if a 'match' attempt times out (currently 120 seconds).
- I believe this test harness *may* be being run as part of the GitHub CI. And as the Kafka example tests use the HTTP endpoint 1.node.ockam.network:4000, I assume tests running in CI will also be able to access ockam.io:80.

## Checks
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.
