### PR TITLE
Only test macro error output against the stable version of rust (rather than both stable and nightly)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -227,4 +227,6 @@ jobs:
       - run: rustup default nightly
       - run: rustup update nightly
       - run: cd implementations/rust && ../../gradlew test
+        env:
+          NIGHTLY_CI: 1
       - uses: ./.github/actions/cargo_target_dir_pre_cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,6 +191,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: rustup default nightly
+      - run: rustup update nightly
       - run: RUSTFLAGS='-Dwarnings' cargo check
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
@@ -207,6 +208,7 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: rustup default nightly
+      - run: rustup update nightly
       - run: cd implementations/rust && ../../gradlew build
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
@@ -223,5 +225,6 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: rustup default nightly
+      - run: rustup update nightly
       - run: cd implementations/rust && ../../gradlew test
       - uses: ./.github/actions/cargo_target_dir_pre_cache

--- a/implementations/rust/ockam/ockam/tests/main.rs
+++ b/implementations/rust/ockam/ockam/tests/main.rs
@@ -15,7 +15,31 @@ fn node() {
     #[cfg(feature = "std")]
     {
         let t = trybuild::TestCases::new();
-        t.compile_fail("tests/node/std/fail*.rs");
+        // The compile_fail tests include exact compiler error output. This can
+        // differ between rust versions (for example, nightly rustc could have
+        // improvements to error reporting which have not yet made it to stable).
+        //
+        // In this case, we'd have no way for both stable and nightly to have
+        // passing CI. There are a few ways this could be approached, but the one we
+        // take is just to only run the compile_fail trybuild tests against one Rust
+        // version in CI.
+        //
+        // This means we must pick between stable and nightly for these tests. While
+        // I don't think we have reason to believe the choice makes much of a
+        // difference in practice, we choose stable:
+        // - There are more users who use the stable version of Rust than on a
+        //   nightly build, so we care more what the error messages look like on
+        //   that version.
+        // - Stable is updated less frequently, and is hopefully aptly named, so
+        //   this should let us avoid churn in cases where the `rustc` developers
+        //   are iterating on some aspect of error messaging.
+        // - Choosing stable avoids us needing contributors to install nightly rust
+        //   if they need to rebuild the trybuild output files, which would be an
+        //   unnecessarly contribution roadblock.
+
+        if std::env::var_os("NIGHTLY_CI").is_none() {
+            t.compile_fail("tests/node/std/fail*.rs");
+        }
         t.pass("tests/node/std/pass*.rs");
         // Untested cases:
         //  - Empty body or unused context: this two cases can't be tested because
@@ -27,6 +51,9 @@ fn node() {
 #[test]
 fn node_test() {
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/node_test/fail*.rs");
+    // see the other use of `NIGHTLY_CI` for explanation.
+    if std::env::var_os("NIGHTLY_CI").is_none() {
+        t.compile_fail("tests/node_test/fail*.rs");
+    }
     t.pass("tests/node_test/pass*.rs");
 }


### PR DESCRIPTION
Closes #2639 
Because it includes it.

This has a long comment explaining the motivation.
