### PR TITLE
Cut release v0.56.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_ble"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "atsame54_xpro",
  "bluenrg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "hashbrown 0.9.1",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.56.0 - 2022-05-04
+
+### Changed
+
+- Updated dependencies
+
 ## 0.55.0 - 2022-05-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -98,7 +98,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.14.0", default_features
 ockam_node = { path = "../ockam_node", version = "^0.53.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.46.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.50.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.50.0", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.51.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.44.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.46.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.44.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/ockam-network/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.55.0"
+version = "0.56.0"
 rust-version = "1.56.0"
 publish = true
 

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -68,7 +68,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.55.0"
+ockam = "0.56.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 - 2022-05-04
+
+### Changed
+
+- Updated dependencies
+
 ## 0.15.0 - 2022-05-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -42,6 +42,6 @@ serde = { version = "1", features = ["derive"] }
 rand = "0.8"
 async-recursion = { version = "1.0.0" }
 
-ockam = { path = "../ockam", version = "^0.55.0", features = ["software_vault"] }
+ockam = { path = "../ockam", version = "^0.56.0", features = ["software_vault"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.46.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.53.0"}

--- a/implementations/rust/ockam/ockam_transport_ble/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_ble/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 - 2022-05-04
+
+### Changed
+
+- Updated dependencies
+
 ## 0.10.0 - 2022-05-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -87,7 +87,7 @@ pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
 pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
-ockam = { path = "../ockam", version = "^0.55.0", default_features = false }
+ockam = { path = "../ockam", version = "^0.56.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.53.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.53.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.21.0", default_features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_ble"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.51.0 - 2022-05-04
+
+### Changed
+
+- Updated dependencies
+
+### Fixed
+
+- Reduce `MAX_PAYLOAD_SIZE` back to 256
+
 ## 0.50.0 - 2022-05-04
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.50.0"
+version = "0.51.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -29,7 +29,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.50.0"
+ockam_transport_tcp = "0.51.0"
 ```
 
 This crate requires the rust standard library `"std"`.


### PR DESCRIPTION
This fix is intended to address the hangs caused by the TCP buffer size issues.

Ideally this would be a patch release, but this part of the script's functionality doesn't seem to actually work, so it's a minor release.