### PR TITLE
chore(rust): improve logging of ockam_command's session keep-alive code

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/cmd/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/inlet.rs
@@ -4,6 +4,7 @@ use ockam::{identity::*, route, Context, Result, TcpTransport, TCP};
 use ockam_core::{Address, AsyncTryClone, Route};
 use std::time::Duration;
 
+#[derive(Debug)]
 struct ExistingSession {
     pub _channel: Address,
     pub inlet_address: Address,
@@ -67,6 +68,7 @@ impl SessionManager for InletSessionManager {
 
     async fn stop_session(&mut self, _ctx: &Context) -> Result<()> {
         if let Some(existing_session) = self.existing_session.take() {
+            tracing::info!("Stopping session {:?}", existing_session);
             // TODO: Stop SecureChannel
             self.tcp.stop_inlet(existing_session.inlet_address).await?;
         }

--- a/implementations/rust/ockam/ockam_command/src/session/msg.rs
+++ b/implementations/rust/ockam/ockam_command/src/session/msg.rs
@@ -2,7 +2,7 @@ use ockam::Message;
 use rand::random;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Message, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Message, Debug, Clone, PartialEq)]
 pub struct RequestId(pub String);
 
 impl RequestId {
@@ -14,7 +14,13 @@ impl RequestId {
     }
 }
 
-#[derive(Serialize, Deserialize, Message, Clone)]
+impl core::fmt::Display for RequestId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Message, Clone)]
 pub enum SessionMsg {
     Heartbeat,
     Ping(RequestId),

--- a/implementations/rust/ockam/ockam_command/src/session/responder.rs
+++ b/implementations/rust/ockam/ockam_command/src/session/responder.rs
@@ -1,6 +1,7 @@
 use crate::session::error::SessionManagementError;
 use crate::session::msg::SessionMsg;
 use ockam::{Context, Result, Routed, Worker};
+use tracing::info;
 
 pub struct SessionResponder;
 
@@ -18,6 +19,7 @@ impl Worker for SessionResponder {
 
         match msg.body() {
             SessionMsg::Ping(request_id) => {
+                info!("Received keep-alive ping {}, sending pong", request_id);
                 ctx.send(return_route, SessionMsg::Pong(request_id)).await?
             }
             SessionMsg::Pong(_) | SessionMsg::Heartbeat => {


### PR DESCRIPTION
Requesed by @mrinalwadhwa -- only logical change is that I noticed we retry immediately on failure to start session. I added a small sleep, so that we don't behave badly in unexpected cases (we don't want to spam logs, saturate the network, etc).