### PR TITLE
fix(rust): reduce `MAX_PAYLOAD_SIZE` back to 256

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_receiver.rs
@@ -6,7 +6,7 @@ use ockam_node::Context;
 use tokio::{io::AsyncReadExt, net::tcp::OwnedReadHalf};
 use tracing::error;
 
-const MAX_PAYLOAD_SIZE: usize = 32 * 1024;
+const MAX_PAYLOAD_SIZE: usize = 256;
 
 /// A TCP Portal receiving message processor
 ///


### PR DESCRIPTION
This is an alternative to #2707, which keeps the overall structure and only reduces the buffer size back to the old (pre #2702) value. Unlike #2707, I haven't actually checked if this one works.

(That said, if it *doesn't* work, then that tells us something else that patch is broken, which would be surprising...)