### PR TITLE
chore(rust): clean ockam transport ble dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arrayref"
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.10"
+version = "3.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
+checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
 dependencies = [
  "atty",
  "bitflags",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
 dependencies = [
  "os_str_bytes",
 ]
@@ -736,13 +736,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.2.0"
+version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
+checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
 dependencies = [
  "cfg-if",
- "num_cpus",
- "parking_lot",
+ "hashbrown 0.12.1",
+ "lock_api",
 ]
 
 [[package]]
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
+checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
 name = "duct"
@@ -1178,6 +1178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
 name = "heapless"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1285,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "idna"
@@ -1342,9 +1348,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libdbus-sys"
@@ -1367,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -1406,9 +1412,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
@@ -1499,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1509,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -1610,7 +1616,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "clap 3.1.10",
+ "clap 3.1.16",
  "dirs",
  "hex",
  "ockam",
@@ -1779,11 +1785,11 @@ dependencies = [
  "futures-util",
  "heapless",
  "nb 1.0.0",
- "ockam",
  "ockam_core",
- "ockam_executor",
+ "ockam_identity",
  "ockam_node",
  "ockam_transport_core",
+ "ockam_vault",
  "pic32-hal",
  "riscv",
  "serde",
@@ -1911,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1960,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -2020,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
@@ -2245,7 +2251,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.7",
+ "semver 1.0.9",
 ]
 
 [[package]]
@@ -2271,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "semver-parser"
@@ -2283,9 +2289,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
@@ -2322,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2333,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -2636,9 +2642,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2696,18 +2702,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2725,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2740,9 +2746,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -2841,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2872,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -2901,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da18123d1316f5a65fc9b94e30a0fcf58afb1daff1b8e18f41dc30f5bfc38c8"
+checksum = "7fc92f558afb6d1d7c6f175eb8d615b8ef49c227543e68e19c123d4ee43d8a7d"
 dependencies = [
  "dissimilar",
  "glob",
@@ -2942,9 +2948,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"
@@ -2969,9 +2975,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "universal-hash"
@@ -3120,15 +3126,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -3139,9 +3145,9 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3151,9 +3157,9 @@ checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3163,9 +3169,9 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3175,9 +3181,9 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3187,9 +3193,9 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"
@@ -3219,9 +3225,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zeroize"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
 dependencies = [
  "zeroize_derive",
 ]

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -20,12 +20,11 @@ autoexamples = false
 publish = true
 
 [features]
-default = ["std", "use_btleplug", "ockam/software_vault"]
+default = ["std", "use_btleplug"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
 std = [
-    "ockam/std",
     "ockam_core/std",
     "ockam_node/std",
     "ockam_transport_core/std",
@@ -36,7 +35,6 @@ std = [
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
 no_std = [
-    "ockam/no_std",
     "ockam_core/no_std",
     "ockam_node/no_std",
     "ockam_transport_core/no_std",
@@ -47,7 +45,6 @@ no_std = [
 # Feature: "alloc" enables support for heap allocation on "no_std"
 # platforms, requires nightly.
 alloc = [
-    "ockam/alloc",
     "ockam_core/alloc",
     "ockam_node/alloc",
     "ockam_transport_core/alloc",
@@ -87,10 +84,8 @@ pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
 pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
-ockam = { path = "../ockam", version = "^0.57.0", default_features = false }
 ockam_core = { path = "../ockam_core", version = "^0.53.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.54.0", default_features = false }
-ockam_executor = { path = "../ockam_executor", version = "^0.21.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.26.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }
@@ -127,6 +122,10 @@ cortex-m = "0.7.3"
 # Architecture RISCV: TODO move this into its own "Ockam Addon" crate
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 riscv = "0.7.0"
+
+[dev-dependencies]
+ockam_identity = { path = "../ockam_identity", version = "^0.45.0" }
+ockam_vault = { path = "../ockam_vault", version = "^0.47.0" }
 
 [[example]]
 name = "04-routing-over-ble-transport-initiator"

--- a/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
@@ -1,12 +1,21 @@
 // This node routes a message, to a worker on a different node, over the ble transport.
 
-use ockam::{route, Context, Result};
-use ockam_transport_ble::{BleClient, BleTransport, BLE};
+use ockam_core::{route, Result};
+use ockam_node::Context;
 
 use ockam_transport_ble::driver::btleplug::BleAdapter;
+use ockam_transport_ble::{BleClient, BleTransport, BLE};
 
-#[ockam::node]
-async fn main(mut ctx: Context) -> Result<()> {
+fn main() -> Result<()> {
+    let (ctx, mut exe) = ockam_node::start_node();
+    exe.execute(async move {
+        async_main(ctx).await.unwrap();
+    })
+    .unwrap();
+    Ok(())
+}
+
+async fn async_main(mut ctx: Context) -> Result<()> {
     // Create a ble_client
     let ble_adapter = BleAdapter::try_new().await?;
     let ble_client = BleClient::with_adapter(ble_adapter);

--- a/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
@@ -1,18 +1,24 @@
 // This node routes a message, to a worker on a different node, over the ble transport.
 
-use ockam::{
-    identity::{Identity, TrustEveryonePolicy},
-    route,
-    vault::Vault,
-    Context, Result,
-};
-use ockam_transport_ble::{BleTransport, BLE};
+use ockam_core::{route, Result};
+use ockam_identity::{Identity, TrustEveryonePolicy};
+use ockam_node::Context;
+use ockam_vault::Vault;
 
 use ockam_transport_ble::driver::btleplug::BleAdapter;
 use ockam_transport_ble::driver::BleClient;
+use ockam_transport_ble::{BleTransport, BLE};
 
-#[ockam::node]
-async fn main(mut ctx: Context) -> Result<()> {
+fn main() -> Result<()> {
+    let (ctx, mut exe) = ockam_node::start_node();
+    exe.execute(async move {
+        async_main(ctx).await.unwrap();
+    })
+    .unwrap();
+    Ok(())
+}
+
+async fn async_main(mut ctx: Context) -> Result<()> {
     // Create a ble_client
     let ble_adapter = BleAdapter::try_new().await?;
     let ble_client = BleClient::with_adapter(ble_adapter);

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
@@ -92,7 +92,7 @@ where
         }
     }
 
-    pub fn reset<T, Time>(&mut self, timer: &mut T, time: Time) -> ockam::Result<()>
+    pub fn reset<T, Time>(&mut self, timer: &mut T, time: Time) -> Result<()>
     where
         T: embedded_hal::timer::CountDown<Time = Time>,
         Time: Copy,
@@ -106,7 +106,7 @@ where
     }
 
     #[cfg(target_arch = "mips")]
-    pub fn reset_with_delay<D, UXX>(&mut self, delay: &mut D, time: UXX) -> ockam::Result<()>
+    pub fn reset_with_delay<D, UXX>(&mut self, delay: &mut D, time: UXX) -> Result<()>
     where
         D: blocking::delay::DelayMs<UXX>,
         UXX: Copy,
@@ -119,7 +119,7 @@ where
         self._handle_reset_response()
     }
 
-    pub fn _handle_reset_response(&mut self) -> ockam::Result<()> {
+    pub fn _handle_reset_response(&mut self) -> Result<()> {
         match self
             .bluetooth
             .with_spi(&mut self.spi, |controller| block!(controller.read()))
@@ -160,7 +160,7 @@ where
     SPI::Error: Debug,
     GpioError: Debug + Send,
 {
-    async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+    async fn bind(&mut self, ble_addr: &BleAddr) -> Result<()> {
         self.ble_addr = ble_addr.clone();
 
         ble_uart::setup(&mut self.spi, &mut self.bluetooth)
@@ -182,7 +182,7 @@ where
         Ok(())
     }
 
-    async fn start_advertising(&mut self) -> ockam::Result<()> {
+    async fn start_advertising(&mut self) -> Result<()> {
         if let Err(e) = ble_uart::start_advertising(
             &mut self.spi,
             &mut self.bluetooth,
@@ -208,7 +208,7 @@ where
     SPI::Error: Debug,
     GpioError: Debug + Send,
 {
-    async fn poll<'b>(&mut self, out_fragment: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+    async fn poll<'b>(&mut self, out_fragment: &'b mut [u8]) -> Result<BleEvent<'b>> {
         // avoid deadlocking the caller
         ockam_node::tokio::task::yield_now().await;
 
@@ -218,8 +218,6 @@ where
                 self.start_advertising().await?;
                 self.state = State::Advertising;
                 debug!("\nstate = {:?}", self.state);
-                #[cfg(feature = "debug_alloc")]
-                ockam_executor::debug_alloc::stats();
             }
             State::Advertising => {}
             State::Connected => {}
@@ -292,7 +290,7 @@ where
         }
     }
 
-    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+    async fn write(&mut self, buffer: &[u8]) -> Result<()> {
         debug!("BleAdapter<bluetooth_hci>::write");
 
         let Self {

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use packet::PacketBuffer;
 pub(crate) use stream::{AsyncStream, Sink, Source};
 
 use crate::BleAddr;
-use ockam_core::{async_trait, compat::boxed::Box};
+use ockam_core::{async_trait, compat::boxed::Box, Result};
 
 /// The minimum MTU required by the BLE spec. Many devices
 /// (e.g. bluenrg_ms) don't allow for configuration higher than this.
@@ -76,24 +76,24 @@ pub enum BleEvent<'a> {
 /// hardware to function as a BLE Client
 #[async_trait]
 pub trait BleClientDriver {
-    async fn scan(&mut self, ble_addr: &BleAddr) -> ockam::Result<()>;
-    async fn connect(&mut self) -> ockam::Result<()>;
+    async fn scan(&mut self, ble_addr: &BleAddr) -> Result<()>;
+    async fn connect(&mut self) -> Result<()>;
 }
 
 /// Implement the BleServerDriver trait if you want to allow your
 /// hardware to function as a BLE Client
 #[async_trait]
 pub trait BleServerDriver {
-    async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()>;
-    async fn start_advertising(&mut self) -> ockam::Result<()>;
+    async fn bind(&mut self, ble_addr: &BleAddr) -> Result<()>;
+    async fn start_advertising(&mut self) -> Result<()>;
 }
 
 /// Implement the BleStreamDriver to transmit and receive data from
 /// your hardware
 #[async_trait]
 pub trait BleStreamDriver {
-    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>>;
-    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()>;
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> Result<BleEvent<'b>>;
+    async fn write(&mut self, buffer: &[u8]) -> Result<()>;
 }
 
 /// A BLE client that initiates GATT commands and requests, and
@@ -116,11 +116,11 @@ impl<A> BleClientDriver for BleClient<A>
 where
     A: BleClientDriver + BleStreamDriver + Send,
 {
-    async fn scan(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+    async fn scan(&mut self, ble_addr: &BleAddr) -> Result<()> {
         self.inner.scan(ble_addr).await
     }
 
-    async fn connect(&mut self) -> ockam::Result<()> {
+    async fn connect(&mut self) -> Result<()> {
         self.inner.connect().await
     }
 }
@@ -130,11 +130,11 @@ impl<A> BleStreamDriver for BleClient<A>
 where
     A: BleClientDriver + BleStreamDriver + Send,
 {
-    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> Result<BleEvent<'b>> {
         self.inner.poll(buffer).await
     }
 
-    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+    async fn write(&mut self, buffer: &[u8]) -> Result<()> {
         self.inner.write(buffer).await
     }
 }
@@ -159,11 +159,11 @@ impl<A> BleServerDriver for BleServer<A>
 where
     A: BleServerDriver + BleStreamDriver + Send,
 {
-    async fn bind(&mut self, ble_addr: &BleAddr) -> ockam::Result<()> {
+    async fn bind(&mut self, ble_addr: &BleAddr) -> Result<()> {
         self.inner.bind(ble_addr).await
     }
 
-    async fn start_advertising(&mut self) -> ockam::Result<()> {
+    async fn start_advertising(&mut self) -> Result<()> {
         self.inner.start_advertising().await
     }
 }
@@ -173,11 +173,11 @@ impl<A> BleStreamDriver for BleServer<A>
 where
     A: BleServerDriver + BleStreamDriver + Send,
 {
-    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> ockam::Result<BleEvent<'b>> {
+    async fn poll<'b>(&mut self, buffer: &'b mut [u8]) -> Result<BleEvent<'b>> {
         self.inner.poll(buffer).await
     }
 
-    async fn write(&mut self, buffer: &[u8]) -> ockam::Result<()> {
+    async fn write(&mut self, buffer: &[u8]) -> Result<()> {
         self.inner.write(buffer).await
     }
 }

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/packet.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/packet.rs
@@ -5,6 +5,8 @@ use crate::driver::CHARACTERISTIC_VALUE_LENGTH;
 use crate::driver::MAX_OCKAM_MESSAGE_LENGTH;
 use crate::error::BleError;
 
+use ockam_core::Result;
+
 /// PacketBuffer
 pub struct PacketBuffer {
     fragment_len: usize,
@@ -129,7 +131,7 @@ impl PacketBuffer {
         Some(self.packet_len)
     }
 
-    pub fn receive_next_fragment(&mut self, fragment: &[u8]) -> ockam::Result<Option<&[u8]>> {
+    pub fn receive_next_fragment(&mut self, fragment: &[u8]) -> Result<Option<&[u8]>> {
         if self.offset >= self.packet_len {
             panic!("packet buffer already has enough fragments")
         }

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/stream.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/stream.rs
@@ -1,4 +1,5 @@
 use ockam_core::compat::sync::Arc;
+use ockam_core::Result;
 
 #[cfg(feature = "std")]
 use futures::lock::Mutex;
@@ -48,15 +49,12 @@ impl<A> AsyncStream<A>
 where
     A: BleStreamDriver + Send,
 {
-    async fn write(&self, buffer: &[u8]) -> ockam::Result<()> {
+    async fn write(&self, buffer: &[u8]) -> Result<()> {
         let mut guard = self.inner.lock().await;
         (*guard).write(buffer).await
     }
 
-    async fn poll<'a, 'b>(
-        &'a self,
-        buffer: &'b mut [u8],
-    ) -> ockam::Result<crate::driver::BleEvent<'b>> {
+    async fn poll<'a, 'b>(&'a self, buffer: &'b mut [u8]) -> Result<crate::driver::BleEvent<'b>> {
         let mut guard = self.inner.lock().await;
         (*guard).poll(buffer).await
     }
@@ -71,7 +69,7 @@ impl<A> Sink<A>
 where
     A: BleStreamDriver + Send,
 {
-    pub async fn write(&self, buffer: &[u8]) -> ockam::Result<()> {
+    pub async fn write(&self, buffer: &[u8]) -> Result<()> {
         self.inner.write(buffer).await
     }
 }
@@ -88,7 +86,7 @@ where
     pub async fn poll<'a, 'b>(
         &'a self,
         buffer: &'b mut [u8],
-    ) -> ockam::Result<crate::driver::BleEvent<'b>> {
+    ) -> Result<crate::driver::BleEvent<'b>> {
         self.inner.poll(buffer).await
     }
 }

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -1,12 +1,11 @@
 mod handle;
 
-use ockam::LocalMessage;
 use ockam_core::{
     async_trait,
     compat::{boxed::Box, collections::BTreeMap, vec::Vec},
     Any,
 };
-use ockam_core::{Address, Decodable, Message, Result, Routed, Worker};
+use ockam_core::{Address, Decodable, LocalMessage, Message, Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_transport_core::TransportError;
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_transport_ble/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/transport.rs
@@ -1,9 +1,8 @@
 use core::str::FromStr;
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use ockam::AsyncTryClone;
 use ockam_core::compat::boxed::Box;
-use ockam_core::{async_trait, Result};
+use ockam_core::{async_trait, AsyncTryClone, Result};
 use ockam_node::Context;
 
 use crate::driver::{BleClient, BleServer};

--- a/implementations/rust/ockam/ockam_transport_ble/src/types.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/types.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use core::str::FromStr;
 use ockam_core::compat::string::{String, ToString};
-use ockam_core::Result;
 use ockam_transport_core::TransportError;
 
 #[derive(Clone, Debug, Default)]
@@ -25,7 +24,7 @@ impl From<&BleAddr> for String {
 impl FromStr for BleAddr {
     type Err = ockam_core::Error;
 
-    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self {
             device_name: s.to_string(),
             local_name: s.to_string(),
@@ -33,7 +32,7 @@ impl FromStr for BleAddr {
     }
 }
 
-pub fn parse_ble_addr<S: AsRef<str>>(s: S) -> Result<BleAddr> {
+pub fn parse_ble_addr<S: AsRef<str>>(s: S) -> ockam_core::Result<BleAddr> {
     Ok(s.as_ref()
         .parse()
         .map_err(|_| TransportError::InvalidAddress)?)

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
@@ -1,6 +1,5 @@
-use ockam::Address;
 use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
-use ockam_core::{async_trait, Encodable, Result, Routed, TransportMessage, Worker};
+use ockam_core::{async_trait, Address, Encodable, Result, Routed, TransportMessage, Worker};
 use ockam_node::Context;
 use ockam_transport_core::TransportError;
 


### PR DESCRIPTION
## Proposed Changes

This pull request removes the following dependencies from the `ockam_transport_ble` crate:

* `ockam`
* `ockam_executor`