### PR TITLE
fix(rust): use serde_bare to prepend length to payload when missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "ockam_executor",
  "ockam_macros",
  "serde 1.0.136",
+ "serde_bare",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -60,6 +60,7 @@ tracing-subscriber = { version = "0.3", features = [
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
 ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default-features = false, optional = true }
+serde_bare = { version = "0.5.0", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/implementations/rust/ockam/ockam_node/src/parser.rs
+++ b/implementations/rust/ockam/ockam_node/src/parser.rs
@@ -12,9 +12,9 @@ pub(crate) fn message<M: Message>(vec: &[u8]) -> Result<M> {
         // sent by a non-Rust implementation.  In this case we
         // prepend the length of the mesage to the vector and try
         // again.  I know it's bad, but as long as we don't have
-        // properly specified payload encoding this is what will
+        // properly specified payload encoding this is what we'll
         // have to do.
-        let mut new_v = vec![vec.len() as u8]; // FIXME: does not handle message sizes over 255
+        let mut new_v = serde_bare::to_vec(&serde_bare::Uint(vec.len() as u64))?;
         trace!("New message length: {:?}", new_v);
 
         new_v.append(&mut vec.to_vec());

--- a/implementations/rust/ockam/ockam_node/src/tests.rs
+++ b/implementations/rust/ockam/ockam_node/src/tests.rs
@@ -388,3 +388,36 @@ async fn wait_for_worker(ctx: &mut Context) -> Result<()> {
     }
     Ok(())
 }
+
+/// Test the, unexpected, case where a payload is received that does not
+/// code its length at the start. This _may_ happen when dealing with a
+/// payload sent by a non-Rust implementation.
+/// See https://github.com/ockam-network/ockam/issues/2236.
+#[test]
+fn parse_payload_without_inner_length() {
+    use crate::parser;
+
+    // A well formed String payload of 32 smiley chars.
+    let payload: [u8; 130] = [
+        128, 1, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128,
+        240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159,
+        152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128,
+        240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159,
+        152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128,
+        240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159,
+        152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128, 240, 159, 152, 128,
+        240, 159, 152, 128,
+    ];
+    let r = parser::message::<String>(&payload).unwrap();
+    assert_eq!("😀".repeat(32), r);
+
+    // A String payload of 32 smiley chars that is missing its inner length.
+    let payload = "😀".repeat(32);
+    let r = parser::message::<String>(payload.as_bytes()).unwrap();
+    assert_eq!("😀".repeat(32), r);
+
+    // A 100KiB String payload of smiley chars that is missing its inner length.
+    let payload = "😀".repeat(25600);
+    let r = parser::message::<String>(payload.as_bytes()).unwrap();
+    assert_eq!("😀".repeat(25600), r);
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

Inside parser::message(), when serde_bare::from_slice() fails to decode a payload we prepend the length of the payload to the payload and try again.

The length is prepended as an unsigned byte (u8). That does not match the BARE spec but works for payloads below 127 bytes.

## Proposed Changes

Use serde_bare to prepend the length as a BARE Uint data type.

Add a test for parser::message() that fails with the old code and passes with the new. 

Fixes #2236 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
