### PR TITLE
chore(rust): remove the `dyn-clonable` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,27 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clonable"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
-dependencies = [
- "dyn-clonable-impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "dyn-clonable-impl"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,7 +1795,6 @@ version = "0.50.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",
- "dyn-clonable",
  "dyn-clone",
  "hex",
  "ockam_channel",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -115,7 +115,6 @@ tracing = { version = "0.1", default-features = false }
 rand = { version = "0.8", default-features = false }
 hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
-dyn-clonable = "0.9"
 
 [dev-dependencies]
 ockam_vault_sync_core = { path = "../ockam_vault_sync_core", version = "^0.41.0"}

--- a/implementations/rust/ockam/ockam/src/system/handler.rs
+++ b/implementations/rust/ockam/ockam/src/system/handler.rs
@@ -1,4 +1,3 @@
-use dyn_clonable::*;
 use dyn_clone::DynClone;
 use ockam_core::compat::{boxed::Box, collections::BTreeMap, string::String};
 use ockam_core::{Address, Message, Result, Routed};
@@ -21,9 +20,8 @@ use ockam_core::{Address, Message, Result, Routed};
 /// It is highly recommended to use the
 /// [SystemBuilder](crate::SystemBuilder) utility to generate this
 /// information.
-#[clonable]
 #[ockam_core::async_trait]
-pub trait SystemHandler<C, M>: Clone + DynClone
+pub trait SystemHandler<C, M>: DynClone
 where
     C: Send + 'static,
     M: Message,
@@ -46,4 +44,12 @@ where
         ctx: &mut C,
         msg: Routed<M>,
     ) -> Result<()>;
+}
+
+dyn_clone::clone_trait_object! {
+    <C, M>
+    SystemHandler<C, M>
+    where
+        C: Send + 'static,
+        M: Message,
 }


### PR DESCRIPTION
Seems to break `no_std` and isn't really needed anyway.