### PR TITLE
chore(rust): crate release ockam version 0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "arrayref",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "futures 0.3.21",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "ockam-ffi"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "lazy_static",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_identity"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "ockam_core",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "hex",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "hashbrown 0.9.1",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_ble"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "atsame54_xpro",
  "bluenrg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.52.0 - 2022-04-11
+
+### Added
+
+- Add docs and rename some of the request/response types in `ockam`
+- Add "crate" attribute to "node" macro
+
+### Changed
+
+- Get rid of common `RouterMessage` in favor of transport-specific structs (ble, ws)
+- Reorganize and document `ockam` crate
+- Tune up some of the documentation
+- Rename `mod remote_forwarder` module to `mod remote`, fix examples
+- Ensure more documentation ends up in the right place
+- Implement miniature `ockam` command for demo
+- Re-export `DelayedEvent` from ockam crate
+- Vault updates
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Fix clippy warnings
+
 ## 0.51.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -98,7 +98,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.46.0", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.47.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.41.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -94,7 +94,7 @@ path = "tests/main.rs"
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -96,7 +96,7 @@ path = "tests/main.rs"
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.47.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
@@ -116,7 +116,7 @@ hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -97,7 +97,7 @@ ockam_core = { path = "../ockam_core", version = "^0.50.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.46.0", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.46.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -101,7 +101,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_featur
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.46.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default_features = false, optional = true }
-ockam_identity = { path = "../ockam_identity", version = "^0.40.0", default_features = false }
+ockam_identity = { path = "../ockam_identity", version = "^0.41.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.36.0", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.51.0"
+version = "0.52.0"
 rust-version = "1.56.0"
 publish = true
 

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -100,7 +100,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features =
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.46.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.41.0", default_features = false }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
@@ -117,7 +117,7 @@ dyn-clone = "1.0"
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -93,7 +93,7 @@ name = "tests"
 path = "tests/main.rs"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -99,7 +99,7 @@ ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = f
 ockam_vault = { path = "../ockam_vault", version = "^0.44.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.47.0", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.42.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.41.0", default_features = false }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -95,7 +95,7 @@ path = "tests/main.rs"
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.46.0", optional = true }

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -68,7 +68,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.51.0"
+ockam = "0.52.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.47.0 - 2022-04-11
+
+### Changed
+
+- Implement miniature `ockam` command for demo
+- Vault updates
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Fix clippy warnings
+
 ## 0.46.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -66,7 +66,7 @@ alloc = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -79,7 +79,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0"}
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.42.0"}
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.43.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -70,14 +70,14 @@ ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.43.0"}
 trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.46.0"
+version = "0.47.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -67,7 +67,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.42.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.44.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -65,7 +65,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -68,7 +68,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
@@ -78,7 +78,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0"}
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.43.0"}
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -69,7 +69,7 @@ ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.46.0"
+ockam_channel = "0.47.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 - 2022-04-11
+
+### Added
+
+- Add session management
+- Add session management to cli
+
+### Changed
+
+- Vault updates
+- Make `Identity` trait immutable
+- Updated dependencies
+
+### Fixed
+
+- Ensure that the command supports `OCKAM_LOG`
+- Fix session ids handling in `ockam_command`
+
 ## 0.11.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -43,5 +43,5 @@ rand = "0.8"
 async-recursion = { version = "1.0.0" }
 
 ockam = { path = "../ockam", version = "^0.52.0", features = ["software_vault"] }
-ockam_vault = { path = "../ockam_vault", version = "0.43.0", features = ["storage"] }
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -44,4 +44,4 @@ async-recursion = { version = "1.0.0" }
 
 ockam = { path = "../ockam", version = "^0.52.0", features = ["software_vault"] }
 ockam_vault = { path = "../ockam_vault", version = "0.43.0", features = ["storage"] }
-ockam_core = { path = "../ockam_core", version = "0.50.0" }
+ockam_core = { path = "../ockam_core", version = "^0.51.0"}

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -42,6 +42,6 @@ serde = { version = "1", features = ["derive"] }
 rand = "0.8"
 async-recursion = { version = "1.0.0" }
 
-ockam = { path = "../ockam", version = "0.51.0", features = ["software_vault"] }
+ockam = { path = "../ockam", version = "^0.52.0", features = ["software_vault"] }
 ockam_vault = { path = "../ockam_vault", version = "0.43.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "0.50.0" }

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.51.0 - 2022-04-11
+
+### Changed
+
+- Get rid of common `RouterMessage` in favor of transport-specific structs (ble, ws)
+- Make `ockam_core::Error` derive `Eq` and `PartialEq`
+- Don't re-export `hex` or `hashbrown` from `ockam_core`
+- Tune up some of the documentation
+- Ensure more documentation ends up in the right place
+- Implement miniature `ockam` command for demo
+- Vault updates
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Fix clippy warnings
+
 ## 0.50.0 - 2022-03-28
 
 ### Added

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.50.0"
+version = "0.51.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -50,7 +50,7 @@ alloc = [
 bls = []
 
 [dependencies]
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default_features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default_features = false }
 async-trait = "0.1.42"
 hashbrown = { version = "0.11", default-features = false, features = [
     "ahash",

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.50.0"
+ockam_core = "0.51.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ be disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.50.0" , default-features = false }
+ockam_core = { version = "0.51.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.0 - 2022-04-11
+
+### Changed
+
+- Updated dependencies
+
 ## 0.18.0 - 2022-03-28
 
 ### Changed

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ockam-network/ockam/tree/develop/implementation
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.18.0"
+version = "0.19.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.15", default-features = false, features = [
     "async-await",
 ] }
 heapless = { version = "0.7", features = ["mpmc_large"] }
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_executor = "0.18.0"
+ockam_executor = "0.19.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.40.0 - 2022-04-11
+
+### Changed
+
+- Vault updates
+- Updated dependencies
+
 ## 0.39.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 bls = ["ockam_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0"}
+ockam_core = { path = "../ockam_core", version = "^0.51.0"}
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -29,6 +29,6 @@ bls = ["ockam_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam-ffi = "0.39.0"
+ockam-ffi = "0.40.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_identity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_identity/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.41.0 - 2022-04-11
+
+### Added
+
+- Add timeout to `SecureChannel` creation
+
+### Changed
+
+- Reorganize and document `ockam` crate
+- Don't re-export `hex` or `hashbrown` from `ockam_core`
+- Implement miniature `ockam` command for demo
+- Vault updates
+- Make `Identity` trait immutable
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Fix clippy warnings
+
 ## 0.40.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -76,7 +76,7 @@ ockam_core = { path = "../ockam_core", version = "^0.50.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default-features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.46.0", default-features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -75,7 +75,7 @@ credentials = [
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default-features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default-features = false }
@@ -97,6 +97,6 @@ hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -77,7 +77,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default-features
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.43.0", default-features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_identity"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -73,7 +73,7 @@ credentials = [
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default-features = false }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -72,7 +72,7 @@ credentials = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -78,7 +78,7 @@ ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = f
 ockam_vault = { path = "../ockam_vault", version = "^0.44.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default-features = false, optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.42.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -74,7 +74,7 @@ credentials = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.50.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.51.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.47.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.44.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_identity/README.md
+++ b/implementations/rust/ockam/ockam_identity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_identity = "0.40.0"
+ockam_identity = "0.41.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.42.0 - 2022-04-11
+
+### Changed
+
+- Updated dependencies
+
 ## 0.41.0 - 2022-03-28
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -34,5 +34,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.41.0"
+ockam_key_exchange_core = "0.42.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.43.0 - 2022-04-11
+
+### Changed
+
+- Don't re-export `hex` or `hashbrown` from `ockam_core`
+- Implement miniature `ockam` command for demo
+- Vault updates
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+
 ## 0.42.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "hex/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "hex/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.42.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 hex = { version = "0.4", default-features = false }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -43,4 +43,4 @@ hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
-ockam_node = { path = "../ockam_node", version = "^0.50.0"}
+ockam_node = { path = "../ockam_node", version = "^0.51.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -42,5 +42,5 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}
 ockam_node = { path = "../ockam_node", version = "^0.51.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.42.0"
+ockam_key_exchange_x3dh = "0.43.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.44.0 - 2022-04-11
+
+### Changed
+
+- Implement miniature `ockam` command for demo
+- Vault updates
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+
 ## 0.43.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.42.0", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -39,6 +39,6 @@ ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = f
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.44.0"}
 ockam_node = { path = "../ockam_node", version = "^0.51.0"}
 hex = "0.4"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.41.0", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.43.0"
+version = "0.44.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -40,5 +40,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.4
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.43.0"}
-ockam_node = { path = "../ockam_node", version = "^0.50.0"}
+ockam_node = { path = "../ockam_node", version = "^0.51.0"}
 hex = "0.4"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.43.0"
+ockam_key_exchange_xx = "0.44.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_macros/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_macros/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 - 2022-04-11
+
+### Added
+
+- Add "crate" attribute to "node" macro
+
+### Changed
+
+- Vault updates
+- Updated dependencies
+
 ## 0.11.0 - 2022-03-28
 
 ### Added

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_macros"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Ockam Developers"]

--- a/implementations/rust/ockam/ockam_macros/README.md
+++ b/implementations/rust/ockam/ockam_macros/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_macros = "0.11.0"
+ockam_macros = "0.12.0"
 ```
 
 ## Develop

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.51.0 - 2022-04-11
+
+### Changed
+
+- Get rid of common `RouterMessage` in favor of transport-specific structs (ble, ws)
+- Make `ockam_node::error` module public
+- Reorganize and document `ockam` crate
+- Don't re-export `hex` or `hashbrown` from `ockam_core`
+- Implement miniature `ockam` command for demo
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Ensure that the command supports `OCKAM_LOG`
+- Fix clippy warnings
+
 ## 0.50.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc", "futures/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0"}
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.50.0"
+version = "0.51.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -44,7 +44,7 @@ dump_internals = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0"}
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0"}
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",
     "time",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -59,7 +59,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.19.0", default-features = false, optional = true }
 serde_bare = { version = "0.5.0", default-features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.50.0"
+ockam_node = "0.51.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_ble/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_ble/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 - 2022-04-11
+
+### Changed
+
+- Get rid of common `RouterMessage` in favor of transport-specific structs (ble, ws)
+- Tune up some of the documentation
+- Rename `mod remote_forwarder` module to `mod remote`, fix examples
+- Implement miniature `ockam` command for demo
+- Make `Identity` trait immutable
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Fix clippy warnings
+
 ## 0.6.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -88,7 +88,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
 ockam = { path = "../ockam", version = "^0.52.0", default_features = false }
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0", default_features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -90,7 +90,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 ockam = { path = "../ockam", version = "^0.52.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
-ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default_features = false }
+ockam_executor = { path = "../ockam_executor", version = "^0.19.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.24.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -89,7 +89,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 [dependencies]
 ockam = { path = "../ockam", version = "^0.52.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0", default_features = false }
 

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_ble"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -91,7 +91,7 @@ ockam = { path = "../ockam", version = "^0.52.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default_features = false }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0", default_features = false }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.24.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "async-await-macro", "sink"] }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -87,7 +87,7 @@ pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
 pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
-ockam = { path = "../ockam", version = "^0.51.0", default_features = false }
+ockam = { path = "../ockam", version = "^0.52.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.18.0", default_features = false }

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.0 - 2022-04-11
+
+### Changed
+
+- Implement tcp disconnection
+- Implement miniature `ockam` command for demo
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+
 ## 0.23.0 - 2022-03-28
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -31,5 +31,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_core = "0.23.0"
+ockam_transport_core = "0.24.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.47.0 - 2022-04-11
+
+### Added
+
+- Add `Tcp` disconnect test
+
+### Changed
+
+- Implement tcp disconnection
+- Implement manual disconnection for `Tcp`
+- Implemented tcp connection to already connected ip under different hostname
+- Updated dependencies
+
+### Fixed
+
+- Fix clippy warnings
+
+### Removed
+
+- Remove outdated tcprouter docs
+
 ## 0.46.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.46.0"
+version = "0.47.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -31,7 +31,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}
 ockam_node = { path = "../ockam_node", version = "^0.51.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.24.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -30,7 +30,7 @@ alloc = []
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}
 ockam_node = { path = "../ockam_node", version = "^0.50.0"}
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0"}
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -28,7 +28,7 @@ std = ["ockam_macros/std"]
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0"}
+ockam_core = { path = "../ockam_core", version = "^0.51.0"}
 ockam_node = { path = "../ockam_node", version = "^0.50.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -29,7 +29,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}
-ockam_node = { path = "../ockam_node", version = "^0.50.0"}
+ockam_node = { path = "../ockam_node", version = "^0.51.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.46.0"
+ockam_transport_tcp = "0.47.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.40.0 - 2022-04-11
+
+### Changed
+
+- Get rid of common `RouterMessage` in favor of transport-specific structs (ble, ws)
+- Implement miniature `ockam` command for demo
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+- Fix clippy warnings
+
 ## 0.39.0 - 2022-04-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -28,7 +28,7 @@ futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}
-ockam_node = { path = "../ockam_node", version = "^0.50.0"}
+ockam_node = { path = "../ockam_node", version = "^0.51.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -27,7 +27,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
-ockam_core = { path = "../ockam_core", version = "^0.50.0"}
+ockam_core = { path = "../ockam_core", version = "^0.51.0"}
 ockam_node = { path = "../ockam_node", version = "^0.50.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -44,4 +44,4 @@ tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 ockam = { path = "../ockam", default-features = false, features = ["std"] }
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0"}
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0"}

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.51.0"}
 ockam_node = { path = "../ockam_node", version = "^0.51.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.23.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.24.0"}
 tokio = { version = "1.8", features = [
     "rt-multi-thread",
     "sync",

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.39.0"
+ockam_transport_websocket = "0.40.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.44.0 - 2022-04-11
+
+### Changed
+
+- Don't re-export `hex` or `hashbrown` from `ockam_core`
+- Implement miniature `ockam` command for demo
+- Vault updates
+- Updated dependencies
+
+### Fixed
+
+- Insert a temporary mechanism to improve error messages
+
 ## 0.43.0 - 2022-03-28
 
 ### Changed

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -69,7 +69,7 @@ storage = ["std", "serde", "serde_json"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.51.0", default_features = false }
 signature_core = { path = "../signature_core", version = "^0.36.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.36.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.34.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -68,7 +68,7 @@ storage = ["std", "serde", "serde_json"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
-ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default-features = false }
+ockam_macros = { path = "../ockam_macros", version = "^0.12.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
 signature_core = { path = "../signature_core", version = "^0.36.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.36.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -67,7 +67,7 @@ alloc = ["ockam_core/alloc", "ockam_node/alloc", "aes-gcm/alloc"]
 storage = ["std", "serde", "serde_json"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.50.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.51.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.11.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.50.0", default_features = false }
 signature_core = { path = "../signature_core", version = "^0.36.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.43.0"
+version = "0.44.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.43.0"
+ockam_vault = "0.44.0"
 ```
 
 ## Crate Features
@@ -33,7 +33,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault = { version = "0.43.0" , default-features = false }
+ockam_vault = { version = "0.44.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency


### PR DESCRIPTION
After this release is completed, I will produce binaries new ockam CLI binaries (although it may take a little bit to set things up the way I had it last time).