### PR TITLE
fix(elixir): remove newlines from log messages

### DIFF
--- a/implementations/elixir/ockam/ockam_hub/config/config.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/config.exs
@@ -5,6 +5,9 @@ import Config
 
 config :logger, level: :info
 
-config :logger, :console, metadata: [:module, :line, :pid]
+config :logger, :console,
+  metadata: [:module, :line, :pid],
+  format_string: "$dateT$time $metadata[$level] $message\n",
+  format: {Ockam.Hub.LogFormatter, :format}
 
 import_config "#{Mix.env()}.exs"

--- a/implementations/elixir/ockam/ockam_hub/lib/hub/log_formatter.ex
+++ b/implementations/elixir/ockam/ockam_hub/lib/hub/log_formatter.ex
@@ -1,0 +1,23 @@
+defmodule Ockam.Hub.LogFormatter do
+  @moduledoc """
+  Formats lines using Logger.Formatter, but replaces line breaks in log messages with `\n`
+
+  Config:
+  `:format_string` in logger config - pattern to format log with
+
+  Usage:
+  config :logger, :console,
+    format: {Ockam.Hub.LogFormatter, :format} # Use this formatter
+    format_string: "$time $metadata[$level] $message\n" # Pattern to format the log entry
+
+  """
+  def format(level, message, timestamp, metadata) do
+    pattern =
+      Application.get_env(:logger, :console, [])
+      |> Keyword.get(:format_string)
+      |> Logger.Formatter.compile()
+
+    message_escaped = String.replace(to_string(message), "\n", "\\n")
+    Logger.Formatter.format(pattern, level, message_escaped, timestamp, metadata)
+  end
+end


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

Elixir logs can have line breaks which does not work too well with log export and processing

## Proposed Changes

Replace line breaks in log messages with `\n`
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
