### PR TITLE
chore: remove _service suffix from service addresses

### DIFF
--- a/examples/elixir/get_started/07-routing-via-remote-forwarder-responder.exs
+++ b/examples/elixir/get_started/07-routing-via-remote-forwarder-responder.exs
@@ -15,7 +15,7 @@ alias Ockam.Workers.RemoteForwarder
 # Create a remote forwarder for the "app" on the node at TCPAddress - ("1.node.ockam.network", 4000)
 {:ok, forwarder} = RemoteForwarder.create(
   # Route to forwarding service
-  service_route: [TCPAddress.new("1.node.ockam.network", 4000), "forwarding_service"],
+  service_route: [TCPAddress.new("1.node.ockam.network", 4000), "forwarding"],
   # Route to worker to forward to
   forward_to: ["echoer"]
 )

--- a/examples/elixir/get_started/08-secure-channel-over-remote-forwarder-responder.ex
+++ b/examples/elixir/get_started/08-secure-channel-over-remote-forwarder-responder.ex
@@ -19,7 +19,7 @@ alias Ockam.Workers.RemoteForwarder
 # Create a remote forwarder for the "app" on the node at TCPAddress - ("1.node.ockam.network", 4000)
 {:ok, forwarder} = RemoteForwarder.create(
   # Route to forwarding service
-  service_route: [TCPAddress.new("1.node.ockam.network", 4000), "forwarding_service"],
+  service_route: [TCPAddress.new("1.node.ockam.network", 4000), "forwarding"],
   # Route to worker to forward to
   forward_to: ["secure_channel_listener"]
 )

