### PR TITLE
chore(rust): introduce transport type

### DIFF
--- a/implementations/rust/ockam/ockam/src/channel/mod.rs
+++ b/implementations/rust/ockam/ockam/src/channel/mod.rs
@@ -49,11 +49,13 @@ impl ChannelBuilder {
     /// ```
     pub async fn new(ctx: &Context) -> Result<Self> {
         debug!("Creating new ChannelBuilder context...");
-        ctx.new_context(Address::random(0)).await.map(|ctx| Self {
-            ctx,
-            tx_hooks: PipeBehavior::empty(),
-            rx_hooks: PipeBehavior::empty(),
-        })
+        ctx.new_context(Address::random_local())
+            .await
+            .map(|ctx| Self {
+                ctx,
+                tx_hooks: PipeBehavior::empty(),
+                rx_hooks: PipeBehavior::empty(),
+            })
     }
 
     /// Attach a new behavior to be used by the underlying pipe sender
@@ -76,7 +78,7 @@ impl ChannelBuilder {
 
     /// Connect to a channel listener
     pub async fn connect<R: Into<Route>>(&self, listener: R) -> Result<ChannelHandle> {
-        let tx = Address::random(0);
+        let tx = Address::random_local();
         ChannelWorker::stage1(
             &self.ctx,
             tx.clone(),

--- a/implementations/rust/ockam/ockam/src/channel/worker.rs
+++ b/implementations/rust/ockam/ockam/src/channel/worker.rs
@@ -48,14 +48,14 @@ impl ChannelWorker {
         tx_hooks: PipeBehavior,
         rx_hooks: PipeBehavior,
     ) -> Result<()> {
-        let pub_addr = Address::random(0);
+        let pub_addr = Address::random_local();
         ctx.start_worker(
             vec![int_addr.clone(), pub_addr.clone()],
             ChannelWorker {
                 stage: WorkerStage::Stage2,
                 listener: None,
-                tx_addr: Address::random(0),
-                rx_addr: Address::random(0),
+                tx_addr: Address::random_local(),
+                rx_addr: Address::random_local(),
                 peer_routes: Some((peer_tx_route, peer_rx_route)),
                 self_addrs: (pub_addr, int_addr),
                 peer_addr,
@@ -77,7 +77,7 @@ impl ChannelWorker {
         tx_hooks: PipeBehavior,
         rx_hooks: PipeBehavior,
     ) -> Result<()> {
-        let int_addr = Address::random(0);
+        let int_addr = Address::random_local();
         ctx.start_worker(
             vec![int_addr.clone(), pub_addr.clone()],
             ChannelWorker {
@@ -88,9 +88,9 @@ impl ChannelWorker {
                 // create an outgoing message cache in the channel
                 // endpoint and can instead use the PipeSender cache
                 // mechanism instead
-                peer_addr: Address::random(0),
-                rx_addr: Address::random(0),
-                tx_addr: Address::random(0),
+                peer_addr: Address::random_local(),
+                rx_addr: Address::random_local(),
+                tx_addr: Address::random_local(),
                 self_addrs: (pub_addr, int_addr),
                 tx_hooks,
                 rx_hooks,
@@ -146,7 +146,7 @@ impl ChannelWorker {
             self.tx_addr, self.rx_addr
         );
 
-        let rx_int = Address::random(0);
+        let rx_int = Address::random_local();
         PipeReceiver::create(
             ctx,
             self.rx_addr.clone(),
@@ -155,7 +155,7 @@ impl ChannelWorker {
         )
         .await?;
 
-        let tx_int = Address::random(0);
+        let tx_int = Address::random_local();
         PipeSender::uninitialized(
             ctx,
             self.tx_addr.clone(),
@@ -204,7 +204,7 @@ impl ChannelWorker {
         let (route_to_sender, route_to_receiver) = self.peer_routes.clone().unwrap();
 
         // Create a PipeReceiver
-        let rx_int_addr = Address::random(0);
+        let rx_int_addr = Address::random_local();
         PipeReceiver::create(
             ctx,
             self.rx_addr.clone(),
@@ -218,7 +218,7 @@ impl ChannelWorker {
             ctx,
             route_to_receiver.0,
             self.tx_addr.clone(),
-            Address::random(0),
+            Address::random_local(),
             self.tx_hooks.clone(),
         )
         .await?;

--- a/implementations/rust/ockam/ockam/src/delay.rs
+++ b/implementations/rust/ockam/ockam/src/delay.rs
@@ -12,7 +12,7 @@ pub(crate) struct DelayedEvent<M: Message> {
 impl<M: Message> DelayedEvent<M> {
     /// Create a new 100ms delayed message event
     pub(crate) async fn new(ctx: &Context, route: Route, msg: M) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
 
         debug!(
             "Creating a delayed event with address '{}'",

--- a/implementations/rust/ockam/ockam/src/forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/forwarder.rs
@@ -53,7 +53,7 @@ impl Forwarder {
         registration_payload: Vec<u8>,
     ) -> Result<()> {
         info!("Created new alias for {}", forward_route);
-        let address = Address::random(0);
+        let address = Address::random_local();
         let forwarder = Self {
             forward_route,
             payload: Some(registration_payload),

--- a/implementations/rust/ockam/ockam/src/pipe/listener.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/listener.rs
@@ -27,8 +27,8 @@ impl Worker for PipeListener {
                 info!("Creating new PipeReceiver for incoming handshake");
 
                 // Create a new pipe receiver with a modified behavioral stack
-                let recv_addr = Address::random(0);
-                let int_addr = Address::random(0);
+                let recv_addr = Address::random_local();
+                let int_addr = Address::random_local();
                 let hooks = self.hooks.clone().attach(HandshakeInit::default());
                 PipeReceiver::create(ctx, recv_addr.clone(), int_addr.clone(), hooks).await?;
 

--- a/implementations/rust/ockam/ockam/src/pipe/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/mod.rs
@@ -28,12 +28,12 @@ const CLUSTER_NAME: &str = "_internal.pipe";
 ///
 /// Returns the PipeSender's public address.
 pub async fn connect_static<R: Into<Route>>(ctx: &mut Context, recv: R) -> Result<Address> {
-    let addr = Address::random(0);
+    let addr = Address::random_local();
     PipeSender::create(
         ctx,
         recv.into(),
         addr.clone(),
-        Address::random(0),
+        Address::random_local(),
         PipeBehavior::empty(),
     )
     .await
@@ -52,12 +52,12 @@ where
     R: Into<Route>,
     P: Into<PipeBehavior>,
 {
-    let addr = Address::random(0);
+    let addr = Address::random_local();
     PipeSender::create(
         ctx,
         recv.into(),
         addr.clone(),
-        Address::random(0),
+        Address::random_local(),
         hooks.into(),
     )
     .await
@@ -66,8 +66,8 @@ where
 
 /// Connect to the pipe receive listener and then to a pipe receiver
 pub async fn connect_dynamic(ctx: &mut Context, listener: Route) -> Result<Address> {
-    let addr = Address::random(0);
-    let int_addr = Address::random(0);
+    let addr = Address::random_local();
+    let int_addr = Address::random_local();
 
     // Create an "uninitialised" PipeSender
     PipeSender::uninitialized(
@@ -85,7 +85,13 @@ pub async fn connect_dynamic(ctx: &mut Context, listener: Route) -> Result<Addre
 
 /// Create a receiver with a static address
 pub async fn receiver<I: Into<Address>>(ctx: &mut Context, addr: I) -> Result<()> {
-    PipeReceiver::create(ctx, addr.into(), Address::random(0), PipeBehavior::empty()).await
+    PipeReceiver::create(
+        ctx,
+        addr.into(),
+        Address::random_local(),
+        PipeBehavior::empty(),
+    )
+    .await
 }
 
 /// Create a new receiver with an explicit behavior manager
@@ -94,7 +100,7 @@ where
     A: Into<Address>,
     P: Into<PipeBehavior>,
 {
-    PipeReceiver::create(ctx, addr.into(), Address::random(0), b.into()).await
+    PipeReceiver::create(ctx, addr.into(), Address::random_local(), b.into()).await
 }
 
 /// Create a pipe receive listener with custom behavior
@@ -105,7 +111,7 @@ pub async fn listen_with_behavior<P: Into<PipeBehavior>>(
     ctx: &mut Context,
     hooks: P,
 ) -> Result<Address> {
-    let addr = Address::random(0);
+    let addr = Address::random_local();
     PipeListener::create_with_behavior(ctx, addr.clone(), hooks.into())
         .await
         .map(|_| addr)
@@ -116,7 +122,7 @@ pub async fn listen_with_behavior<P: Into<PipeBehavior>>(
 /// This special worker will create pipe receivers for any incoming
 /// connection.  The worker can simply be stopped via its address.
 pub async fn listen(ctx: &mut Context) -> Result<Address> {
-    let addr = Address::random(0);
+    let addr = Address::random_local();
     PipeListener::create(ctx, addr.clone()).await.map(|_| addr)
 }
 

--- a/implementations/rust/ockam/ockam/src/pipe2/listener.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/listener.rs
@@ -29,7 +29,7 @@ impl Worker for PipeListener {
         // First we need to re-address the worker system.  This means
         // using the same SystemHandler instances and routes, but with
         // new addresses to not cause collisions on this node.
-        let (init_addr, fin_addr) = (Address::random(0), Address::random(0));
+        let (init_addr, fin_addr) = (Address::random_local(), Address::random_local());
         let mut sys_builder = self.system.clone();
         sys_builder.readdress(&fin_addr);
 
@@ -40,7 +40,7 @@ impl Worker for PipeListener {
         let worker = PipeReceiver::new(system, fin_addr.clone(), Some(init_addr.clone()));
 
         // Finally start the worker with the full set of used addresses
-        let mut worker_addrs = vec![Address::random(0), init_addr.clone(), fin_addr];
+        let mut worker_addrs = vec![Address::random_local(), init_addr.clone(), fin_addr];
         worker_addrs.append(&mut system_addrs);
         ctx.start_worker(worker_addrs, worker).await?;
 

--- a/implementations/rust/ockam/ockam/src/pipe2/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/mod.rs
@@ -58,7 +58,7 @@ enum Mode {
 /// ```rust
 /// # use ockam::{Context, Result, Address, pipe2::PipeBuilder};
 /// # async fn pipes_example_no_run(ctx: &mut Context) -> Result<()> {
-/// # let (tcp_connection, my_pipe) = (Address::random(0), Address::random(0));
+/// # let (tcp_connection, my_pipe) = (Address::random_local(), Address::random_local());
 /// let result = PipeBuilder::fixed()
 ///     .connect(vec![tcp_connection, my_pipe])
 ///     .build(ctx)
@@ -78,7 +78,7 @@ enum Mode {
 /// ```rust
 /// # use ockam::{Context, Result, Address, pipe2::PipeBuilder};
 /// # async fn pipes_example_no_run(ctx: &mut Context) -> Result<()> {
-/// # let my_pipe = Address::random(0);
+/// # let my_pipe = Address::random_local();
 /// let receive = PipeBuilder::fixed()
 ///     .receive(my_pipe)
 ///     .build(ctx)
@@ -154,8 +154,8 @@ impl PipeBuilder {
             hooks: BTreeSet::new(),
             peer: None,
             recv: None,
-            tx_fin: Address::random(0),
-            rx_fin: Address::random(0),
+            tx_fin: Address::random_local(),
+            rx_fin: Address::random_local(),
             mode,
         }
     }
@@ -215,8 +215,8 @@ impl PipeBuilder {
         let mut send_hooks = SystemBuilder::new();
         let mut recv_hooks = SystemBuilder::new();
 
-        let (ord_tx_addr, ord_rx_addr) = (Address::random(0), Address::random(0));
-        let (ack_tx_addr, ack_rx_addr) = (Address::random(0), Address::random(0));
+        let (ord_tx_addr, ord_rx_addr) = (Address::random_local(), Address::random_local());
+        let (ack_tx_addr, ack_rx_addr) = (Address::random_local(), Address::random_local());
 
         // Setup ordering enforcement hooks
         if self.hooks.contains(&PipeHook::Ordering) {
@@ -287,7 +287,7 @@ impl PipeBuilder {
 
         // Create a sender
         if let Some(peer) = self.peer {
-            let addr = Address::random(0);
+            let addr = Address::random_local();
             tx_addr = Some(addr.clone());
             let mut addr_set = vec![addr.clone(), self.tx_fin.clone()];
             addr_set.append(&mut tx_sys.addresses());
@@ -327,7 +327,7 @@ impl PipeBuilder {
 
         if let Some(peer) = self.peer {
             let tx_sys = tx_sys.finalise(ctx).await?;
-            let (addr, init_addr) = (Address::random(0), Address::random(0));
+            let (addr, init_addr) = (Address::random_local(), Address::random_local());
             tx_addr = Some(addr.clone());
 
             let mut addr_set = vec![addr.clone(), init_addr.clone(), self.tx_fin.clone()];

--- a/implementations/rust/ockam/ockam/src/pipe2/tests.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/tests.rs
@@ -4,7 +4,7 @@ use ockam_core::{compat::string::String, Address, Result};
 #[crate::test]
 async fn very_simple_pipe2(ctx: &mut Context) -> Result<()> {
     info!("Starting the test...");
-    let rx_addr = Address::random(0);
+    let rx_addr = Address::random_local();
 
     // Start a static receiver
     let rx = PipeBuilder::fixed()
@@ -54,7 +54,7 @@ async fn handshake_pipe(ctx: &mut Context) -> Result<()> {
 
 #[crate::test]
 async fn fixed_delivery_pipe(ctx: &mut Context) -> Result<()> {
-    let rx_addr = Address::random(0);
+    let rx_addr = Address::random_local();
 
     // Start a static receiver
     let rx = PipeBuilder::fixed()
@@ -109,7 +109,7 @@ async fn dynamic_delivery_pipe(ctx: &mut Context) -> Result<()> {
 
 #[crate::test]
 async fn fixed_ordering_pipe(ctx: &mut Context) -> Result<()> {
-    let rx_addr = Address::random(0);
+    let rx_addr = Address::random_local();
 
     // Start a static receiver
     let rx = PipeBuilder::fixed()
@@ -139,7 +139,7 @@ async fn fixed_ordering_pipe(ctx: &mut Context) -> Result<()> {
 
 #[crate::test]
 async fn fixed_delivery_and_ordering_pipe(ctx: &mut Context) -> Result<()> {
-    let rx_addr = Address::random(0);
+    let rx_addr = Address::random_local();
 
     // Start a static receiver
     let rx = PipeBuilder::fixed()

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -300,7 +300,7 @@ mod test {
         let node_in_hub = (TCP, cloud_address);
         let remote_info = RemoteForwarder::create(ctx, node_in_hub.clone()).await?;
 
-        let mut child_ctx = ctx.new_context(Address::random(0)).await?;
+        let mut child_ctx = ctx.new_context(Address::random_local()).await?;
 
         child_ctx
             .send(
@@ -334,7 +334,7 @@ mod test {
         let node_in_hub = (TCP, cloud_address);
         let _ = RemoteForwarder::create_static(ctx, node_in_hub.clone(), "alias").await?;
 
-        let mut child_ctx = ctx.new_context(Address::random(0)).await?;
+        let mut child_ctx = ctx.new_context(Address::random_local()).await?;
 
         child_ctx
             .send(

--- a/implementations/rust/ockam/ockam/src/stream/mod.rs
+++ b/implementations/rust/ockam/ockam/src/stream/mod.rs
@@ -15,7 +15,10 @@ use crate::{
 use core::{ops::Deref, time::Duration};
 use ockam_core::compat::rand::{self, Rng};
 use ockam_core::compat::string::String;
-use ockam_core::{Decodable, RouteBuilder};
+use ockam_core::{Decodable, RouteBuilder, TransportType};
+
+/// Stream controller transport type.
+pub const STREAM: TransportType = TransportType::new(16);
 
 /// Ockam stream protocol controller
 ///
@@ -83,14 +86,16 @@ impl Stream {
     /// By default, the created stream will poll for new messages
     /// every 250 milliseconds.
     pub async fn new(ctx: &Context) -> Result<Self> {
-        ctx.new_context(Address::random(0)).await.map(|ctx| Self {
-            ctx,
-            interval: Duration::from_millis(250),
-            forwarding_address: None,
-            stream_service: "stream".into(),
-            index_service: "stream_index".into(),
-            client_id: None,
-        })
+        ctx.new_context(Address::random(STREAM))
+            .await
+            .map(|ctx| Self {
+                ctx,
+                interval: Duration::from_millis(250),
+                forwarding_address: None,
+                stream_service: "stream".into(),
+                index_service: "stream_index".into(),
+                client_id: None,
+            })
     }
 
     /// Customize the polling interval for the stream consumer
@@ -168,10 +173,10 @@ impl Stream {
         let receiver_name = receiver_name.into();
 
         // Generate two new random addresses
-        let receiver_address = Address::random(0);
-        let sender_address = Address::random(0);
+        let receiver_address = Address::random_local();
+        let sender_address = Address::random_local();
 
-        let receiver_rx = Address::random(0);
+        let receiver_rx = Address::random_local();
 
         // Generate a random client_id if one has not been provided
         let client_id = match self.client_id.clone() {

--- a/implementations/rust/ockam/ockam/src/system/builder.rs
+++ b/implementations/rust/ockam/ockam/src/system/builder.rs
@@ -162,7 +162,7 @@ where
         let addrs: BTreeMap<_, _> = self
             .inner
             .iter()
-            .map(|(_, data)| (data.addr.clone(), Address::random(0)))
+            .map(|(_, data)| (data.addr.clone(), Address::random_local()))
             .collect();
 
         // Small utility function that will either return the the new

--- a/implementations/rust/ockam/ockam/src/system/hooks/delivery.rs
+++ b/implementations/rust/ockam/ockam/src/system/hooks/delivery.rs
@@ -60,7 +60,7 @@ impl SystemHandler<Context, OckamMessage> for SenderConfirm {
             // For a message with no type we register a delayed event
             // and forward it to the next step in the system
             None => {
-                let ack_id = Address::random(0);
+                let ack_id = Address::random_local();
                 let inner_msg = msg.body();
                 let outer_msg = OckamMessage::wrap(inner_msg)?
                     .scope_data(ack_id.encode()?)

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -1,6 +1,6 @@
 use crate::{
     compat::{collections::VecDeque, string::String, vec::Vec},
-    Address, Result, RouteError,
+    Address, Result, RouteError, TransportType,
 };
 use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
@@ -17,8 +17,8 @@ impl Route {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::Route;
-    /// # pub const TCP: u8 = 1;
+    /// # use ockam_core::{Route, TransportType};
+    /// # pub const TCP: TransportType = TransportType::new(1);
     /// // ["1#alice", "0#bob"]
     /// let route: Route = Route::new()
     ///     .append_t(TCP, "alice")
@@ -36,8 +36,8 @@ impl Route {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{Address, Route};
-    /// # pub const TCP: u8 = 1;
+    /// # use ockam_core::{Address, Route, TransportType};
+    /// # pub const TCP: TransportType = TransportType::new(1);
     /// // ["1#alice", "0#bob"]
     /// let route: Route = vec![
     ///     Address::new(TCP, "alice"),
@@ -295,19 +295,18 @@ impl RouteBuilder<'_> {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{Route, RouteBuilder};
-    /// # pub const TCP: u8 = 1;
+    /// # use ockam_core::{Route, RouteBuilder, TransportType, LOCAL};
+    /// # pub const TCP: TransportType = TransportType::new(1);
     /// let builder: RouteBuilder = Route::new()
     ///     .append_t(TCP, "alice")
-    ///     .append_t(0, "bob");
+    ///     .append_t(LOCAL, "bob");
     ///
     /// // ["1#alice", "0#bob"]
     /// let route: Route = builder.into();
     /// ```
     ///
-    pub fn append_t<A: Into<String>>(mut self, t: u8, addr: A) -> Self {
-        self.inner
-            .push_back(format!("{}#{}", t, addr.into()).into());
+    pub fn append_t<A: Into<String>>(mut self, ty: TransportType, addr: A) -> Self {
+        self.inner.push_back(Address::from((ty, addr.into())));
         self
     }
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/src/main.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/src/main.rs
@@ -197,7 +197,7 @@ async fn main(ctx: Context) -> Result<()> {
     let available_inlet_ports =
         (config.available_inlet_port_start..config.available_inlet_port_end + 1).collect();
 
-    let internal_address = Address::random(0);
+    let internal_address = Address::random_local();
     let fabric_worker = TcpInletService::new(
         tcp.clone(),
         internal_address.clone(),

--- a/implementations/rust/ockam/ockam_identity/src/channel/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/secure_channel_worker.rs
@@ -87,7 +87,7 @@ impl<I: IdentityTrait, T: TrustPolicy> SecureChannelWorker<I, T> {
         trust_policy: T,
         vault: impl XXVault,
     ) -> Result<Address> {
-        let child_address = Address::random(0);
+        let child_address = Address::random_local();
         let mut child_ctx = ctx.new_context(child_address.clone()).await?;
 
         // Generate 2 random fresh address for newly created SecureChannel.
@@ -100,7 +100,7 @@ impl<I: IdentityTrait, T: TrustPolicy> SecureChannelWorker<I, T> {
             .initiator()
             .await?;
         // Create regular secure channel and set self address as first responder
-        let temp_ctx = ctx.new_context(Address::random(0)).await?;
+        let temp_ctx = ctx.new_context(Address::random_local()).await?;
         let self_remote_address_clone = self_remote_address.clone();
         let channel_future = Box::pin(async move {
             SecureChannel::create_extended(

--- a/implementations/rust/ockam/ockam_identity/src/credential/identity_credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/identity_credentials.rs
@@ -501,7 +501,11 @@ impl CredentialProtocol for Identity {
             .await
             .unwrap()
             .expect("no current identity");
-        let mut ctx = self.handle.ctx().new_context(Address::random(0)).await?;
+        let mut ctx = self
+            .handle
+            .ctx()
+            .new_context(Address::random_local())
+            .await?;
 
         let worker = HolderWorker::new(
             identity,
@@ -511,7 +515,7 @@ impl CredentialProtocol for Identity {
             values,
             ctx.address(),
         );
-        ctx.start_worker(Address::random(0), worker).await?;
+        ctx.start_worker(Address::random_local(), worker).await?;
 
         let res = ctx
             .receive_timeout::<CredentialAcquisitionResultMessage>(120 /* FIXME */)
@@ -535,7 +539,11 @@ impl CredentialProtocol for Identity {
             .expect("no current identity");
         let credential = self.get_credential(&credential).await?;
 
-        let mut ctx = self.handle.ctx().new_context(Address::random(0)).await?;
+        let mut ctx = self
+            .handle
+            .ctx()
+            .new_context(Address::random_local())
+            .await?;
         let worker = PresenterWorker::new(
             identity,
             verifier_route,
@@ -543,7 +551,7 @@ impl CredentialProtocol for Identity {
             reveal_attributes,
             ctx.address(),
         );
-        ctx.start_worker(Address::random(0), worker).await?;
+        ctx.start_worker(Address::random_local(), worker).await?;
 
         let _ = ctx
             .receive_timeout::<PresentationFinishedMessage>(120 /* FIXME */)
@@ -569,7 +577,11 @@ impl CredentialProtocol for Identity {
         let issuer = identity.get_contact(issuer_id).await?.unwrap();
         let pubkey = issuer.get_signing_public_key()?;
 
-        let mut ctx = self.handle.ctx().new_context(Address::random(0)).await?;
+        let mut ctx = self
+            .handle
+            .ctx()
+            .new_context(Address::random_local())
+            .await?;
         let worker = VerifierWorker::new(
             identity,
             pubkey.as_ref().try_into().unwrap(), // FIXME

--- a/implementations/rust/ockam/ockam_identity/src/credential/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/workers/listener.rs
@@ -56,7 +56,7 @@ impl Worker for ListenerWorker {
             return Err(IdentityError::IssuerListenerInvalidMessage.into());
         }
 
-        let address = Address::random(0);
+        let address = Address::random_local();
         let worker = IssuerWorker::new(
             self.identity.async_try_clone().await?,
             their_identity_id.clone(),

--- a/implementations/rust/ockam/ockam_identity/src/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity.rs
@@ -18,7 +18,7 @@ pub struct Identity<V: IdentityVault> {
 
 impl<V: IdentityVault> Identity<V> {
     pub async fn create(ctx: &Context, vault: &V) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
         let state = IdentityState::create(vault.async_try_clone().await?).await?;
         Ok(Self {
             ctx: child_ctx,

--- a/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
@@ -10,7 +10,7 @@ pub struct IdentityBuilder<V: IdentityVault> {
 
 impl<V: IdentityVault> IdentityBuilder<V> {
     pub async fn new(ctx: &Context, vault: &V) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
 
         Ok(Self {
             ctx: child_ctx,

--- a/implementations/rust/ockam/ockam_identity/src/worker/trust_policy_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/worker/trust_policy_worker.rs
@@ -18,7 +18,7 @@ impl TrustPolicyImpl {
 
 impl TrustPolicyImpl {
     pub async fn create_using_worker(ctx: &Context, address: &Address) -> Result<Self> {
-        let handle = Handle::new(ctx.new_context(Address::random(0)).await?, address.clone());
+        let handle = Handle::new(ctx.new_context(Address::random_local()).await?, address.clone());
 
         Ok(Self::new(handle))
     }
@@ -29,7 +29,7 @@ impl TrustPolicyImpl {
     }
 
     pub async fn create_worker(ctx: &Context, trust_policy: impl TrustPolicy) -> Result<Address> {
-        let address = Address::random(0);
+        let address = Address::random_local();
 
         ctx.start_worker(address.clone(), TrustPolicyWorker::new(trust_policy))
             .await?;

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -17,7 +17,7 @@ use core::time::Duration;
 use ockam_core::compat::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use ockam_core::{
     AccessControl, Address, AddressSet, AllowAll, AsyncTryClone, LocalMessage, Message, Processor,
-    Result, Route, TransportMessage, Worker,
+    Result, Route, TransportMessage, TransportType, Worker,
 };
 
 /// A default timeout in seconds
@@ -49,7 +49,7 @@ pub struct Context {
 #[ockam_core::async_trait]
 impl AsyncTryClone for Context {
     async fn async_try_clone(&self) -> Result<Self> {
-        self.new_context(Address::random(0)).await
+        self.new_context(Address::random_local()).await
     }
 }
 
@@ -640,7 +640,7 @@ impl Context {
     }
 
     /// Register a router for a specific address type
-    pub async fn register<A: Into<Address>>(&self, type_: u8, addr: A) -> Result<()> {
+    pub async fn register<A: Into<Address>>(&self, type_: TransportType, addr: A) -> Result<()> {
         self.register_impl(type_, addr.into()).await
     }
 
@@ -653,7 +653,7 @@ impl Context {
         Ok(())
     }
 
-    async fn register_impl(&self, type_: u8, addr: Address) -> Result<()> {
+    async fn register_impl(&self, type_: TransportType, addr: Address) -> Result<()> {
         let (tx, mut rx) = channel(1);
         self.sender
             .send(NodeMessage::Router(type_, addr, tx))

--- a/implementations/rust/ockam/ockam_node/src/delayed.rs
+++ b/implementations/rust/ockam/ockam_node/src/delayed.rs
@@ -26,7 +26,7 @@ impl<M: Message + Clone> DelayedEvent<M> {
         destination_addr: impl Into<Address>,
         msg: M,
     ) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
 
         let heartbeat = Self {
             ctx: child_ctx,
@@ -51,7 +51,7 @@ impl<M: Message + Clone> DelayedEvent<M> {
     pub async fn schedule(&mut self, duration: Duration) -> Result<()> {
         self.cancel();
 
-        let child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
         let destination_addr = self.destination_addr.clone();
         let msg = self.msg.clone();
 

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -2,7 +2,7 @@ use crate::tokio::sync::mpsc::{channel, Receiver, Sender};
 use crate::{error::Error, relay::RelayMessage, router::SenderPair};
 use core::fmt::Formatter;
 use ockam_core::compat::{string::String, vec::Vec};
-use ockam_core::{Address, AddressSet};
+use ockam_core::{Address, AddressSet, TransportType};
 
 /// Messages sent from the Node to the Executor
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub enum NodeMessage {
     /// Request the sender for a worker address
     SenderReq(Address, Sender<NodeReplyResult>),
     /// Register a new router for a route id type
-    Router(u8, Address, Sender<NodeReplyResult>),
+    Router(TransportType, Address, Sender<NodeReplyResult>),
     /// Message the router to set an address as "ready"
     SetReady(Address),
     /// Check whether an address has been marked as "ready"

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     NodeMessage, NodeReply, ShutdownType,
 };
 use ockam_core::compat::collections::BTreeMap;
-use ockam_core::{Address, Result};
+use ockam_core::{Address, Result, TransportType};
 
 /// A pair of senders to a worker relay
 #[derive(Debug)]
@@ -41,21 +41,21 @@ pub struct Router {
     /// Internal address state
     map: InternalMap,
     /// Externally registered router components
-    external: BTreeMap<u8, Address>,
+    external: BTreeMap<TransportType, Address>,
     /// Receiver for messages from node
     receiver: Receiver<NodeMessage>,
 }
 
 enum RouteType {
     Internal(Address),
-    External(u8),
+    External(TransportType),
 }
 
 fn determine_type(next: &Address) -> RouteType {
-    if next.tt == 0 {
+    if next.transport_type().is_local() {
         RouteType::Internal(next.clone())
     } else {
-        RouteType::External(next.tt)
+        RouteType::External(next.transport_type())
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/router/utils.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/utils.rs
@@ -2,7 +2,7 @@ use super::Router;
 use crate::tokio::sync::mpsc::Sender;
 use crate::{error::Error, NodeReply, NodeReplyResult, Reason};
 
-use ockam_core::{Address, Result};
+use ockam_core::{Address, Result, TransportType};
 
 /// Receive an address and resolve it to a sender
 ///
@@ -48,7 +48,7 @@ pub(super) async fn resolve(
     .map_err(|_| Error::InternalIOFailure.into())
 }
 
-pub(super) fn router_addr(router: &mut Router, tt: u8) -> Result<Address> {
+pub(super) fn router_addr(router: &mut Router, tt: TransportType) -> Result<Address> {
     router
         .external
         .get(&tt)

--- a/implementations/rust/ockam/ockam_transport_ble/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/lib.rs
@@ -40,11 +40,13 @@ mod transport;
 mod types;
 mod workers;
 
+use ockam_core::TransportType;
+
 pub use driver::{BleClient, BleServer};
 pub use transport::BleTransport;
 pub use types::*;
 
 /// BLE address type constant
-pub const BLE: u8 = 4;
+pub const BLE: TransportType = TransportType::new(4);
 
 pub(crate) const CLUSTER_NAME: &str = "_internals.transport.ble";

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
@@ -24,7 +24,7 @@ pub(crate) struct BleRouterHandle {
 #[async_trait]
 impl AsyncTryClone for BleRouterHandle {
     async fn async_try_clone(&self) -> Result<Self> {
-        let child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
         Ok(Self::new(child_ctx, self.api_addr.clone()))
     }
 }

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -41,7 +41,7 @@ pub struct BleRouter {
 
 impl BleRouter {
     async fn create_self_handle(&self, ctx: &Context) -> Result<BleRouterHandle> {
-        let handle_ctx = ctx.new_context(Address::random(0)).await?;
+        let handle_ctx = ctx.new_context(Address::random_local()).await?;
         let handle = BleRouterHandle::new(handle_ctx, self.api_addr.clone());
         Ok(handle)
     }
@@ -135,11 +135,11 @@ impl BleRouter {
     /// To also handle incoming connections, use
     /// [`BleRouter::bind`](BleRouter::bind)
     pub(crate) async fn register(ctx: &Context) -> Result<BleRouterHandle> {
-        let main_addr = Address::random(0);
-        let api_addr = Address::random(0);
+        let main_addr = Address::random_local();
+        let api_addr = Address::random_local();
         debug!("Registering new BleRouter with address {}", &main_addr);
 
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
         let router = Self {
             _ctx: child_ctx,
             main_addr: main_addr.clone(),

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/listener.rs
@@ -32,7 +32,7 @@ where
             inner: Some(ble_server),
             router_handle,
         };
-        let waddr = Address::random(0);
+        let waddr = Address::random_local();
 
         debug!(
             "BleListenProcessor::start Starting processor with address: {:?}",

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
@@ -59,7 +59,7 @@ where
     ) -> Result<WorkerPair> {
         debug!("Creating new BLE worker pair");
 
-        let tx_addr = Address::random(0);
+        let tx_addr = Address::random_local();
         let sender = BleSendWorker::new(stream, peer.clone());
 
         debug!("start send worker({:?})", tx_addr.clone());
@@ -87,7 +87,7 @@ where
         debug!("initialize for peer: {:?}", self.peer);
 
         if let Some(rx_stream) = self.rx_stream.take() {
-            let rx_addr = Address::random(0);
+            let rx_addr = Address::random_local();
             let receiver =
                 BleRecvProcessor::new(rx_stream, format!("{}#{}", crate::BLE, self.peer).into());
             ctx.start_processor(rx_addr.clone(), receiver).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -38,11 +38,11 @@ mod transport;
 pub use transport::*;
 
 use ockam_core::compat::net::SocketAddr;
-use ockam_core::Result;
+use ockam_core::{Result, TransportType};
 use ockam_transport_core::TransportError;
 
 /// TCP address type constant
-pub const TCP: u8 = 1;
+pub const TCP: TransportType = TransportType::new(1);
 
 pub(crate) const CLUSTER_NAME: &str = "_internals.transport.tcp";
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -18,7 +18,7 @@ impl TcpInletListenProcessor {
         outlet_listener_route: Route,
         addr: SocketAddr,
     ) -> Result<Address> {
-        let waddr = Address::random(0);
+        let waddr = Address::random_local();
 
         debug!("Binding TcpPortalListenerWorker to {}", addr);
         let inner = TcpListener::bind(addr)

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
@@ -79,9 +79,9 @@ impl TcpPortalWorker {
         stream: Option<TcpStream>,
         type_name: TypeName,
     ) -> Result<Address> {
-        let internal_addr = Address::random(0);
-        let remote_addr = Address::random(0);
-        let receiver_address = Address::random(0);
+        let internal_addr = Address::random_local();
+        let remote_addr = Address::random_local();
+        let receiver_address = Address::random_local();
 
         info!(
             "Creating new {:?} at internal: {}, remote: {}",

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -25,7 +25,7 @@ impl TcpRouterHandle {
 #[async_trait]
 impl AsyncTryClone for TcpRouterHandle {
     async fn async_try_clone(&self) -> Result<Self> {
-        let child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
         Ok(Self::new(child_ctx, self.api_addr.clone()))
     }
 }
@@ -48,7 +48,7 @@ impl TcpRouterHandle {
         );
         let self_addr = pair.tx_addr();
 
-        let mut child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
         child_ctx
             .send(
                 self.api_addr.clone(),
@@ -71,7 +71,7 @@ impl TcpRouterHandle {
 
     /// Unregister
     pub async fn unregister(&self, self_addr: Address) -> Result<()> {
-        let mut child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
 
         child_ctx
             .send(
@@ -148,7 +148,7 @@ impl TcpRouterHandle {
 
     /// Establish an outgoing TCP connection on an existing transport
     pub async fn connect<S: AsRef<str>>(&self, peer: S) -> Result<Address> {
-        let mut child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
 
         child_ctx
             .send(
@@ -173,7 +173,7 @@ impl TcpRouterHandle {
     }
 
     pub async fn disconnect<S: AsRef<str>>(&self, peer: S) -> Result<()> {
-        let mut child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
 
         child_ctx
             .send(

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/mod.rs
@@ -31,7 +31,7 @@ pub(crate) struct TcpRouter {
 
 impl TcpRouter {
     async fn create_self_handle(&self) -> Result<TcpRouterHandle> {
-        let handle_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let handle_ctx = self.ctx.new_context(Address::random_local()).await?;
         let handle = TcpRouterHandle::new(handle_ctx, self.api_addr.clone());
         Ok(handle)
     }
@@ -206,11 +206,11 @@ impl TcpRouter {
     /// To also handle incoming connections, use
     /// [`TcpRouter::bind`](TcpRouter::bind)
     pub async fn register(ctx: &Context) -> Result<TcpRouterHandle> {
-        let main_addr = Address::random(0);
-        let api_addr = Address::random(0);
+        let main_addr = Address::random_local();
+        let api_addr = Address::random_local();
         debug!("Initialising new TcpRouter with address {}", &main_addr);
 
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
 
         let router = Self {
             ctx: child_ctx,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
@@ -18,7 +18,7 @@ impl TcpListenProcessor {
         router_handle: TcpRouterHandle,
         addr: SocketAddr,
     ) -> Result<()> {
-        let waddr = Address::random(0);
+        let waddr = Address::random_local();
 
         debug!("Binding TcpListener to {}", addr);
         let inner = TcpListener::bind(addr)

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -93,8 +93,8 @@ impl TcpSendWorker {
     ) -> Result<WorkerPair> {
         trace!("Creating new TCP worker pair");
 
-        let tx_addr = Address::random(0);
-        let internal_addr = Address::random(0);
+        let tx_addr = Address::random_local();
+        let internal_addr = Address::random_local();
         let sender = TcpSendWorker::new(
             router_handle,
             stream,
@@ -177,7 +177,7 @@ impl Worker for TcpSendWorker {
 
         let rx = self.rx.take().ok_or(TransportError::GenericIo)?;
 
-        let rx_addr = Address::random(0);
+        let rx_addr = Address::random_local();
         let receiver = TcpRecvProcessor::new(
             rx,
             format!("{}#{}", crate::TCP, self.peer).into(),

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -19,7 +19,7 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
     };
 
     let _sender = {
-        let mut ctx = ctx.new_context(Address::random(0)).await?;
+        let mut ctx = ctx.new_context(Address::random_local()).await?;
         let msg: String = {
             let mut rng = rand::thread_rng();
             iter::repeat(())
@@ -64,7 +64,7 @@ async fn tcp_lifecycle__reconnect__should_not_error(ctx: &mut Context) -> Result
     let transport = TcpTransport::create(ctx).await?;
     transport.listen(bind_address).await?;
 
-    let mut child_ctx = ctx.new_context(Address::random(0)).await?;
+    let mut child_ctx = ctx.new_context(Address::random_local()).await?;
     let msg: String = {
         let mut rng = rand::thread_rng();
         iter::repeat(())

--- a/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
@@ -30,7 +30,7 @@ extern crate tracing;
 use std::net::SocketAddr;
 
 pub use error::WebSocketError;
-use ockam_core::Result;
+use ockam_core::{Result, TransportType};
 use ockam_transport_core::TransportError;
 pub use transport::*;
 
@@ -42,7 +42,7 @@ mod transport;
 mod workers;
 
 /// WebSocket address type constant
-pub const WS: u8 = 3;
+pub const WS: TransportType = TransportType::new(3);
 
 pub(crate) const CLUSTER_NAME: &str = "_internals.transport.ws";
 

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/handle.rs
@@ -19,7 +19,7 @@ pub(crate) struct WebSocketRouterHandle {
 #[async_trait]
 impl AsyncTryClone for WebSocketRouterHandle {
     async fn async_try_clone(&self) -> Result<Self> {
-        let child_ctx = self.ctx.new_context(Address::random(0)).await?;
+        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
         Ok(Self::new(child_ctx, self.api_addr.clone()))
     }
 }

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
@@ -43,7 +43,7 @@ pub struct WebSocketRouter {
 
 impl WebSocketRouter {
     async fn create_self_handle(&self, ctx: &Context) -> Result<WebSocketRouterHandle> {
-        let handle_ctx = ctx.new_context(Address::random(0)).await?;
+        let handle_ctx = ctx.new_context(Address::random_local()).await?;
         let handle = WebSocketRouterHandle::new(handle_ctx, self.api_addr.clone());
         Ok(handle)
     }
@@ -139,14 +139,14 @@ impl WebSocketRouter {
     /// To also handle incoming connections, use
     /// [`WebSocketRouter::bind`](WebSocketRouter::bind)
     pub(crate) async fn register(ctx: &Context) -> Result<WebSocketRouterHandle> {
-        let main_addr = Address::random(0);
-        let api_addr = Address::random(0);
+        let main_addr = Address::random_local();
+        let api_addr = Address::random_local();
         debug!(
             "Initialising new WebSocketRouter with address {}",
             &main_addr
         );
 
-        let child_ctx = ctx.new_context(Address::random(0)).await?;
+        let child_ctx = ctx.new_context(Address::random_local()).await?;
 
         let router = Self {
             ctx: child_ctx,

--- a/implementations/rust/ockam/ockam_transport_websocket/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/workers/listener.rs
@@ -28,7 +28,7 @@ impl WebSocketListenProcessor {
             inner,
             router_handle,
         };
-        let waddr = Address::random(0);
+        let waddr = Address::random_local();
         ctx.start_processor(waddr, processor).await?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_transport_websocket/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/workers/sender.rs
@@ -43,7 +43,7 @@ impl WorkerPair {
     {
         trace!("Creating new WS worker pair");
 
-        let internal_addr = Address::random(0);
+        let internal_addr = Address::random_local();
         let (ws_sink, ws_stream) = stream.split();
         let sender = WebSocketSendWorker::new(
             ws_sink,
@@ -52,11 +52,11 @@ impl WorkerPair {
             DelayedEvent::create(ctx, internal_addr.clone(), vec![]).await?,
         );
 
-        let tx_addr = Address::random(0);
+        let tx_addr = Address::random_local();
         ctx.start_worker(vec![tx_addr.clone(), internal_addr], sender)
             .await?;
 
-        let rx_addr = Address::random(0);
+        let rx_addr = Address::random_local();
         let receiver = WebSocketRecvProcessor::new(ws_stream, peer);
         ctx.start_processor(rx_addr.clone(), receiver).await?;
 

--- a/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
@@ -18,7 +18,7 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
     };
 
     let _sender = {
-        let mut ctx = ctx.new_context(Address::random(0)).await?;
+        let mut ctx = ctx.new_context(Address::random_local()).await?;
         let msg: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
             .take(256)


### PR DESCRIPTION
## Current Behaviour

`ockam_core::Address` has a public field `tt` of type `u8` which represents the transport type.

## Proposed Changes

The field is no longer public and a separate type `TransportType` is introduced. This should make the use of the transport type more type-safe. A common case is creating random local addresses, previously done with `Address::random(0)`. To help with this and to not require an extra import of a local `TransportType`, `Address::random_local()` can be used.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

