### PR TITLE
chore(rust): fast-forward ockam_command version to match ockam crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.13.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.13.0"
+version = "0.53.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
This moves the ockam_command crate to have the same version as the ockam crate, thus making the `ockam --version` output less confusing.

CC @mrinalwadhwa