--- a/examples/elixir/tcp_inlet_and_outlet/04-outlet.exs
+++ b/examples/elixir/tcp_inlet_and_outlet/04-outlet.exs
@@ -26,7 +26,7 @@ Ockam.SecureChannel.create_listener(
 {:ok, forwarder} =
   RemoteForwarder.create(
     # Route to forwarding service
-    service_route: [TCPAddress.new("1.node.ockam.network", 4000), "forwarding_service"],
+    service_route: [TCPAddress.new("1.node.ockam.network", 4000), "forwarding"],
     # Route to worker to forward to
     forward_to: ["secure_channel_listener"]
   )

--- a/examples/rust/get_started/examples/old/10-routing-to-a-cloud-node.rs
+++ b/examples/rust/get_started/examples/old/10-routing-to-a-cloud-node.rs
@@ -10,10 +10,10 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Initialize the TCP Transport.
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    // Send a message to the `echo_service` worker on your cloud node.
+    // Send a message to the `echo` worker on your cloud node.
     ctx.send(
-        // route to the echo_service worker on your cloud node
-        route![(TCP, cloud_node_tcp_address), "echo_service"],
+        // route to the echo worker on your cloud node
+        route![(TCP, cloud_node_tcp_address), "echo"],
         // the message you want echo-ed back
         "Hello Ockam!".to_string(),
     )

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/forwarding/forwarding.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/forwarding/forwarding.ex
@@ -42,7 +42,7 @@ defmodule Ockam.Examples.Forwarding do
 
   def responder(notify \\ nil) do
     TCP.start()
-    forwarding_route = [@hub_address, "forwarding_service"]
+    forwarding_route = [@hub_address, "forwarding"]
 
     Ockam.Node.register_address("example_responder")
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/reliable_deduplication.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/reliable_deduplication.ex
@@ -75,7 +75,7 @@ defmodule Ockam.Examples.Messaging.ReliableDeduplication do
 
     {:ok, _subscription} =
       PubSubSubscriber.create(
-        pub_sub_route: [client, "pub_sub_service"],
+        pub_sub_route: [client, "pub_sub"],
         name: "responder",
         topic: "responder"
       )
@@ -111,7 +111,7 @@ defmodule Ockam.Examples.Messaging.ReliableDeduplication do
 
     {:ok, _subscription} =
       PubSubSubscriber.create(
-        pub_sub_route: [client, "pub_sub_service"],
+        pub_sub_route: [client, "pub_sub"],
         name: "initiator",
         topic: "initiator"
       )

--- a/implementations/elixir/ockam/ockam/lib/ockam/workers/pub_sub_subscriber.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/workers/pub_sub_subscriber.ex
@@ -1,6 +1,6 @@
 defmodule Ockam.Workers.PubSubSubscriber do
   @moduledoc """
-  Worker to maintain Ockam.Hub pub_sub_service subscription
+  Worker to maintain Ockam.Hub pub_sub service subscription
 
   Refreshes subscription to pub_sup service every interval milliseconds
 

--- a/implementations/elixir/ockam/ockam_hub/docs/token-lease-manager.md
+++ b/implementations/elixir/ockam/ockam_hub/docs/token-lease-manager.md
@@ -15,7 +15,7 @@ Currently, *Token Lease Manager* is a Ockam Worker which depends on two main pie
 
 They will be modules that will be passed as arguments under `:cloud_service_module` and `:storage_service_module`.
 
-It will be started if the service `token_lease_service` is required.
+It will be started if the service `token_lease` is required.
 
 ## Cloud Service
 

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/discovery.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/discovery.ex
@@ -20,7 +20,7 @@ defmodule Ockam.Hub.Service.Provider.Discovery do
     {DiscoveryService,
      Keyword.merge(
        [
-         address: "discovery_service",
+         address: "discovery",
          storage: Ockam.Hub.Service.Discovery.Storage.Supervisor,
          ## TODO: provide superviser from args
          storage_options: [supervisor: Ockam.Hub.Service.Provider]

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/routing.ex
@@ -22,24 +22,31 @@ defmodule Ockam.Hub.Service.Provider.Routing do
 
   @impl true
   def child_spec(:echo, args) do
-    {EchoService, Keyword.merge([address: "echo_service"], args)}
+    {EchoService, Keyword.merge([address: "echo"], args)}
   end
 
   def child_spec(:forwarding, args) do
     {ForwardingService,
-     Keyword.merge([address: "forwarding_service", extra_addresses: ["forwarding"]], args)}
+     Keyword.merge([address: "forwarding", extra_addresses: ["forwarding_service"]], args)}
   end
 
   def child_spec(:static_forwarding, args) do
     {StaticForwardingService,
-     Keyword.merge([address: "static_forwarding_service", prefix: "forward_to"], args)}
+     Keyword.merge(
+       [
+         address: "static_forwarding",
+         prefix: "forward_to",
+         extra_addresses: ["static_forwarding_service"]
+       ],
+       args
+     )}
   end
 
   def child_spec(:pub_sub, args) do
-    {PubSubService, Keyword.merge([address: "pub_sub_service", prefix: "pub_sub_t"], args)}
+    {PubSubService, Keyword.merge([address: "pub_sub", prefix: "pub_sub_t"], args)}
   end
 
   def child_spec(:tracing, args) do
-    {TracingService, Keyword.merge([address: "tracing_service"], args)}
+    {TracingService, Keyword.merge([address: "tracing"], args)}
   end
 end

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/secure_channel.ex
@@ -7,7 +7,7 @@ defmodule Ockam.Hub.Service.Provider.SecureChannel do
   @behaviour Ockam.Hub.Service.Provider
 
   @services [:secure_channel]
-  @address "secure_channel_service"
+  @address "secure_channel"
 
   @impl true
   def services() do

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/token_lease_manager.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/service/provider/token_lease_manager.ex
@@ -2,8 +2,8 @@ defmodule Ockam.TokenLeaseManager.Hub.Service.Provider do
   @moduledoc false
   @behaviour Ockam.Hub.Service.Provider
 
-  @services [:influxdb_token_lease_service]
-  @address "influxdb_token_lease_service"
+  @services [:influxdb_token_lease]
+  @address "influxdb_token_lease"
 
   @impl true
   def services() do

--- a/implementations/elixir/ockam/ockam_hub/test/hub/service/tracing_test.exs
+++ b/implementations/elixir/ockam/ockam_hub/test/hub/service/tracing_test.exs
@@ -2,12 +2,12 @@ defmodule Test.Hub.Service.TracingTest do
   use ExUnit.Case
 
   test "trace payloads" do
-    Ockam.Hub.Service.Tracing.create(address: "tracing_service")
-    Ockam.Hub.Service.Echo.create(address: "echo_service")
+    Ockam.Hub.Service.Tracing.create(address: "tracing")
+    Ockam.Hub.Service.Echo.create(address: "echo")
     Ockam.Node.register_address("TEST")
 
     Ockam.Router.route(%{
-      onward_route: ["tracing_service"],
+      onward_route: ["tracing"],
       return_route: ["TEST"],
       payload: "register"
     })
@@ -21,7 +21,7 @@ defmodule Test.Hub.Service.TracingTest do
       end
 
     payload = "Hello!"
-    echo_request = %{onward_route: [tracing_address, "echo_service"], payload: payload}
+    echo_request = %{onward_route: [tracing_address, "echo"], payload: payload}
     Ockam.Workers.Call.call(echo_request)
 
     # Receive outgoing message


### PR DESCRIPTION
## Current Behaviour

Currently we have inconsistency in service worker addresses, some have a `_service` suffix, some don't.

## Proposed Changes

Remove `_service` suffix for services

Keep backwards compatible `forwarding_service` and `static_forwarding_service` for RemoteForwarder

## TODO

In RemoteForwarder in Rust code: change service addresses to `forwarding` and `static_forwarding`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
