### PR TITLE
WIP chore(rust): update no_std example project

### DIFF
--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
@@ -33,22 +33,30 @@ cortexm = [
     "cortex-m",
     "cortex-m-rt",
     "cortex-m-semihosting",
-    "panic-semihosting"
+    "panic-semihosting",
+    "log-semihosting",
+    "tracing",
+    "ockam_core/no_std"
 ]
 
 qemu = ["no_std", "alloc", "cortexm"]
 atsame54 = ["no_std", "alloc", "cortexm", "atsame54_xpro"]
 stm32f4 = ["no_std", "alloc", "cortexm", "stm32f4xx-hal"]
 
+log-itm = []
+log-semihosting = []
+log-uart = []
 
 [dependencies]
 ockam = { path = "../../../ockam", default_features = false, features = ["software_vault"] }
+ockam_core = { path = "../../../ockam_core", default_features = false, optional = true }
 
 alloc-cortex-m = { version = "0.4.1", optional = true }
 cortex-m = { version = "0.7.2", optional = true }
 cortex-m-rt = { version = "0.6.14", optional = true }
 cortex-m-semihosting = { version = "0.3.7", optional = true }
 panic-semihosting = { version = "0.5.6", optional = true }
+tracing = { version = "0.1", default-features = false, optional = true }
 
 atsame54_xpro = { version = "0.2.0", optional = true }
 stm32f4xx-hal = { version = "0.9.0", features = ["rt", "stm32f407"], optional = true }

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/01-node.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/01-node.rs
@@ -12,10 +12,7 @@ mod allocator;
 use panic_semihosting as _;
 
 #[cfg(feature = "cortexm")]
-use cortex_m_semihosting::debug;
-
-#[cfg(feature = "cortexm")]
-use ockam::println;
+use ockam_core::println;
 
 #[cfg(feature = "atsame54")]
 use atsame54_xpro as _;
@@ -26,10 +23,31 @@ use stm32f4xx_hal as _;
 #[cfg(feature = "cortexm")]
 #[cortex_m_rt::entry]
 fn entry() -> ! {
+    // initialize allocator
     #[cfg(feature = "alloc")]
     allocator::init();
 
-    main().unwrap();
+    // register tracing subscriber
+    #[cfg(feature = "cortexm")]
+    {
+        use hello_ockam_no_std::tracing_subscriber;
+        tracing_subscriber::register();
+    }
+
+    // execute main program entry point
+    match main() {
+        Ok(_) => (),
+        Err(e) => {
+            println!("Error executing main program entry point: {:?}", e);
+        }
+    }
+
+    // exit qemu
+    #[cfg(feature = "cortexm")]
+    {
+        use cortex_m_semihosting::debug;
+        debug::exit(debug::EXIT_SUCCESS);
+    }
 
     loop { }
 }
@@ -41,16 +59,9 @@ use ockam::{Context, Result};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
-
     // Stop the node as soon as it starts.
     println!("Stop the node as soon as it starts.");
     let result = ctx.stop().await;
-
-    // exit qemu
-    #[cfg(feature = "cortexm")]
-    {
-        debug::exit(debug::EXIT_SUCCESS);
-    }
 
     result
 }

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/echoer.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/echoer.rs
@@ -4,8 +4,9 @@ use ockam::{
         boxed::Box,
         string::String
     },
-    println
 };
+#[cfg(all(not(feature = "std"), feature = "cortexm"))]
+use ockam_core::println;
 use ockam::{Context, Result, Routed, Worker};
 
 pub struct Echoer;

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/hop.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/hop.rs
@@ -1,8 +1,9 @@
 #[cfg(all(not(feature = "std"), feature = "cortexm"))]
 use ockam::{
     compat::boxed::Box,
-    println
 };
+#[cfg(all(not(feature = "std"), feature = "cortexm"))]
+use ockam_core::println;
 use ockam::{Any, Context, Result, Routed, Worker};
 
 pub struct Hop;

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/lib.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/lib.rs
@@ -1,9 +1,9 @@
-//#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(not(feature = "std"), feature = "cortexm"), no_std)]
-
 
 mod echoer;
 pub use echoer::*;
 
 mod hop;
 pub use hop::*;
