### PR TITLE
feat(rust): add send_and_receive method to context

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -365,6 +365,26 @@ impl Context {
         Ok(())
     }
 
+    /// Using a temporary new context, send a message and then receive a message
+    ///
+    /// This helper function uses [`new_context`], [`send`], and
+    /// [`receive`] internally. See their documentation for more
+    /// details.
+    ///
+    /// [`new_context`]: Self::new_context
+    /// [`send`]: Self::send
+    /// [`receive`]: Self::receive
+    pub async fn send_and_receive<R, M, N>(&self, route: R, msg: M) -> Result<N>
+    where
+        R: Into<Route>,
+        M: Message + Send + 'static,
+        N: Message,
+    {
+        let mut child_ctx = self.new_context(Address::random_local()).await?;
+        child_ctx.send(route, msg).await?;
+        Ok(child_ctx.receive::<N>().await?.take().body())
+    }
+
     /// Send a message to another address associated with this worker
     ///
     /// This function is a simple wrapper around `Self::send()` which


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

In #2628, it was identified that the below pattern was common and that a helper function could be added to ```Context``` to help reduce repeated code.

```rust
let mut child_ctx = ctx.new_context(Address::random(0)).await?;
child_ctx.send(address, msg).await?;

let response = child_ctx
    .receive::<T>()
    .await?
    .take()
    .body();
```

## Proposed Changes

Added the helper function ```send_and_receive(&self, route, msg)``` to ```Context```. Using a new temporary context, the function sends a message (given in arguments) and then attempts to receive a message (which the function returns). 

Added a basic test case to exercise the new function.

Fixes #2628.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