+
+pub mod tracing_subscriber;

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/tracing_subscriber.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/src/tracing_subscriber.rs
@@ -1,0 +1,244 @@
+/// A simple tracing_subscriber implementation for no_std targets
+
+use tracing::{
+    Event,
+    Id,
+    Metadata,
+    Subscriber,
+    dispatcher::Dispatch,
+    field::{self, Field},
+    span::{Attributes, Record}
+};
+
+
+// - tracing_println ----------------------------------------------------------
+
+#[macro_export]
+macro_rules! tracing_println {
+    ($($arg:tt)*) => {{
+        // dummy logger
+        #[cfg(not(any(feature="log-itm", feature="log-semihosting", feature="log-uart")))]
+        {
+            use ockam_core::compat::io::Write;
+            let mut buffer = [0 as u8; 1];
+            let mut cursor = ockam_core::compat::io::Cursor::new(&mut buffer[..]);
+
+            match write!(&mut cursor, $($arg)*) {
+                Ok(()) => (),
+                Err(_) => (),
+            }
+        }
+
+        // itm logger
+        #[cfg(feature="log-itm")]
+        {
+            // give the itm buffer time to empty
+            cortex_m::asm::delay(350_000);
+            // print output using itm peripheral
+            let itm = unsafe { &mut *cortex_m::peripheral::ITM::ptr() };
+            cortex_m::iprintln!(&mut itm.stim[0], $($arg)*);
+        }
+
+        // semihosting logger
+        #[cfg(feature="log-semihosting")]
+        cortex_m_semihosting::hprintln!($($arg)*).unwrap();
+
+        // uart logger
+        #[cfg(all(feature="log-uart", feature="atsame54"))]
+        {
+            use atsame54_xpro as hal;
+            use hal::prelude::_embedded_hal_serial_Write;
+            cortex_m::asm::delay(500_000);
+            crate::uart_println!($($arg)*);
+        }
+    }};
+}
+
+
+// - registration -------------------------------------------------------------
+
+pub fn register() {
+    let subscriber = EmbeddedSubscriber::new();
+    let dispatch = Dispatch::new(subscriber);
+    tracing::dispatcher::set_global_default(dispatch)
+        .expect("global default dispatcher for tracing is already set");
+    tracing::debug!("tracing_subscriber::register initialized");
+}
+
+#[cfg(feature="log-uart")]
+pub fn register_with_uart(uart: uart::Uart) {
+    unsafe { uart::UART.replace(uart); }
+
+    let subscriber = EmbeddedSubscriber::new();
+    let dispatch = Dispatch::new(subscriber);
+    tracing::dispatcher::set_global_default(dispatch)
+        .expect("global default dispatcher for tracing is already set");
+    tracing::debug!("tracing_subscriber::register_with_uart initialized");
+}
+
+
+// - EmbeddedSubscriber -------------------------------------------------------
+
+// TODO add a SubscriberBuilder so we can set log levels etc.
+//
+// See: https://docs.rs/tracing-subscriber/0.3.3/tracing_subscriber/fmt/struct.Subscriber.html
+//      tracing.git/tracing-subscriber/src/fmt/format/pretty.rs
+
+struct EmbeddedSubscriber;
+
+impl EmbeddedSubscriber {
+    fn new() -> Self {
+        Self
+    }
+}
+
+
+impl Subscriber for EmbeddedSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        crate::tracing_println!("EmbeddedSubscriber::new_span");
+        tracing::span::Id::from_u64(0xAAAA)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {
+        crate::tracing_println!("EmbeddedSubscriber::record");
+    }
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {
+        crate::tracing_println!("EmbeddedSubscriber::record_follows_from");
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = EmbeddedVisitor::new();
+        event.record(&mut visitor);
+    }
+
+    fn enter(&self, _span: &Id) {
+        crate::tracing_println!("EmbeddedSubscriber::enter");
+    }
+
+    fn exit(&self, _span: &Id) {
+        crate::tracing_println!("EmbeddedSubscriber::exit");
+    }
+}
+
+
+// - EmbeddedVisitor ----------------------------------------------------------
+
+struct EmbeddedVisitor;
+
+impl EmbeddedVisitor {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl field::Visit for EmbeddedVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            crate::tracing_println!("{}", value);
+        } else {
+            crate::tracing_println!("unknown: {}: {:?}", field.name(), value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+        if field.name() == "message" {
+            crate::tracing_println!("{:?}", value);
+        } else {
+            crate::tracing_println!("unknown: {}: {:?}", field.name(), value);
+        }
+    }
+}
+
+
+
+// - Support for UART logging -------------------------------------------------
+
+// TODO this needs to be generic across Uart
+
+#[cfg(feature="log-uart")]
+use crate::tracing_subscriber::uart::BufferWriter;
+
+#[cfg(feature="log-uart")]
+use core::fmt::Write;
+
+#[cfg(all(feature="log-uart", feature="atsame54"))]
+pub(crate) mod uart {
+    use atsame54_xpro as hal;
+    use hal::gpio::v2::{Pin, PA04, PA05};
+    use hal::sercom::v2::{IoSet3, Sercom0, uart};
+
+    type Rx = Pin<PA05, hal::gpio::v2::AlternateD>;
+    type Tx = Pin<PA04, hal::gpio::v2::AlternateD>;
+    type Pads = uart::Pads<Sercom0, IoSet3, Rx, Tx>;
+    type Config = uart::Config<Pads, uart::EightBit>;
+
+    pub(crate) type Uart = uart::Uart<Config, uart::Duplex>;
+
+    pub(crate) static mut UART: Option<Uart> = None;
+
+    #[macro_export]
+    macro_rules! uart_println {
+        ($($arg:tt)*) => {{
+            if let Some(uart) = unsafe { uart::UART.as_mut() } {
+                let mut buffer = [0u8; 512];
+                let mut buffer = BufferWriter::new(&mut buffer[..]);
+                writeln!(&mut buffer,  $($arg)*).unwrap();
+                for byte in buffer.as_bytes() {
+                    // NOTE `block!` blocks until `uart.write()` completes and returns
+                    // `Result<(), Error>`
+                    match ::nb::block!(uart.write(*byte)) {
+                        Ok(()) => (),
+                        Err(_) => {
+                            cortex_m::asm::delay(10_000);
+                        },
+                    }
+                }
+            }
+        }};
+    }
+
+    // - BufferWriter ---------------------------------------------------------
+
+    pub struct BufferWriter<'a> {
+        buffer: &'a mut [u8],
+        cursor: usize,
+    }
+
+    #[allow(dead_code)]
+    impl<'a> BufferWriter<'a> {
+        pub fn new(buffer: &'a mut [u8]) -> Self {
+            BufferWriter { buffer, cursor: 0 }
+        }
+
+        pub fn reset(&mut self) {
+            self.cursor = 0;
+        }
+
+        pub fn as_bytes(&self) -> &[u8] {
+            &self.buffer[0..self.cursor]
+        }
+
+        pub fn as_str(&self) -> &str {
+            core::str::from_utf8(&self.buffer[0..self.cursor]).unwrap()
+        }
+    }
+
+    impl core::fmt::Write for BufferWriter<'_> {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            let len = self.buffer.len();
+            for (i, &b) in self.buffer[self.cursor..len]
+                .iter_mut()
+                .zip(s.as_bytes().iter())
+            {
+                *i = b;
+            }
+            self.cursor = usize::min(len, self.cursor + s.as_bytes().len());
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
This PR brings the `no_std` example project in `implementations/rust/ockam/ockam_examples/example_projects/no_std` up to date with the latest Ockam changes.

TODO

[x] 🚑 get project working again with latest `develop` branch
[ ] ♻️ refactor dependencies, Cargo features and tracing-subscriber after the `antoinevg/embedded-rust` branch has landed